### PR TITLE
Mypy linting error resolved by specifying Python version, plus npm install missing linting package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,71 +1,72 @@
 repos:
-# Common git hooks
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
-  hooks:
-    # Git style
-    - id: check-added-large-files
-      exclude: ^frontend/src/assets/fonts/
-    - id: check-merge-conflict
-    - id: no-commit-to-branch
+  # Common git hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      # Git style
+      - id: check-added-large-files
+        exclude: ^frontend/src/assets/fonts/
+      - id: check-merge-conflict
+      - id: no-commit-to-branch
 
-    # Common errors
-    - id: end-of-file-fixer
-    - id: trailing-whitespace
-    - id: check-yaml
-      exclude: ^helm/templates
-    - id: check-merge-conflict
-    - id: check-executables-have-shebangs
+      # Common errors
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+        exclude: ^helm/templates
+      - id: check-merge-conflict
+      - id: check-executables-have-shebangs
 
-    # Cross-platform
-    - id: check-case-conflict
-    - id: mixed-line-ending
-      args: [--fix=lf]
-    - id: check-symlinks
+      # Cross-platform
+      - id: check-case-conflict
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: check-symlinks
 
-    # Security
-    - id: detect-aws-credentials
-      args: ['--allow-missing-credentials']
-    - id: detect-private-key
+      # Security
+      - id: detect-aws-credentials
+        args: ["--allow-missing-credentials"]
+      - id: detect-private-key
 
-# Python
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.14.1
-  hooks:
-    - id: mypy
-      additional_dependencies:
-      - types-PyYAML
-      - types-requests
-      - types-pytz
-- repo: https://github.com/pycqa/flake8
-  rev: 7.1.1
-  hooks:
-    - id: flake8
-      additional_dependencies: [flake8-black]
-- repo: https://github.com/psf/black
-  rev: 25.1.0
-  hooks:
-    - id: black
-- repo: https://github.com/pycqa/isort
-  rev: 6.0.0
-  hooks:
-    - id: isort
-      name: isort (python)
-- repo: https://github.com/gitleaks/gitleaks
-  rev: v8.23.2
-  hooks:
-    - id: gitleaks
-- repo: local
-  hooks:
-    - id: add-helm-version
-      name: add-helm-version
-      entry: ./add_helm_version.sh
-      language: script
-    - id: prettier
-      name: prettier
-      entry: bash -c "cd frontend && npm run format"
-      language: node
-    - id: lint
-      name: lint
-      entry: bash -c "cd frontend && npm run lint"
-      language: node
+  # Python
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.14.1
+    hooks:
+      - id: mypy
+        args: [--python-version=3.12]
+        additional_dependencies:
+          - types-PyYAML
+          - types-requests
+          - types-pytz
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-black]
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 6.0.0
+    hooks:
+      - id: isort
+        name: isort (python)
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.23.2
+    hooks:
+      - id: gitleaks
+  - repo: local
+    hooks:
+      - id: add-helm-version
+        name: add-helm-version
+        entry: ./add_helm_version.sh
+        language: script
+      - id: prettier
+        name: prettier
+        entry: bash -c "cd frontend && npm run format"
+        language: node
+      - id: lint
+        name: lint
+        entry: bash -c "cd frontend && npm run lint"
+        language: node

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3423,7 +3423,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.26.1.tgz",
       "integrity": "sha512-2X3mwqsj9Bd3Ciz508ZUtoQQYpOhU/kWoUqIf49H8Z0+Vbh6UF/y0OEYp0Q0axOGzaBGs7QxRwq0knSQ8khQNA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.26.1",


### PR DESCRIPTION
Resolved some linting issues for me:

MyPy uses my mac root python version, ignoring poetry env version, standard set python version, etc...
-> Version specified in linting file

ESLint:
Oops! Something went wrong! :(

ESLint: 8.57.1

ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin".

Could not be resolved by tinkering with global ESLint version on my mac, but a simple npm install did resolve it.