### PR TITLE
Fix: data product or dataset without owners

### DIFF
--- a/backend/app/data_product_memberships/service.py
+++ b/backend/app/data_product_memberships/service.py
@@ -158,6 +158,18 @@ class DataProductMembershipService:
 
         data_product = data_product_membership.data_product
 
+        if not any(
+            membership.role == DataProductUserRole.OWNER
+            for membership in data_product.memberships
+            if membership != data_product_membership
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Cannot remove the last owner from data product {data_product.id}"
+                ),
+            )
+
         data_product.memberships.remove(data_product_membership)
         db.commit()
         RefreshInfrastructureLambda().trigger()
@@ -200,16 +212,31 @@ class DataProductMembershipService:
         membership_role: DataProductUserRole,
         db: Session,
     ):
-        data_product_membership = (
-            db.query(DataProductMembership).filter_by(id=id).first()
-        )
+        data_product_membership = db.get(DataProductMembership, id)
         if data_product_membership is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Data product membership {id} not found",
             )
 
-        data_product_membership = db.get(DataProductMembership, id)
+        data_product = data_product_membership.data_product
+
+        if (
+            data_product_membership.role == DataProductUserRole.OWNER
+            and membership_role != DataProductUserRole.OWNER
+            and not any(
+                membership.role == DataProductUserRole.OWNER
+                for membership in data_product.memberships
+                if membership != data_product_membership
+            )
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Cannot remove the last owner from data product {data_product.id}"
+                ),
+            )
+
         data_product_membership.role = membership_role
         db.commit()
         db.refresh(data_product_membership)

--- a/backend/app/data_products/schema.py
+++ b/backend/app/data_products/schema.py
@@ -1,6 +1,11 @@
+from typing import Annotated
 from uuid import UUID
 
+from annotated_types import MinLen
+from pydantic import field_validator
+
 from app.data_outputs.schema_get import DataOutputGet
+from app.data_product_memberships.enums import DataProductUserRole
 from app.data_product_memberships.schema import (
     DataProductMembership,
     DataProductMembershipCreate,
@@ -14,10 +19,21 @@ from app.tags.schema import Tag
 
 
 class DataProductCreate(BaseDataProduct):
-    memberships: list[DataProductMembershipCreate]
+    memberships: Annotated[list[DataProductMembershipCreate], MinLen(1)]
     domain_id: UUID
     tag_ids: list[UUID]
     lifecycle_id: UUID
+
+    @field_validator("memberships", mode="after")
+    @classmethod
+    def contains_owner(
+        cls, value: list[DataProductMembershipCreate]
+    ) -> list[DataProductMembershipCreate]:
+        if not any(
+            membership.role == DataProductUserRole.OWNER for membership in value
+        ):
+            raise ValueError("Data product must have at least one owner")
+        return value
 
 
 class DataProductUpdate(DataProductCreate):

--- a/backend/app/data_products/service.py
+++ b/backend/app/data_products/service.py
@@ -268,11 +268,6 @@ class DataProductService:
         for membership in memberships_to_remove:
             data_product.memberships.remove(membership)
 
-        if not any(
-            m.role == DataProductUserRole.OWNER for m in data_product.memberships
-        ):
-            raise ValueError("At least one owner membership is required.")
-
     def update_data_product(
         self, id: UUID, data_product: DataProductUpdate, db: Session
     ):

--- a/backend/app/datasets/schema.py
+++ b/backend/app/datasets/schema.py
@@ -1,5 +1,7 @@
-from typing import Optional
+from typing import Annotated, Optional
 from uuid import UUID
+
+from annotated_types import MinLen
 
 from app.datasets.enums import DatasetAccessType
 from app.datasets.status import DatasetStatus
@@ -27,14 +29,14 @@ class DatasetStatusUpdate(ORMModel):
 
 
 class DatasetCreateUpdate(BaseDataset):
-    owners: list[UUID]
+    owners: Annotated[list[UUID], MinLen(1)]
     domain_id: UUID
     tag_ids: list[UUID]
 
 
 class Dataset(BaseDataset):
     id: UUID
-    owners: list[User]
+    owners: Annotated[list[User], MinLen(1)]
     status: DatasetStatus
     domain: Domain
     tags: list[Tag]

--- a/backend/app/datasets/schema_get.py
+++ b/backend/app/datasets/schema_get.py
@@ -1,6 +1,7 @@
 from typing import Annotated, Optional
 from uuid import UUID
 
+from annotated_types import MinLen
 from pydantic import Field, computed_field
 
 from app.data_outputs.schema_get import DataOutputGet
@@ -31,7 +32,7 @@ class DatasetGet(ORMModel):
     external_id: str
     name: str
     description: str
-    owners: list[User]
+    owners: Annotated[list[User], MinLen(1)]
     data_product_links: list[DataProductLink]
     lifecycle: Optional[DataProductLifeCycle]
     status: DatasetStatus

--- a/backend/app/datasets/service.py
+++ b/backend/app/datasets/service.py
@@ -175,6 +175,18 @@ class DatasetService:
     def remove_user_from_dataset(self, dataset_id: UUID, user_id: UUID, db: Session):
         dataset = ensure_dataset_exists(dataset_id, db)
         user = ensure_user_exists(user_id, db)
+
+        if user not in dataset.owners:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"User {user_id} is not an owner of dataset {dataset_id}",
+            )
+        elif len(dataset.owners) == 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Cannot remove the last owner of dataset {dataset_id}",
+            )
+
         dataset.owners.remove(user)
         db.commit()
         RefreshInfrastructureLambda().trigger()

