### PR TITLE
Add defaults for missing env vars

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -16,12 +16,12 @@ services:
   frontend:
     build: ./frontend
     volumes:
-      - ${PWD}/frontend/config.docker.js:/app/dist/config.js
+      - ${PWD:-.}/frontend/config.docker.js:/app/dist/config.js
   postgresql:
     image: postgres:16.3-alpine
     container_name: data-product-portal-postgresql
     ports:
-      - ${POSTGRES_PORT}:5432
+      - ${POSTGRES_PORT:-5432}:5432
     env_file:
       - .env.docker
     healthcheck:


### PR DESCRIPTION
Add defaults for environment variables.
Docker compose picks these up automatically from `.env` file. With the moving of the `.env` file to the backend and with that file being optional, docker compose might have behaved weirdly.
This could have resulted in not being able to connect to the postgresdb or not having the right frontend config (missing `$PWD`