### PR TITLE
Add feature flag for RBAC to backend settings

### DIFF
--- a/backend/app/core/authz/authorization.py
+++ b/backend/app/core/authz/authorization.py
@@ -89,6 +89,9 @@ class Authorization(metaclass=Singleton):
     def has_access(
         self, *, sub: str, dom: str, obj: str, act: AuthorizationAction
     ) -> bool:
+        if not settings.AUTHORIZER_ENABLED:
+            return True
+
         enforcer: AsyncEnforcer = self._enforcer
         return enforcer.enforce(sub, dom, obj, str(act))
 

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -51,6 +51,7 @@ class Settings(BaseSettings):
     EMAIL_BUTTON_COLOR: str = "#3B9672"
 
     # Authorizer
+    AUTHORIZER_ENABLED: bool = False
     AUTHORIZER_CACHE_SIZE: int = 128
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -13,6 +13,7 @@ from app.data_product_memberships.model import DataProductUserRole
 from app.database.database import Base, get_db_session
 from app.datasets.enums import DatasetAccessType
 from app.main import app
+from app.settings import settings
 
 from . import TestingSessionLocal
 from .factories.data_product_type import DataProductTypeFactory
@@ -124,3 +125,8 @@ def admin() -> UserFactory:
 async def authorizer() -> AsyncGenerator[Authorization, None]:
     """Initializes casbin at the start of the testing session."""
     yield await Authorization.initialize()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def enable_authorizer() -> None:
+    settings.AUTHORIZER_ENABLED = True


### PR DESCRIPTION
Enables to start wiring in the new role enforcement across the API without breaking anything.

Closes #869