### PR TITLE
Improve endpoint security with data product role dependency

### DIFF
--- a/backend/app/core/auth/router.py
+++ b/backend/app/core/auth/router.py
@@ -5,9 +5,8 @@ from app.core.auth.auth import authorize_user
 from app.core.auth.credentials import AWSCredentials
 from app.core.auth.device_flows.router import router as device
 from app.core.auth.service import AuthService
-from app.data_product_memberships.enums import DataProductUserRole
 from app.database.database import get_db_session
-from app.dependencies import OnlyProductRoles
+from app.dependencies import OnlyWithProductAccess
 from app.users.schema import User
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -21,7 +20,7 @@ def authorize(authorized_user: User = Depends(authorize_user)) -> User:
 
 @router.get(
     "/aws_credentials",
-    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.MEMBER]))],
+    dependencies=[Depends(OnlyWithProductAccess())],
 )
 def get_aws_credentials(
     data_product_name: str,

--- a/backend/app/core/auth/router.py
+++ b/backend/app/core/auth/router.py
@@ -5,7 +5,9 @@ from app.core.auth.auth import authorize_user
 from app.core.auth.credentials import AWSCredentials
 from app.core.auth.device_flows.router import router as device
 from app.core.auth.service import AuthService
+from app.data_product_memberships.enums import DataProductUserRole
 from app.database.database import get_db_session
+from app.dependencies import OnlyProductRoles
 from app.users.schema import User
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -17,7 +19,10 @@ def authorize(authorized_user: User = Depends(authorize_user)) -> User:
     return authorized_user
 
 
-@router.get("/aws_credentials")
+@router.get(
+    "/aws_credentials",
+    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.MEMBER]))],
+)
 def get_aws_credentials(
     data_product_name: str,
     environment: str,

--- a/backend/app/data_products/router.py
+++ b/backend/app/data_products/router.py
@@ -4,14 +4,16 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from app.core.auth.auth import get_authenticated_user
+from app.data_product_memberships.enums import DataProductUserRole
 from app.data_products.schema import (
+    DataProductAboutUpdate,
     DataProductCreate,
     DataProductUpdate,
-    DataProductAboutUpdate,
 )
 from app.data_products.schema_get import DataProductGet, DataProductsGet
 from app.data_products.service import DataProductService
 from app.database.database import get_db_session
+from app.dependencies import OnlyProductRoles
 from app.users.schema import User
 
 router = APIRouter(prefix="/data_products", tags=["data_products"])
@@ -75,6 +77,7 @@ def create_data_product(
             },
         }
     },
+    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.OWNER]))],
 )
 def remove_data_product(id: UUID, db: Session = Depends(get_db_session)):
     return DataProductService().remove_data_product(id, db)
@@ -90,6 +93,7 @@ def remove_data_product(id: UUID, db: Session = Depends(get_db_session)):
             },
         }
     },
+    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.MEMBER]))],
 )
 def update_data_product(
     id: UUID, data_product: DataProductUpdate, db: Session = Depends(get_db_session)
@@ -107,6 +111,7 @@ def update_data_product(
             },
         }
     },
+    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.MEMBER]))],
 )
 def update_data_product_about(
     id: UUID,
@@ -132,6 +137,7 @@ def update_data_product_about(
             },
         },
     },
+    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.OWNER]))],
 )
 def link_dataset_to_data_product(
     id: UUID,
@@ -160,6 +166,7 @@ def link_dataset_to_data_product(
             },
         },
     },
+    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.OWNER]))],
 )
 def unlink_dataset_from_data_product(
     id: UUID,
@@ -172,12 +179,17 @@ def unlink_dataset_from_data_product(
     )
 
 
-@router.get("/{id}/role")
+@router.get(
+    "/{id}/role", dependencies=[Depends(OnlyProductRoles([DataProductUserRole.MEMBER]))]
+)
 def get_role(id: UUID, environment: str, db: Session = Depends(get_db_session)) -> str:
     return DataProductService().get_data_product_role_arn(id, environment, db)
 
 
-@router.get("/{id}/signin_url")
+@router.get(
+    "/{id}/signin_url",
+    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.MEMBER]))],
+)
 def get_signin_url(
     id: UUID,
     environment: str,
@@ -189,11 +201,17 @@ def get_signin_url(
     )
 
 
-@router.get("/{id}/conveyor_notebook_url")
+@router.get(
+    "/{id}/conveyor_notebook_url",
+    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.MEMBER]))],
+)
 def get_conveyor_notebook_url(id: UUID, db: Session = Depends(get_db_session)) -> str:
     return DataProductService().get_conveyor_notebook_url(id, db)
 
 
