### PR TITLE
Add endpoint to check resource access

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
   hooks:
     - id: flake8
       additional_dependencies: [flake8-black]
-- repo: https://github.com/psf/black
+- repo: https://github.com/psf/black-pre-commit-mirror
   rev: 25.1.0
   hooks:
     - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,9 +34,10 @@ repos:
   hooks:
     - id: mypy
       additional_dependencies:
-      - types-PyYAML
+      - types-cachetools
       - types-requests
       - types-pytz
+      - types-PyYAML
 - repo: https://github.com/pycqa/flake8
   rev: 7.1.1
   hooks:

--- a/backend/app/authorization/router.py
+++ b/backend/app/authorization/router.py
@@ -25,14 +25,11 @@ def check_access(
     """Allows the requesting user to check whether an access check will fail or succeed.
     Useful to conditionally disable parts of the UI that are known to be inaccessible.
     """
-    authorizer = Authorization()
+    dom = "*" if request.domain is None else request.domain
+    obj = "*" if request.object_id is None else str(request.object_id)
 
-    domain = "*" if request.domain is None else request.domain
-    object_ = "*" if request.object_id is None else str(request.object_id)
+    authorizer = Authorization()
     access = authorizer.has_access(
-        subject=str(user.id),
-        domain=domain,
-        object_=object_,
-        action=request.action,
+        sub=str(user.id), dom=dom, obj=obj, act=request.action
     )
     return AccessResponse(access=access)

--- a/backend/app/authorization/router.py
+++ b/backend/app/authorization/router.py
@@ -25,11 +25,10 @@ def check_access(
     """Allows the requesting user to check whether an access check will fail or succeed.
     Useful to conditionally disable parts of the UI that are known to be inaccessible.
     """
-    dom = "*" if request.domain is None else request.domain
+    sub = str(user.id)
+    dom = "*" if request.domain is None else str(request.domain)
     obj = "*" if request.object_id is None else str(request.object_id)
 
     authorizer = Authorization()
-    access = authorizer.has_access(
-        sub=str(user.id), dom=dom, obj=obj, act=request.action
-    )
+    access = authorizer.has_access(sub=sub, dom=dom, obj=obj, act=request.action)
     return AccessResponse(access=access)

--- a/backend/app/authorization/router.py
+++ b/backend/app/authorization/router.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, Depends
+
+from app.authorization.schema import AccessRequest, AccessResponse
+from app.core.auth.auth import get_authenticated_user
+from app.core.authz.authorization import Authorization
+from app.users.schema import User
+
+router = APIRouter(prefix="/authz", tags=["authz"])
+
+
+@router.post(
+    "/access/check",
+    responses={
+        200: {
+            "description": "Access check result",
+            "content": {
+                "application/json": {"access": "true"},
+            },
+        },
+    },
+)
+def check_access(
+    request: AccessRequest, user: User = Depends(get_authenticated_user)
+) -> AccessResponse:
+    """Allows the requesting user to check whether an access check will fail or succeed.
+    Useful to conditionally disable parts of the UI that are known to be inaccessible.
+    """
+    authorizer = Authorization()
+
+    domain = "*" if request.domain is None else request.domain
+    object_ = "*" if request.object_id is None else str(request.object_id)
+    access = authorizer.has_access(
+        subject=str(user.id),
+        domain=domain,
+        object_=object_,
+        action=request.action,
+    )
+    return AccessResponse(access=access)

--- a/backend/app/authorization/schema.py
+++ b/backend/app/authorization/schema.py
@@ -1,0 +1,15 @@
+from typing import Optional
+from uuid import UUID
+
+from app.core.authz.actions import AuthorizationAction
+from app.shared.schema import ORMModel
+
+
+class AccessRequest(ORMModel):
+    object_id: Optional[UUID]
+    domain: Optional[str]
+    action: AuthorizationAction
+
+
+class AccessResponse(ORMModel):
+    access: bool

--- a/backend/app/authorization/schema.py
+++ b/backend/app/authorization/schema.py
@@ -6,8 +6,8 @@ from app.shared.schema import ORMModel
 
 
 class AccessRequest(ORMModel):
-    object_id: Optional[UUID]
-    domain: Optional[UUID]
+    object_id: Optional[UUID] = None
+    domain: Optional[UUID] = None
     action: AuthorizationAction
 
 

--- a/backend/app/authorization/schema.py
+++ b/backend/app/authorization/schema.py
@@ -7,7 +7,7 @@ from app.shared.schema import ORMModel
 
 class AccessRequest(ORMModel):
     object_id: Optional[UUID]
-    domain: Optional[str]
+    domain: Optional[UUID]
     action: AuthorizationAction
 
 

--- a/backend/app/core/authz/authorization.py
+++ b/backend/app/core/authz/authorization.py
@@ -56,12 +56,7 @@ class Authorization(metaclass=Singleton):
             obj = cls.resolve_parameter(request, object_id)
             dom = cls.resolve_domain(db, model, obj)
 
-            if not cls().has_access(
-                subject=str(user.id),
-                domain=dom,
-                object_=obj,
-                action=action,
-            ):
+            if not cls().has_access(sub=str(user.id), dom=dom, obj=obj, act=action):
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="You don't have permission to perform this action",
@@ -92,10 +87,10 @@ class Authorization(metaclass=Singleton):
 
     @cachedmethod(lambda self: self._cache)
     def has_access(
-        self, *, subject: str, domain: str, object_: str, action: AuthorizationAction
+        self, *, sub: str, dom: str, obj: str, act: AuthorizationAction
     ) -> bool:
         enforcer: AsyncEnforcer = self._enforcer
-        return enforcer.enforce(subject, domain, object_, str(action))
+        return enforcer.enforce(sub, dom, obj, str(act))
 
     def _after_update(self) -> None:
         """The cache should be purged when the casbin database is altered,

--- a/backend/app/core/authz/authorization.py
+++ b/backend/app/core/authz/authorization.py
@@ -1,13 +1,20 @@
 from collections.abc import Callable
 from pathlib import Path
-from typing import Sequence, cast
+from typing import Sequence, Type, Union, cast
 
 import casbin_async_sqlalchemy_adapter as sqlalchemy_adapter
+from cachetools import Cache, LRUCache, cachedmethod
 from casbin import AsyncEnforcer
 from fastapi import Depends, HTTPException, Request, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from app.core.auth.auth import get_authenticated_user
+from app.data_products.model import DataProduct
 from app.database import database
+from app.database.database import get_db_session
+from app.datasets.model import Dataset
+from app.settings import settings
 from app.users.schema import User
 from app.utils.singleton import Singleton
 
@@ -17,7 +24,8 @@ from .actions import AuthorizationAction
 class Authorization(metaclass=Singleton):
 
     def __init__(self, enforcer: AsyncEnforcer = None) -> None:
-        self.enforcer: AsyncEnforcer = cast(AsyncEnforcer, enforcer)
+        self._enforcer: AsyncEnforcer = cast(AsyncEnforcer, enforcer)
+        self._cache: Cache = LRUCache(maxsize=settings.AUTHORIZER_CACHE_SIZE)
 
     @classmethod
     async def initialize(cls) -> "Authorization":
@@ -36,23 +44,28 @@ class Authorization(metaclass=Singleton):
     @classmethod
     def enforce(
         cls,
+        model: Union[Type[DataProduct], Type[Dataset]],
         action: AuthorizationAction,
         object_id: str = "object_id",
-        domain: str = "domain",
     ) -> Callable[[Request, User], None]:
         def inner(
             request: Request,
             user: User = Depends(get_authenticated_user),
+            db: Session = Depends(get_db_session),
         ) -> None:
             obj = cls.resolve_parameter(request, object_id)
-            dom = cls.resolve_parameter(request, domain)
+            dom = cls.resolve_domain(db, model, obj)
 
-            return cls()._enforce(
-                sub=str(user.id),
-                dom=dom,
-                obj=obj,
-                act=action,
-            )
+            if not cls().has_access(
+                subject=str(user.id),
+                domain=dom,
+                object_=obj,
+                action=action,
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="You don't have permission to perform this action",
+                )
 
         return inner
 
@@ -65,23 +78,42 @@ class Authorization(metaclass=Singleton):
 
         return default
 
-    def _enforce(self, *, sub: str, dom: str, obj: str, act: int) -> None:
-        enforcer: AsyncEnforcer = self.enforcer
-        if not enforcer.enforce(sub, dom, obj, str(act)):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="You don't have permission to perform this action",
-            )
+    @staticmethod
+    def resolve_domain(
+        db: Session,
+        model: Union[Type[DataProduct], Type[Dataset]],
+        id_: str,
+        default: str = "*",
+    ) -> str:
+        if id_ == default:
+            return default
+        domain = db.execute(select(model.domain_id).where(model.id == id_)).scalar()
+        return default if domain is None else str(domain)
+
+    @cachedmethod(lambda self: self._cache)
+    def has_access(
+        self, *, subject: str, domain: str, object_: str, action: AuthorizationAction
+    ) -> bool:
+        enforcer: AsyncEnforcer = self._enforcer
+        return enforcer.enforce(subject, domain, object_, str(action))
+
+    def _after_update(self) -> None:
+        """The cache should be purged when the casbin database is altered,
+        otherwise we risk returning stale results.
+        """
+        self._cache.clear()
 
     async def sync_role_permissions(
         self, *, role_id: str, actions: Sequence[AuthorizationAction]
     ) -> None:
         """Creates or updates the permissions for the chosen role."""
-        enforcer: AsyncEnforcer = self.enforcer
+        enforcer: AsyncEnforcer = self._enforcer
         await enforcer.remove_filtered_policy(0, role_id)
 
         policies = [(role_id, str(action)) for action in actions]
         await enforcer.add_policies(policies)
+
+        self._after_update()
 
     async def sync_everyone_role_permissions(
         self, *, actions: Sequence[AuthorizationAction]
@@ -98,77 +130,87 @@ class Authorization(metaclass=Singleton):
     ) -> None:
         """Creates an entry in the casbin table,
         assigning the user a role for the chosen resource."""
-        enforcer: AsyncEnforcer = self.enforcer
+        enforcer: AsyncEnforcer = self._enforcer
         await enforcer.add_named_grouping_policy("g", user_id, role_id, resource_id)
+        self._after_update()
 
     async def revoke_resource_role(
         self, *, user_id: str, role_id: str, resource_id: str
     ) -> None:
         """Deletes the entry in the casbin table,
         assigning the user the role for the chosen resource."""
-        enforcer: AsyncEnforcer = self.enforcer
+        enforcer: AsyncEnforcer = self._enforcer
         await enforcer.remove_named_grouping_policy("g", user_id, role_id, resource_id)
+        self._after_update()
 
     async def assign_domain_role(
         self, *, user_id: str, role_id: str, domain_id: str
     ) -> None:
         """Creates an entry in the casbin table,
         assigning the user a role for the chosen domain."""
-        enforcer: AsyncEnforcer = self.enforcer
+        enforcer: AsyncEnforcer = self._enforcer
         await enforcer.add_named_grouping_policy("g2", user_id, role_id, domain_id)
+        self._after_update()
 
     async def revoke_domain_role(
         self, *, user_id: str, role_id: str, domain_id: str
     ) -> None:
         """Deletes the entry in the casbin table,
         assigning the user the role for the chosen domain."""
-        enforcer: AsyncEnforcer = self.enforcer
+        enforcer: AsyncEnforcer = self._enforcer
         await enforcer.remove_named_grouping_policy("g2", user_id, role_id, domain_id)
+        self._after_update()
 
     async def assign_admin_role(self, *, user_id: str) -> None:
         """Creates an entry in the casbin table, assigning the user the admin role."""
-        enforcer: AsyncEnforcer = self.enforcer
+        enforcer: AsyncEnforcer = self._enforcer
         await enforcer.add_named_grouping_policy("g3", user_id, "*")
+        self._after_update()
 
     async def revoke_admin_role(self, *, user_id: str) -> None:
         """Deletes the entry in the casbin table, assigning the user the admin role."""
-        enforcer: AsyncEnforcer = self.enforcer
+        enforcer: AsyncEnforcer = self._enforcer
         await enforcer.remove_named_grouping_policy("g3", user_id, "*")
+        self._after_update()
 
     async def clear_assignments_for_user(self, *, user_id: str) -> None:
         """Removes all role assignments for a user inside the casbin table.
         Should be called when a user is removed.
         """
-        enforcer: AsyncEnforcer = self.enforcer
-
+        enforcer: AsyncEnforcer = self._enforcer
         await enforcer.remove_filtered_named_grouping_policy("g", 0, user_id)
         await enforcer.remove_filtered_named_grouping_policy("g2", 0, user_id)
         await enforcer.remove_filtered_named_grouping_policy("g3", 0, user_id)
+        self._after_update()
 
     async def clear_assignments_for_resource_role(self, *, role_id: str) -> None:
         """Removes all assignments of a resource role inside the casbin table.
         Should be called when a resource role is removed.
         """
-        enforcer: AsyncEnforcer = self.enforcer
+        enforcer: AsyncEnforcer = self._enforcer
         await enforcer.remove_filtered_named_grouping_policy("g", 1, role_id)
+        self._after_update()
 
     async def clear_assignments_for_domain_role(self, *, role_id: str) -> None:
         """Removes all assignments of a domain role inside the casbin table.
         Should be called when a domain role is removed.
         """
-        enforcer: AsyncEnforcer = self.enforcer
+        enforcer: AsyncEnforcer = self._enforcer
         await enforcer.remove_filtered_named_grouping_policy("g2", 1, role_id)
+        self._after_update()
 
     async def clear_assignments_for_resource(self, *, resource_id: str) -> None:
         """Removes all assignments of a resource role inside the casbin table.
         Should be called when a resource role is removed.
         """
-        enforcer: AsyncEnforcer = self.enforcer
+        enforcer: AsyncEnforcer = self._enforcer
         await enforcer.remove_filtered_named_grouping_policy("g", 2, resource_id)
+        self._after_update()
 
     async def clear_assignments_for_domain(self, *, domain_id: str) -> None:
         """Removes all assignments of a resource role inside the casbin table.
         Should be called when a domain role is removed.
         """
-        enforcer: AsyncEnforcer = self.enforcer
+        enforcer: AsyncEnforcer = self._enforcer
         await enforcer.remove_filtered_named_grouping_policy("g2", 2, domain_id)
+        self._after_update()

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -50,6 +50,9 @@ class Settings(BaseSettings):
     CORPORATION: str = "Dataminded"
     EMAIL_BUTTON_COLOR: str = "#3B9672"
 
+    # Authorizer
+    AUTHORIZER_CACHE_SIZE: int = 128
+
 
 class LogLevel(str, Enum):
     DEBUG = "DEBUG"

--- a/backend/app/shared/router.py
+++ b/backend/app/shared/router.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Security
 
+from app.authorization.router import router as authorization
 from app.core.auth.auth import api_key_authenticated
 from app.core.config.env_var_parser import get_boolean_variable
 from app.data_outputs.router import router as data_outputs
@@ -25,6 +26,7 @@ router = (
     else APIRouter()
 )
 
+router.include_router(authorization)
 router.include_router(dataset)
 router.include_router(data_product)
 router.include_router(data_product_type)

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -177,6 +177,18 @@ urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >
 crt = ["awscrt (==0.23.8)"]
 
 [[package]]
+name = "cachetools"
+version = "5.5.2"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
+    {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
+]
+
+[[package]]
 name = "casbin"
 version = "1.41.0"
 description = "An authorization library that supports access control models like ACL, RBAC, ABAC in Python"
@@ -1857,4 +1869,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "558d4a7574cf5dd1297c844edcafc2fea74c131099fc89874bc9c564e7d28466"
+content-hash = "8e4fa96f745dccb1bb6f436cbc7de2cc709975d2034e07ed0c5c0482332151c9"

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1869,4 +1869,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "8e4fa96f745dccb1bb6f436cbc7de2cc709975d2034e07ed0c5c0482332151c9"
+content-hash = "482f420e9b1b74c45daed794824e530facc4dd1d504f58dc3a3ed8ffa28c3414"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -33,6 +33,7 @@ emailgen = "^0.1.1"
 casbin = "^1.41.0"
 casbin-async-sqlalchemy-adapter = "^1.7.0"
 asyncpg = "^0.30.0"
+cachetools = "^5.5.2"
 
 [tool.poetry.group.test]
 optional = true

--- a/backend/tests/app/authorization/test_router.py
+++ b/backend/tests/app/authorization/test_router.py
@@ -1,0 +1,57 @@
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from tests.factories import UserFactory
+
+from app.authorization.schema import AccessRequest, AccessResponse
+from app.core.authz.actions import AuthorizationAction
+from app.core.authz.authorization import Authorization
+
+ENDPOINT = "/api/authz"
+
+
+class TestAuthorizationRouter:
+
+    def test_check_access(self, client: TestClient):
+        request = AccessRequest(
+            object_id=None,
+            domain=None,
+            action=AuthorizationAction.GLOBAL__REQUEST_DATASET_ACCESS,
+        )
+        response = client.post(
+            f"{ENDPOINT}/access/check", json=request.model_dump(mode="json")
+        )
+        assert response.status_code == 200
+
+        access = AccessResponse(**response.json())
+        assert access.access is False
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_check_access_authorized(
+        self, client: TestClient, authorizer: Authorization
+    ):
+        user = UserFactory(external_id="sub")
+        role_id = uuid.uuid4()
+        resource_id = uuid.uuid4()
+
+        await authorizer.sync_role_permissions(
+            role_id=str(role_id),
+            actions=[AuthorizationAction.GLOBAL__REQUEST_DATASET_ACCESS],
+        )
+        await authorizer.assign_resource_role(
+            user_id=str(user.id), role_id=str(role_id), resource_id=str(resource_id)
+        )
+
+        request = AccessRequest(
+            object_id=resource_id,
+            domain=None,
+            action=AuthorizationAction.GLOBAL__REQUEST_DATASET_ACCESS,
+        )
+        response = client.post(
+            f"{ENDPOINT}/access/check", json=request.model_dump(mode="json")
+        )
+        assert response.status_code == 200
+
+        access = AccessResponse(**response.json())
+        assert access.access is True

--- a/backend/tests/app/core/authz/test_authorization.py
+++ b/backend/tests/app/core/authz/test_authorization.py
@@ -18,13 +18,12 @@ class TestAuthorization:
 
         await authorizer.sync_everyone_role_permissions(actions=[allowed])
 
-        assert authorizer.has_access(sub=ANY, dom=ANY, obj=ANY, act=allowed)
-        assert not authorizer.has_access(sub=ANY, dom=ANY, obj=ANY, act=denied)
+        assert authorizer.has_access(sub=ANY, dom=ANY, obj=ANY, act=allowed) is True
+        assert authorizer.has_access(sub=ANY, dom=ANY, obj=ANY, act=denied) is False
 
         # Clear role definition again
         await authorizer.sync_everyone_role_permissions(actions=[])
-
-        assert not authorizer.has_access(sub=ANY, dom=ANY, obj=ANY, act=allowed)
+        assert authorizer.has_access(sub=ANY, dom=ANY, obj=ANY, act=allowed) is False
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_resource_role(self, authorizer: Authorization):
@@ -39,18 +38,18 @@ class TestAuthorization:
             user_id=user, role_id=role, resource_id=obj
         )
 
-        assert authorizer.has_access(sub=user, dom=ANY, obj=obj, act=allowed)
-        assert not authorizer.has_access(sub=user, dom=ANY, obj=obj, act=denied)
-        assert not authorizer.has_access(
-            sub=user, dom=ANY, obj="other_resource", act=denied
+        assert authorizer.has_access(sub=user, dom=ANY, obj=obj, act=allowed) is True
+        assert authorizer.has_access(sub=user, dom=ANY, obj=obj, act=denied) is False
+        assert (
+            authorizer.has_access(sub=user, dom=ANY, obj="other_resource", act=denied)
+            is False
         )
 
         # Clear role assignment again
         await authorizer.revoke_resource_role(
             user_id=user, role_id=role, resource_id=obj
         )
-
-        assert not authorizer.has_access(sub=user, dom=ANY, obj=obj, act=allowed)
+        assert authorizer.has_access(sub=user, dom=ANY, obj=obj, act=allowed) is False
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_domain_role(self, authorizer: Authorization):
@@ -63,30 +62,28 @@ class TestAuthorization:
         await authorizer.sync_role_permissions(role_id=role, actions=[allowed])
         await authorizer.assign_domain_role(user_id=user, role_id=role, domain_id=dom)
 
-        assert authorizer.has_access(sub=user, dom=dom, obj=ANY, act=allowed)
-        assert not authorizer.has_access(sub=user, dom=dom, obj=ANY, act=denied)
-        assert not authorizer.has_access(
-            sub=user, dom="other_dom", obj=ANY, act=allowed
+        assert authorizer.has_access(sub=user, dom=dom, obj=ANY, act=allowed) is True
+        assert authorizer.has_access(sub=user, dom=dom, obj=ANY, act=denied) is False
+        assert (
+            authorizer.has_access(sub=user, dom="other_dom", obj=ANY, act=allowed)
+            is False
         )
 
         # Clear role assignment again
         await authorizer.revoke_domain_role(user_id=user, role_id=role, domain_id=dom)
-
-        assert not authorizer.has_access(sub=user, dom=dom, obj=ANY, act=allowed)
+        assert authorizer.has_access(sub=user, dom=dom, obj=ANY, act=allowed) is False
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_admin_role(self, authorizer: Authorization):
         user = "test_user"
 
-        assert not authorizer.has_access(sub=user, dom=ANY, obj=ANY, act=ANY_ACT)
+        assert authorizer.has_access(sub=user, dom=ANY, obj=ANY, act=ANY_ACT) is False
 
         await authorizer.assign_admin_role(user_id=user)
-
-        assert authorizer.has_access(sub=user, dom=ANY, obj=ANY, act=ANY_ACT)
+        assert authorizer.has_access(sub=user, dom=ANY, obj=ANY, act=ANY_ACT) is True
 
         await authorizer.revoke_admin_role(user_id=user)
-
-        assert not authorizer.has_access(sub=user, dom=ANY, obj=ANY, act=ANY_ACT)
+        assert authorizer.has_access(sub=user, dom=ANY, obj=ANY, act=ANY_ACT) is False
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_role_removal(self, authorizer: Authorization):
@@ -100,12 +97,11 @@ class TestAuthorization:
             user_id=user, role_id=role, resource_id=obj
         )
 
-        assert authorizer.has_access(sub=user, dom=ANY, obj=obj, act=act)
+        assert authorizer.has_access(sub=user, dom=ANY, obj=obj, act=act) is True
 
         # Clear role assignment again
         await authorizer.remove_role_permissions(role_id=role)
-
-        assert not authorizer.has_access(sub=user, dom=ANY, obj=obj, act=act)
+        assert authorizer.has_access(sub=user, dom=ANY, obj=obj, act=act) is False
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_multiple_permissions(self, authorizer: Authorization):
@@ -120,8 +116,7 @@ class TestAuthorization:
             user_id=user, role_id=role, resource_id=obj
         )
 
-        assert authorizer.has_access(sub=user, dom=ANY, obj=obj, act=act)
+        assert authorizer.has_access(sub=user, dom=ANY, obj=obj, act=act) is True
 
         await authorizer.remove_role_permissions(role_id=role)
-
-        assert not authorizer.has_access(sub=user, dom=ANY, obj=obj, act=act)
+        assert authorizer.has_access(sub=user, dom=ANY, obj=obj, act=act) is False

--- a/backend/tests/app/data_outputs/test_router.py
+++ b/backend/tests/app/data_outputs/test_router.py
@@ -62,18 +62,18 @@ def data_output_payload_not_owner():
 class TestDataOutputsRouter:
     invalid_id = "00000000-0000-0000-0000-000000000000"
 
-    def test_create_dataoutput(self, data_output_payload, client):
-        created_dataoutput = self.create_data_output(client, data_output_payload)
-        assert created_dataoutput.status_code == 200
-        assert "id" in created_dataoutput.json()
+    def test_create_data_output(self, data_output_payload, client):
+        created_data_output = self.create_data_output(client, data_output_payload)
+        assert created_data_output.status_code == 200
+        assert "id" in created_data_output.json()
 
-    def test_create_dataoutput_not_product_owner(
+    def test_create_data_output_not_product_owner(
         self, data_output_payload_not_owner, client
     ):
-        created_dataoutput = self.create_data_output(
+        created_data_output = self.create_data_output(
             client, data_output_payload_not_owner
         )
-        assert created_dataoutput.status_code == 403
+        assert created_data_output.status_code == 403
 
     def test_get_data_outputs(self, client):
         data_output = DataOutputFactory()
@@ -83,7 +83,7 @@ class TestDataOutputsRouter:
         assert len(data) == 1
         assert data[0]["id"] == str(data_output.id)
 
-    def test_get_data_ouptut_by_id(self, client):
+    def test_get_data_output_by_id(self, client):
         data_output = DataOutputFactory()
 
         response = self.get_data_output_by_id(client, data_output.id)
@@ -138,7 +138,7 @@ class TestDataOutputsRouter:
         data_output = DataOutputFactory(owner=data_product)
         response = self.get_data_output_by_id(client, data_output.id)
         assert response.json()["status"] == "active"
-        response = self.update_data_output_status(
+        _ = self.update_data_output_status(
             client, {"status": "pending"}, data_output.id
         )
         response = self.get_data_output_by_id(client, data_output.id)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,3 +1,4 @@
+from typing import Any, AsyncGenerator, Generator
 from unittest.mock import MagicMock
 
 import pytest
@@ -58,7 +59,7 @@ def mock_oidc_config():
 
 
 @pytest.fixture
-def client():
+def client() -> Generator[TestClient, None, None]:
     # Disable lifespan for testing
     app.router.lifespan_context = _DefaultLifespan(app.router)
 
@@ -71,7 +72,7 @@ def client():
 
 
 @pytest.fixture
-def default_data_product_payload():
+def default_data_product_payload() -> dict[str, Any]:
     data_product_type = DataProductTypeFactory()
     user = UserFactory()
     domain = DomainFactory()
@@ -92,7 +93,7 @@ def default_data_product_payload():
 
 
 @pytest.fixture
-def default_dataset_payload():
+def default_dataset_payload() -> dict[str, Any]:
     user = UserFactory()
     domain = DomainFactory()
     return {
@@ -115,11 +116,11 @@ def clear_db(session: scoped_session[Session]) -> None:
 
 
 @pytest.fixture
-def admin():
+def admin() -> UserFactory:
     return UserFactory(external_id="sub", is_admin=True)
 
 
 @pytest_asyncio.fixture(loop_scope="session", autouse=True)
-async def authorizer():
+async def authorizer() -> AsyncGenerator[Authorization, None]:
     """Initializes casbin at the start of the testing session."""
     yield await Authorization.initialize()

--- a/frontend/src/api/api-urls.ts
+++ b/frontend/src/api/api-urls.ts
@@ -68,6 +68,7 @@ export enum ApiUrl {
     PlatformServiceConfigById = '/api/platforms/configs/:configId',
     Version = '/api/version',
     ThemeSettings = '/api/theme_settings',
+    AccessCheck = '/api/access/check',
 }
 
 export type DynamicPathParams =

--- a/frontend/src/store/features/authorization/authorization-api-slice.ts
+++ b/frontend/src/store/features/authorization/authorization-api-slice.ts
@@ -1,0 +1,16 @@
+import { ApiUrl } from '@/api/api-urls';
+import { baseApiSlice } from '@/store/features/api/base-api-slice';
+import type { AccessRequest, AccessResponse } from '@/types/authorization';
+
+const authorizationApiSlice = baseApiSlice.injectEndpoints({
+    endpoints: (builder) => ({
+        checkAccess: builder.query<AccessRequest, AccessResponse>({
+            query: () => ({
+                url: ApiUrl.AccessCheck,
+                method: 'POST',
+            }),
+        }),
+    }),
+});
+
+export const { useCheckAccessQuery } = authorizationApiSlice;

--- a/frontend/src/types/authorization/authorization.contract.ts
+++ b/frontend/src/types/authorization/authorization.contract.ts
@@ -1,0 +1,9 @@
+export type AccessRequest = {
+    object_id?: string;
+    domain?: string;
+    action: number;
+};
+
+export type AccessResponse = {
+    access: boolean;
+};

--- a/frontend/src/types/authorization/index.ts
+++ b/frontend/src/types/authorization/index.ts
@@ -1,0 +1,1 @@
+export type { AccessRequest, AccessResponse } from './authorization.contract';


### PR DESCRIPTION
Adds an endpoint for the frontend to query resource access.
Can be used to conditionally render UI elements.
Also adds a cache to the backend implementation to avoid this functionality over-querying the casbin table.