### PR TITLE
Change react-router-dom to react-router

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,7 +39,7 @@
         "react-i18next": "^15.4.1",
         "react-oidc-context": "^3.2.0",
         "react-redux": "^9.2.0",
-        "react-router-dom": "^7.2.0",
+        "react-router": "^7.2.0",
         "reactflow": "^11.11.4"
       },
       "devDependencies": {
@@ -9135,22 +9135,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.2.0.tgz",
-      "integrity": "sha512-cU7lTxETGtQRQbafJubvZKHEn5izNABxZhBY0Jlzdv0gqQhCPQt2J8aN5ZPjS6mQOXn5NnirWNh+FpE8TTYN0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.2.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-router/node_modules/cookie": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,7 @@
     "react-i18next": "^15.4.1",
     "react-oidc-context": "^3.2.0",
     "react-redux": "^9.2.0",
-    "react-router-dom": "^7.2.0",
+    "react-router": "^7.2.0",
     "reactflow": "^11.11.4"
   },
   "devDependencies": {

--- a/frontend/src/components/data-outputs/data-output-form/data-output-form.component.tsx
+++ b/frontend/src/components/data-outputs/data-output-form/data-output-form.component.tsx
@@ -2,7 +2,7 @@ import { Button, Form, type FormProps, Input, Popconfirm, Select, Space } from '
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { FORM_GRID_WRAPPER_COLS, MAX_DESCRIPTION_INPUT_LENGTH } from '@/constants/form.constants.ts';
 import { selectCurrentUser } from '@/store/features/auth/auth-slice';

--- a/frontend/src/components/data-products/data-output-form/data-output-form.component.tsx
+++ b/frontend/src/components/data-products/data-output-form/data-output-form.component.tsx
@@ -2,7 +2,7 @@ import { Form, type FormInstance, type FormProps, Input, Select, Space } from 'a
 import TextArea from 'antd/es/input/TextArea';
 import { type RefObject, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { DataOutputPlatformTile } from '@/components/data-outputs/data-output-platform-tile/data-output-platform-tile.component';
 import { FORM_GRID_WRAPPER_COLS, MAX_DESCRIPTION_INPUT_LENGTH } from '@/constants/form.constants.ts';

--- a/frontend/src/components/data-products/data-product-form/data-product-form.component.tsx
+++ b/frontend/src/components/data-products/data-product-form/data-product-form.component.tsx
@@ -2,7 +2,7 @@ import { Button, Form, type FormProps, Input, Popconfirm, Select, Space } from '
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { FORM_GRID_WRAPPER_COLS, MAX_DESCRIPTION_INPUT_LENGTH } from '@/constants/form.constants.ts';
 import { selectCurrentUser } from '@/store/features/auth/auth-slice.ts';

--- a/frontend/src/components/datasets/components/dataset-form.component.tsx
+++ b/frontend/src/components/datasets/components/dataset-form.component.tsx
@@ -3,7 +3,7 @@ import type { TFunction } from 'i18next';
 import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { FORM_GRID_WRAPPER_COLS, MAX_DESCRIPTION_INPUT_LENGTH } from '@/constants/form.constants.ts';
 import { selectCurrentUser } from '@/store/features/auth/auth-slice.ts';

--- a/frontend/src/components/environment-config-create/components/environment-config-create-form.component.tsx
+++ b/frontend/src/components/environment-config-create/components/environment-config-create-form.component.tsx
@@ -1,7 +1,7 @@
 import { Button, Form, type FormProps, Input, Select, Space } from 'antd';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { buildUrl } from '@/api/api-urls';
 import { ENV_PLATFORM_SERVICE_CONFIG_MAPPING } from '@/constants/environment-config.constants.ts';

--- a/frontend/src/components/environment/components/environment-create-form.component.tsx
+++ b/frontend/src/components/environment/components/environment-create-form.component.tsx
@@ -1,6 +1,6 @@
 import { Button, Form, FormProps, Input, Space, Switch } from 'antd';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { FORM_GRID_WRAPPER_COLS } from '@/constants/form.constants.ts';
 import { useCreateEnvironmentMutation } from '@/store/features/environments/environments-api-slice';

--- a/frontend/src/components/explorer/explorer.tsx
+++ b/frontend/src/components/explorer/explorer.tsx
@@ -3,7 +3,7 @@ import 'reactflow/dist/base.css';
 import { Button, Flex, theme } from 'antd';
 import { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Edge, Node, Position, XYPosition } from 'reactflow';
 
 import { NodeEditor } from '@/components/charts/node-editor/node-editor.tsx';

--- a/frontend/src/components/layout/auth/auth.layout.tsx
+++ b/frontend/src/components/layout/auth/auth.layout.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from 'react';
 import { useAuth } from 'react-oidc-context';
 import { useSelector } from 'react-redux';
-import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router';
 
 import { LoadingSpinner } from '@/components/loading/loading-spinner/loading-spinner.tsx';
 import { AppConfig } from '@/config/app-config.ts';

--- a/frontend/src/components/layout/navbar/breadcrumbs/breadcrumb-link/breadcrumb-link.component.tsx
+++ b/frontend/src/components/layout/navbar/breadcrumbs/breadcrumb-link/breadcrumb-link.component.tsx
@@ -1,7 +1,7 @@
 import { Flex } from 'antd';
 import clsx from 'clsx';
 import { ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import styles from './breadcrumb-link.module.scss';
 

--- a/frontend/src/components/layout/navbar/breadcrumbs/breadcrumbs.component.tsx
+++ b/frontend/src/components/layout/navbar/breadcrumbs/breadcrumbs.component.tsx
@@ -3,7 +3,7 @@ import { Breadcrumb, Space, Typography } from 'antd';
 import { BreadcrumbItemType, BreadcrumbSeparatorType } from 'antd/es/breadcrumb/Breadcrumb';
 import { ReactNode, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 
 import dataProductOutlineIcon from '@/assets/icons/data-product-outline-icon.svg?react';
 import datasetOutlineIcon from '@/assets/icons/dataset-outline-icon.svg?react';

--- a/frontend/src/components/layout/protected/protected.layout.tsx
+++ b/frontend/src/components/layout/protected/protected.layout.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from 'react-redux';
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet } from 'react-router';
 
 import { selectCurrentUser } from '@/store/features/auth/auth-slice';
 import { ApplicationPaths } from '@/types/navigation';

--- a/frontend/src/components/layout/public/public.layout.tsx
+++ b/frontend/src/components/layout/public/public.layout.tsx
@@ -1,7 +1,7 @@
 import { Layout, theme } from 'antd';
 import React, { useEffect } from 'react';
 import { useAuth } from 'react-oidc-context';
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router';
 
 import { ApplicationPaths } from '@/types/navigation.ts';
 

--- a/frontend/src/components/layout/root/root.layout.tsx
+++ b/frontend/src/components/layout/root/root.layout.tsx
@@ -1,7 +1,7 @@
 import { Layout } from 'antd';
 import clsx from 'clsx';
 import React from 'react';
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router';
 
 import { Navbar } from '@/components/layout/navbar/navbar.component.tsx';
 import { Sidebar } from '@/components/layout/sidebar/sidebar.component.tsx';

--- a/frontend/src/components/layout/sidebar/sidebar.component.tsx
+++ b/frontend/src/components/layout/sidebar/sidebar.component.tsx
@@ -3,7 +3,7 @@ import { Flex, Layout, Menu, type MenuProps, Space } from 'antd';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { Link, useMatches } from 'react-router-dom';
+import { Link, useMatches } from 'react-router';
 
 import { SidebarLogo } from '@/components/branding/sidebar-logo/sidebar-logo.tsx';
 import { DataProductOutlined, DatasetOutlined, ProductLogo } from '@/components/icons';

--- a/frontend/src/components/list/table-cell-avatar/table-cell-avatar.component.tsx
+++ b/frontend/src/components/list/table-cell-avatar/table-cell-avatar.component.tsx
@@ -1,6 +1,6 @@
 import { Flex, Popover, PopoverProps, Space, Typography } from 'antd';
 import { ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import styles from './table-cell-avatar.module.scss';
 

--- a/frontend/src/components/list/usage-list-item/usage-list-item.component.tsx
+++ b/frontend/src/components/list/usage-list-item/usage-list-item.component.tsx
@@ -1,6 +1,6 @@
 import { List, Typography } from 'antd';
 import { ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import styles from './usage-list-item.module.scss';
 

--- a/frontend/src/components/notifications/notifications.tsx
+++ b/frontend/src/components/notifications/notifications.tsx
@@ -3,7 +3,7 @@ import { Badge, Button, Dropdown, Flex, type MenuProps, Space, theme, Typography
 import type { TFunction } from 'i18next';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, type NavigateFunction, useNavigate } from 'react-router-dom';
+import { Link, type NavigateFunction, useNavigate } from 'react-router';
 
 import { TabKeys as DataProductTabKeys } from '@/pages/data-product/components/data-product-tabs/data-product-tabkeys';
 import { TabKeys as DatasetTabKeys } from '@/pages/dataset/components/dataset-tabs/dataset-tabkeys';

--- a/frontend/src/components/platform-service-config/components/platform-service-config-create-form.component.tsx
+++ b/frontend/src/components/platform-service-config/components/platform-service-config-create-form.component.tsx
@@ -1,7 +1,7 @@
 import { Button, Form, FormProps, Input, Select, Space } from 'antd';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { FORM_GRID_WRAPPER_COLS } from '@/constants/form.constants.ts';
 import { PLATFORM_SERVICE_CONFIG_MAPPING } from '@/constants/platform-service-config.constants';

--- a/frontend/src/pages/data-output-edit/data-output-edit.page.tsx
+++ b/frontend/src/pages/data-output-edit/data-output-edit.page.tsx
@@ -1,5 +1,5 @@
 import { Flex, Space, Typography } from 'antd';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { DataOutputForm } from '@/components/data-outputs/data-output-form/data-output-form.component';
 import { useGetDataOutputByIdQuery } from '@/store/features/data-outputs/data-outputs-api-slice';

--- a/frontend/src/pages/data-output/components/data-output-tabs/data-output-tabs.tsx
+++ b/frontend/src/pages/data-output/components/data-output-tabs/data-output-tabs.tsx
@@ -2,7 +2,7 @@ import Icon, { CodeOutlined, PartitionOutlined } from '@ant-design/icons';
 import { Tabs } from 'antd';
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { ReactFlowProvider } from 'reactflow';
 
 import datasetOutlineIcon from '@/assets/icons/dataset-outline-icon.svg?react';

--- a/frontend/src/pages/data-output/data-output.page.tsx
+++ b/frontend/src/pages/data-output/data-output.page.tsx
@@ -3,7 +3,7 @@ import { Flex, Space, Typography } from 'antd';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { CircleIconButton } from '@/components/buttons/circle-icon-button/circle-icon-button.tsx';
 import { UserAccessOverview } from '@/components/data-access/user-access-overview/user-access-overview.component.tsx';

--- a/frontend/src/pages/data-product-edit/data-product-edit.page.tsx
+++ b/frontend/src/pages/data-product-edit/data-product-edit.page.tsx
@@ -1,5 +1,5 @@
 import { Flex, Space, Typography } from 'antd';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { DataProductForm } from '@/components/data-products/data-product-form/data-product-form.component.tsx';
 import { useGetDataProductByIdQuery } from '@/store/features/data-products/data-products-api-slice.ts';

--- a/frontend/src/pages/data-product/components/data-product-tabs/data-product-tabs.tsx
+++ b/frontend/src/pages/data-product/components/data-product-tabs/data-product-tabs.tsx
@@ -8,7 +8,7 @@ import Icon, {
 import { Tabs } from 'antd';
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { ReactFlowProvider } from 'reactflow';
 
 import dataOutputOutlineIcon from '@/assets/icons/data-output-outline-icon.svg?react';

--- a/frontend/src/pages/data-product/data-product.page.tsx
+++ b/frontend/src/pages/data-product/data-product.page.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { CircleIconButton } from '@/components/buttons/circle-icon-button/circle-icon-button.tsx';
 import { UserAccessOverview } from '@/components/data-access/user-access-overview/user-access-overview.component.tsx';

--- a/frontend/src/pages/data-products/components/data-products-table/data-products-table.component.tsx
+++ b/frontend/src/pages/data-products/components/data-products-table/data-products-table.component.tsx
@@ -3,7 +3,7 @@ import { Button, Flex, Form, Input, Space, Table, Typography } from 'antd';
 import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 
 import { TableQuickFilter } from '@/components/list/table-quick-filter/table-quick-filter';
 import { useQuickFilter } from '@/hooks/use-quick-filter';

--- a/frontend/src/pages/dataset-edit/dataset-edit.page.tsx
+++ b/frontend/src/pages/dataset-edit/dataset-edit.page.tsx
@@ -1,5 +1,5 @@
 import { Flex, Space, Typography } from 'antd';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import { DatasetForm } from '@/components/datasets/components/dataset-form.component.tsx';
 import { useGetDatasetByIdQuery } from '@/store/features/datasets/datasets-api-slice.ts';

--- a/frontend/src/pages/dataset/components/dataset-tabs/dataset-tabs.tsx
+++ b/frontend/src/pages/dataset/components/dataset-tabs/dataset-tabs.tsx
@@ -8,7 +8,7 @@ import {
 import { Tabs } from 'antd';
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { ReactFlowProvider } from 'reactflow';
 
 import { Explorer } from '@/components/explorer/explorer';

--- a/frontend/src/pages/dataset/dataset.page.tsx
+++ b/frontend/src/pages/dataset/dataset.page.tsx
@@ -3,7 +3,7 @@ import { Flex, Popover, Typography } from 'antd';
 import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import datasetBorderIcon from '@/assets/icons/dataset-border-icon.svg?react';
 import shieldHalfIcon from '@/assets/icons/shield-half-icon.svg?react';

--- a/frontend/src/pages/datasets/components/datasets-table/datasets-table.component.tsx
+++ b/frontend/src/pages/datasets/components/datasets-table/datasets-table.component.tsx
@@ -2,7 +2,7 @@ import { Button, Flex, Form, Input, RadioChangeEvent, Space, Table, TableProps, 
 import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 
 import { TableQuickFilter } from '@/components/list/table-quick-filter/table-quick-filter.tsx';
 import { useQuickFilter } from '@/hooks/use-quick-filter.tsx';

--- a/frontend/src/pages/environment-config/environment-config.page.tsx
+++ b/frontend/src/pages/environment-config/environment-config.page.tsx
@@ -1,7 +1,7 @@
 import { Flex, Typography } from 'antd';
 import { Input } from 'antd/lib';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { LoadingSpinner } from '@/components/loading/loading-spinner/loading-spinner';
 import { useGetEnvConfigByIdQuery } from '@/store/features/environments/environments-api-slice';

--- a/frontend/src/pages/environment-configs/components/environment-configs-table/environment-configs-table.component.tsx
+++ b/frontend/src/pages/environment-configs/components/environment-configs-table/environment-configs-table.component.tsx
@@ -1,7 +1,7 @@
 import { Button, Flex, Form, Input, Space, Table, TableProps, Typography } from 'antd';
 import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router';
 
 import { buildUrl } from '@/api/api-urls';
 import { useTablePagination } from '@/hooks/use-table-pagination.tsx';

--- a/frontend/src/pages/environments/components/environments-table/environments-table.component.tsx
+++ b/frontend/src/pages/environments/components/environments-table/environments-table.component.tsx
@@ -1,7 +1,7 @@
 import { Button, Flex, Form, Input, Space, Table, TableProps, Typography } from 'antd';
 import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 
 import { useTablePagination } from '@/hooks/use-table-pagination.tsx';
 import { useGetAllEnvironmentsQuery } from '@/store/features/environments/environments-api-slice.tsx';

--- a/frontend/src/pages/error/error-root-element.page.tsx
+++ b/frontend/src/pages/error/error-root-element.page.tsx
@@ -1,7 +1,7 @@
 import { Button, Result } from 'antd';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { isRouteErrorResponse, useNavigate, useRouteError } from 'react-router-dom';
+import { isRouteErrorResponse, useNavigate, useRouteError } from 'react-router';
 
 import { Logout } from '@/pages/auth/logout/logout-page.tsx';
 import { ApplicationPaths } from '@/types/navigation.ts';

--- a/frontend/src/pages/home/components/data-products-inbox/data-products-inbox.tsx
+++ b/frontend/src/pages/home/components/data-products-inbox/data-products-inbox.tsx
@@ -2,7 +2,7 @@ import { PartitionOutlined, TeamOutlined } from '@ant-design/icons';
 import { Button, Tabs, Typography } from 'antd';
 import { ReactNode, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { LoadingSpinner } from '@/components/loading/loading-spinner/loading-spinner.tsx';
 import { filterOutNonMatchingItems, sortLastVisitedOwnedItems } from '@/pages/home/helpers/last-visited-item-helper.ts';

--- a/frontend/src/pages/home/components/data-products-inbox/data-products-list.tsx
+++ b/frontend/src/pages/home/components/data-products-inbox/data-products-list.tsx
@@ -1,6 +1,6 @@
 import { Button, List } from 'antd';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { CustomSvgIconLoader } from '@/components/icons/custom-svg-icon-loader/custom-svg-icon-loader.component.tsx';
 import { UsageListItem } from '@/components/list/usage-list-item/usage-list-item.component.tsx';

--- a/frontend/src/pages/home/components/datasets-inbox/datasets-inbox.tsx
+++ b/frontend/src/pages/home/components/datasets-inbox/datasets-inbox.tsx
@@ -2,7 +2,7 @@ import { PartitionOutlined, TeamOutlined } from '@ant-design/icons';
 import { Button, Tabs, Typography } from 'antd';
 import { ReactNode, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { LoadingSpinner } from '@/components/loading/loading-spinner/loading-spinner.tsx';
 import { DatasetList } from '@/pages/home/components/datasets-inbox/datasets-list.tsx';

--- a/frontend/src/pages/home/components/datasets-inbox/datasets-list.tsx
+++ b/frontend/src/pages/home/components/datasets-inbox/datasets-list.tsx
@@ -1,6 +1,6 @@
 import { Button, List } from 'antd';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import datasetBorderIcon from '@/assets/icons/dataset-border-icon.svg?react';
 import { CustomSvgIconLoader } from '@/components/icons/custom-svg-icon-loader/custom-svg-icon-loader.component.tsx';

--- a/frontend/src/pages/platform-service-config/platform-service-config.page.tsx
+++ b/frontend/src/pages/platform-service-config/platform-service-config.page.tsx
@@ -1,7 +1,7 @@
 import { Button, Flex, Input, Space, Typography } from 'antd';
 import { ChangeEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { LoadingSpinner } from '@/components/loading/loading-spinner/loading-spinner.tsx';
 import { dispatchMessage } from '@/store/features/feedback/utils/dispatch-feedback.ts';

--- a/frontend/src/pages/platforms-configs/components/platforms-configs-table/platforms-configs-table.component.tsx
+++ b/frontend/src/pages/platforms-configs/components/platforms-configs-table/platforms-configs-table.component.tsx
@@ -1,7 +1,7 @@
 import { Button, Flex, Form, Input, Space, Table, TableProps, Typography } from 'antd';
 import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 
 import { useTablePagination } from '@/hooks/use-table-pagination.tsx';
 import { getPlatformConfigTableColumns } from '@/pages/platforms-configs/components/platforms-configs-table/platforms-configs-columns';

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider } from 'react-router';
 
 import { AuthLayout } from '@/components/layout/auth/auth.layout.tsx';
 import PublicLayout from '@/components/layout/public/public.layout.tsx';


### PR DESCRIPTION
As of version 7, the preferred module is `react-router` instead of `react-router-dom` (`react-router-dom` is still updated for compatibility reasons).

This PR updates `package.json` and relevant imports.