-@router.get("/{id}/conveyor_ide_url")
+@router.get(
+    "/{id}/conveyor_ide_url",
+    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.MEMBER]))],
+)
 def get_conveyor_ide_url(id: UUID, db: Session = Depends(get_db_session)) -> str:
     return DataProductService().get_conveyor_ide_url(id, db)

--- a/backend/app/data_products/router.py
+++ b/backend/app/data_products/router.py
@@ -13,7 +13,7 @@ from app.data_products.schema import (
 from app.data_products.schema_get import DataProductGet, DataProductsGet
 from app.data_products.service import DataProductService
 from app.database.database import get_db_session
-from app.dependencies import OnlyProductRoles
+from app.dependencies import OnlyWithProductAccess
 from app.users.schema import User
 
 router = APIRouter(prefix="/data_products", tags=["data_products"])
@@ -77,7 +77,7 @@ def create_data_product(
             },
         }
     },
-    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.OWNER]))],
+    dependencies=[Depends(OnlyWithProductAccess([DataProductUserRole.OWNER]))],
 )
 def remove_data_product(id: UUID, db: Session = Depends(get_db_session)):
     return DataProductService().remove_data_product(id, db)
@@ -93,7 +93,7 @@ def remove_data_product(id: UUID, db: Session = Depends(get_db_session)):
             },
         }
     },
-    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.MEMBER]))],
+    dependencies=[Depends(OnlyWithProductAccess())],
 )
 def update_data_product(
     id: UUID, data_product: DataProductUpdate, db: Session = Depends(get_db_session)
@@ -111,7 +111,7 @@ def update_data_product(
             },
         }
     },
-    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.MEMBER]))],
+    dependencies=[Depends(OnlyWithProductAccess())],
 )
 def update_data_product_about(
     id: UUID,
@@ -137,7 +137,7 @@ def update_data_product_about(
             },
         },
     },
-    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.OWNER]))],
+    dependencies=[Depends(OnlyWithProductAccess([DataProductUserRole.OWNER]))],
 )
 def link_dataset_to_data_product(
     id: UUID,
@@ -166,7 +166,7 @@ def link_dataset_to_data_product(
             },
         },
     },
-    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.OWNER]))],
+    dependencies=[Depends(OnlyWithProductAccess([DataProductUserRole.OWNER]))],
 )
 def unlink_dataset_from_data_product(
     id: UUID,
@@ -179,16 +179,14 @@ def unlink_dataset_from_data_product(
     )
 
 
-@router.get(
-    "/{id}/role", dependencies=[Depends(OnlyProductRoles([DataProductUserRole.MEMBER]))]
-)
+@router.get("/{id}/role", dependencies=[Depends(OnlyWithProductAccess())])
 def get_role(id: UUID, environment: str, db: Session = Depends(get_db_session)) -> str:
     return DataProductService().get_data_product_role_arn(id, environment, db)
 
 
 @router.get(
     "/{id}/signin_url",
-    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.MEMBER]))],
+    dependencies=[Depends(OnlyWithProductAccess())],
 )
 def get_signin_url(
     id: UUID,
@@ -203,7 +201,7 @@ def get_signin_url(
 
 @router.get(
     "/{id}/conveyor_notebook_url",
-    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.MEMBER]))],
+    dependencies=[Depends(OnlyWithProductAccess())],
 )
 def get_conveyor_notebook_url(id: UUID, db: Session = Depends(get_db_session)) -> str:
     return DataProductService().get_conveyor_notebook_url(id, db)
@@ -211,7 +209,7 @@ def get_conveyor_notebook_url(id: UUID, db: Session = Depends(get_db_session)) -
 
 @router.get(
     "/{id}/conveyor_ide_url",
-    dependencies=[Depends(OnlyProductRoles([DataProductUserRole.MEMBER]))],
+    dependencies=[Depends(OnlyWithProductAccess())],
 )
 def get_conveyor_ide_url(id: UUID, db: Session = Depends(get_db_session)) -> str:
     return DataProductService().get_conveyor_ide_url(id, db)