--- a/backend/tests/app/data_product_memberships/test_router.py
+++ b/backend/tests/app/data_product_memberships/test_router.py
@@ -80,6 +80,12 @@ class TestDataProductMembershipsRouter:
         response = self.remove_data_product_membership(client, membership_2.id)
         assert response.status_code == 200
 
+    def test_remove_data_product_membership_last_owner(self, client):
+        membership = DataProductMembershipFactory(user=UserFactory(external_id="sub"))
+
+        response = self.remove_data_product_membership(client, membership.id)
+        assert response.status_code == 400
+
     def test_update_data_product_membership_role(self, client):
         owner_membership = DataProductMembershipFactory(
             user=UserFactory(external_id="sub")
@@ -94,6 +100,13 @@ class TestDataProductMembershipsRouter:
             client, membership.id, DataProductUserRole.OWNER.value
         )
         assert response.status_code == 200
+
+    def test_update_data_product_membership_role_last_owner(self, client):
+        membership = DataProductMembershipFactory(user=UserFactory(external_id="sub"))
+        response = self.update_data_product_membership_user_role(
+            client, membership.id, DataProductUserRole.MEMBER.value
+        )
+        assert response.status_code == 400
 
     def test_get_pending_actions_no_action(self, client):
         DataProductMembershipFactory(user=UserFactory(external_id="sub"))

--- a/backend/tests/app/datasets/test_router.py
+++ b/backend/tests/app/datasets/test_router.py
@@ -1,4 +1,5 @@
 import uuid
+from copy import deepcopy
 
 import pytest
 from tests.factories import DatasetFactory, DomainFactory, UserFactory
@@ -33,6 +34,12 @@ class TestDatasetsRouter:
         created_dataset = self.create_default_dataset(client, dataset_payload)
         assert created_dataset.status_code == 200
         assert "id" in created_dataset.json()
+
+    def test_create_dataset_no_owners(self, dataset_payload, client):
+        create_payload = deepcopy(dataset_payload)
+        create_payload["owners"] = []
+        created_dataset = self.create_default_dataset(client, create_payload)
+        assert created_dataset.status_code == 422
 
     def test_get_datasets(self, client):
         ds = DatasetFactory()
@@ -88,6 +95,22 @@ class TestDatasetsRouter:
 
         assert updated_dataset.status_code == 200
         assert updated_dataset.json()["id"] == str(ds.id)
+
+    def test_update_dataset_remove_all_owners(self, client):
+        ds = DatasetFactory(owners=[UserFactory(external_id="sub")])
+        update_payload = {
+            "name": "new_name",
+            "external_id": "new_external_id",
+            "description": "new_description",
+            "tags": [],
+            "access_type": "public",
+            "owners": [],
+            "domain_id": str(ds.domain_id),
+        }
+
+        updated_dataset = self.update_default_dataset(client, update_payload, ds.id)
+
+        assert updated_dataset.status_code == 422
 
     def test_update_dataset_about_not_owners(self, client):
         ds = DatasetFactory()
@@ -148,6 +171,13 @@ class TestDatasetsRouter:
         dataset = self.get_dataset_by_id(client, ds.id)
         assert dataset.status_code == 200
         assert len(dataset.json()["owners"]) == 1
+
+    def test_remove_last_user_from_dataset(self, client):
+        owner = UserFactory(external_id="sub")
+        ds = DatasetFactory(owners=[owner])
+
+        response = self.delete_dataset_user(client, owner.id, ds.id)
+        assert response.status_code == 400
 
     def test_get_dataset_by_id_with_invalid_dataset_id(self, client, session):
         dataset = self.get_dataset_by_id(client, self.invalid_id)


### PR DESCRIPTION
- Added extra validation to DataProductCreate and DataProductUpdate schemas
- Added extra validation to Dataset schema
- Added extra validation on remove_user_from_dataset endpoint
- Added extra validation on data product membership manipulation