### PR TITLE
Nginx Configuration with Additional Proxy Headers for Swagger 

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -33,6 +33,7 @@ services:
     build: ./nginx
     ports:
       - 8080:80
+      - 5050:5050
     depends_on:
       - backend
       - frontend

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,17 +1,43 @@
 upstream frontend {
   server frontend:8080;
 }
+
 upstream backend {
-    server backend:5050;
+  server backend:5050;
 }
 
+# Server block for frontend and backend via /api
 server {
   listen 80;
   server_name localhost;
+
   location /api {
     proxy_pass http://backend;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
   }
+
   location / {
     proxy_pass http://frontend;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}
+
+# Server block for backend API directly on port 5050
+server {
+  listen 5050;
+  server_name localhost;
+
+  location / {
+    proxy_pass http://backend;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
   }
 }


### PR DESCRIPTION
…ver Block

- Added `proxy_set_header` directives to the /api and / locations in the main server block to forward headers:
  - `Host` to preserve the original host header.
  - `X-Real-IP` to pass the client’s real IP address.
  - `X-Forwarded-For` to pass the original client’s IP address through proxy servers.
  - `X-Forwarded-Proto` to pass the original protocol (HTTP or HTTPS).

- Introduced a new server block listening on port 5050 for direct backend access:
  - Configured to forward necessary headers similar to the main server block.

These changes improve the transparency and request forward to  access swagger API on port 5050.