--- a/backend/app/data_products/service.py
+++ b/backend/app/data_products/service.py
@@ -355,15 +355,6 @@ class DataProductService:
     def generate_signin_url(
         self, id: UUID, environment: str, authenticated_user: User, db: Session
     ) -> str:
-        if authenticated_user.id not in [
-            membership.user_id
-            for membership in db.get(DataProductModel, id).memberships
-        ]:
-            raise HTTPException(
-                status.HTTP_403_FORBIDDEN,
-                detail="You are not allowed to assume this role",
-            )
-
         role = self.get_data_product_role_arn(id, environment, db)
         json_credentials = self.get_aws_temporary_credentials(role, authenticated_user)
 

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -23,6 +23,8 @@ class OnlyProductRoles:
     """Only allow users that have a membership of a certain role type to this product"""
 
     def __init__(self, allowed_roles: list[DataProductUserRole]):
+        if allowed_roles == [DataProductUserRole.MEMBER]:
+            allowed_roles.append(DataProductUserRole.OWNER)
         self.allowed_roles = allowed_roles
 
     def __call__(

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from fastapi import Depends, HTTPException, status
 from sqlalchemy.orm import Session
+from sqlalchemy.orm.exc import NoResultFound
 
 from app.core.auth.auth import get_authenticated_user
 from app.data_product_memberships.enums import DataProductUserRole
@@ -35,7 +36,12 @@ class OnlyProductRoles:
         db: Session = Depends(get_db_session),
     ) -> None:
         if id:
-            data_product = db.get_one(DataProductModel, id)
+            try:
+                data_product = db.get_one(DataProductModel, id)
+            except NoResultFound:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND, detail="product not founds"
+                )
         elif data_product_name:
             data_product = db.query(DataProductModel).get_one(
                 DataProductModel.external_id, data_product_name

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,6 +1,13 @@
+from typing import Optional
+from uuid import UUID
+
 from fastapi import Depends, HTTPException, status
+from sqlalchemy.orm import Session
 
 from app.core.auth.auth import get_authenticated_user
+from app.data_product_memberships.enums import DataProductUserRole
+from app.data_products.model import DataProduct as DataProductModel
+from app.database.database import get_db_session
 from app.users.schema import User
 
 
@@ -10,3 +17,42 @@ async def only_for_admin(authenticated_user: User = Depends(get_authenticated_us
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only admin can execute this operation",
         )
+
+
+class OnlyProductRoles:
+    """Only allow users that have a membership of a certain role type to this product"""
+
+    def __init__(self, allowed_roles: list[DataProductUserRole]):
+        self.allowed_roles = allowed_roles
+
+    def __call__(
+        self,
+        data_product_name: Optional[str] = None,
+        id: Optional[UUID] = None,
+        authenticated_user: User = Depends(get_authenticated_user),
+        db: Session = Depends(get_db_session),
+    ) -> None:
+        if id:
+            data_product = db.get_one(DataProductModel, id)
+        elif data_product_name:
+            data_product = db.query(DataProductModel).get_one(
+                DataProductModel.external_id, data_product_name
+            )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Provide at least a product name or id",
+            )
+        if (
+            authenticated_user.id
+            not in [
+                membership.user_id
+                for membership in data_product.memberships
+                if membership.role in self.allowed_roles
+            ]
+            and not authenticated_user.is_admin
+        ):
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN,
+                detail="You are not allowed to assume this role",
+            )

--- a/backend/tests/data_products_datasets/test_router.py
+++ b/backend/tests/data_products_datasets/test_router.py
@@ -110,7 +110,7 @@ class TestDataProductsDatasetsRouter:
         assert response.status_code == 200
 
     def test_request_dataset_link_with_invalid_dataset_id(self, client):
-        membership = DataProductMembershipFactory()
+        membership = DataProductMembershipFactory(user=UserFactory(external_id="sub"))
         response = self.request_data_product_dataset_link(
             client, membership.data_product_id, self.invalid_id
         )


### PR DESCRIPTION
Some endpoints were completely unprotected. They did not check whether or not you were a member / owner for a product.
E.g. the request credentials from AWS endpoint.
This is a big security risk.

Now all endpoints from the data products route are at least secured. The rest can be refactored once this method is approved and tested