### PR TITLE
Feature/build docker on main

### DIFF
--- a/.github/workflows/docker-build-main.yml
+++ b/.github/workflows/docker-build-main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'feature/build-docker-on-main'
 
 jobs:
   prep-version:

--- a/.github/workflows/docker-build-main.yml
+++ b/.github/workflows/docker-build-main.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Get commit hash
         id: vars
         run: echo "version=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    outputs:
+        version: ${{ steps.vars.outputs.version }}
   backend:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docker-build-main.yml
+++ b/.github/workflows/docker-build-main.yml
@@ -16,12 +16,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Get Commit hash
-        id: previoustag
-        run: |
-           echo "GIT_HASH=$(git rev-parse --short '$GITHUB_SHA')" >> $GITHUB_ENV
-    outputs:
-      version: ${{ env.GIT_HASH }}
+      - name: Get commit hash
+        id: vars
+        run: echo "version=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
   backend:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docker-build-main.yml
+++ b/.github/workflows/docker-build-main.yml
@@ -1,0 +1,93 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  prep-version:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get Commit hash
+        id: previoustag
+        run: |
+           echo "GIT_HASH=$(git rev-parse --short "$GITHUB_SHA") >> $GITHUB_ENV
+    outputs:
+      version: ${{ env.GIT_HASH }}
+  backend:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    needs: ["prep-version"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.BUILDACCOUNTID }}:role/portal_github_actions
+          aws-region: us-east-1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registries: ${{ secrets.PUBLICAWSACCOUNTID }}
+          registry-type: public
+          mask-password: "true"
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-publish
+        shell: bash
+        env:
+          ECR_REGISTRY: public.ecr.aws/conveyordata
+          ECR_REPOSITORY: data-product-portal/backend
+          IMAGE_TAG: ${{ needs.prep-version.outputs.version }}
+        run: |
+          docker build ./backend -t "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          echo "IMAGE $IMAGE_TAG is pushed to $ECR_REGISTRY/$ECR_REPOSITORY"
+          echo "image_tag=$IMAGE_TAG"
+          echo "full_image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+  frontend:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    needs: ["prep-version"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.BUILDACCOUNTID }}:role/portal_github_actions
+          aws-region: us-east-1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registries: ${{ secrets.PUBLICAWSACCOUNTID }}
+          registry-type: public
+          mask-password: "true"
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-publish
+        shell: bash
+        env:
+          ECR_REGISTRY: public.ecr.aws/conveyordata
+          ECR_REPOSITORY: data-product-portal/frontend
+          IMAGE_TAG: ${{ needs.prep-version.outputs.version }}
+        run: |
+          docker build ./frontend -t "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          echo "IMAGE $IMAGE_TAG is pushed to $ECR_REGISTRY/$ECR_REPOSITORY"
+          echo "image_tag=$IMAGE_TAG"
+          echo "full_image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/docker-build-main.yml
+++ b/.github/workflows/docker-build-main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Get Commit hash
         id: previoustag
         run: |
-           echo "GIT_HASH=$(git rev-parse --short "$GITHUB_SHA") >> $GITHUB_ENV
+           echo "GIT_HASH=$(git rev-parse --short '$GITHUB_SHA')" >> $GITHUB_ENV
     outputs:
       version: ${{ env.GIT_HASH }}
   backend:

--- a/.github/workflows/docker-build-main.yml
+++ b/.github/workflows/docker-build-main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'feature/build-docker-on-main'
 
 jobs:
   prep-version:


### PR DESCRIPTION
Add new Github action to release the backend and frontend docker (not Helm) also on a new push to main.
The docker will get the short SHA of the Github commit reference as it's tag.
This allows for intermediate soft releases on certain deployment environments without explicitly releasing a new version