### PR TITLE
Make it possible to pass custom translations via configmap in helm

### DIFF
--- a/helm/templates/deployment_frontend.yaml
+++ b/helm/templates/deployment_frontend.yaml
@@ -53,9 +53,20 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.custom_translation_file_path }}
+            - name: translation
+              mountPath: /app/dist/locales/en/translation.json
+              subPath: translation.json
+          {{- end }}
       {{- with .Values.frontendvolumes }}
       volumes:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.custom_translation_file_path }}
+        - name: translation
+          configMap:
+            name: translation
+            optional: True
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,6 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+custom_translation_file_path: ""
 global:
   postgresql:
     auth:


### PR DESCRIPTION
Note:
- if option is enabled then configmap needs to be added separately (Helm does not allow to inject files outside of the helm directory)
- Configmap needs to be called translation and the file within translation.json