### PR TITLE
Align postgresql container images

### DIFF
--- a/backend/test-compose.yaml
+++ b/backend/test-compose.yaml
@@ -1,6 +1,6 @@
 services:
   postgresql:
-    image: bitnami/postgresql:16.2.0
+    image: bitnami/postgresql:16.6.0
     container_name: data-product-portal-postgresql-test
     ports:
       - 5433:5432

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,7 +25,7 @@ services:
     volumes:
       - ${PWD:-.}/frontend/config.docker.js:/app/dist/config.js
   postgresql:
-    image: postgres:16.3-alpine
+    image: bitnami/postgresql:16.6.0
     container_name: data-product-portal-postgresql
     ports:
       - ${POSTGRES_PORT:-5432}:5432


### PR DESCRIPTION
Aligned both to the latest 16.x releases of the bitnami (VMware) images.
These are smaller and supposedly more secure than the official ones.