### PR TITLE
Update CLI workflow

### DIFF
--- a/.github/workflows/cli-workflow.yml
+++ b/.github/workflows/cli-workflow.yml
@@ -45,27 +45,24 @@ jobs:
       contents: write
     needs: ["prep-version"]
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v5
-      -
-        name: Run GoReleaser
+        with:
+          go-version-file: 'cli/go.mod'
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
-          # 'latest', 'nightly', or a semver
           version: '~> v2'
           args: release --clean
+          workdir: cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Upload assets
+      - name: Upload assets
         uses: actions/upload-artifact@v4
         with:
           name: Data product portal CLI

--- a/.github/workflows/cli-workflow.yml
+++ b/.github/workflows/cli-workflow.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'cli/go.mod'
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: cli/go.mod
-          cache: false
+          cache-dependency-path: cli/go.sum
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -16,8 +16,8 @@ config.env
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+# Dependency directories
+vendor/
 
 # Go workspace file
 go.work

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -1,19 +1,15 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
 
 # The lines below are called `modelines`. See `:help modeline`
-# Feel free to remove those if you don't want/need to use them.
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
-version: 1
+version: 2
 
 before:
   hooks:
-    # You may remove this if you don't use go modules.
-    - sh -c "cd cli && go mod tidy"
-    # you may remove this if you don't need go generate
-    - sh -c "cd cli && go generate ./..."
+    - go mod tidy
+    - go generate ./...
 
 builds:
   - env:


### PR DESCRIPTION
- Move .goreleaser inside the cli/ directory
- Use the go version of the go.mod file
- Include /vendor directory in .gitignore
- Enable caching