### PR TITLE
Extend RBAC model to support other global roles than the admin

### DIFF
--- a/backend/app/core/authz/authorization.py
+++ b/backend/app/core/authz/authorization.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from pathlib import Path
-from typing import Sequence, Type, Union, cast
+from typing import Sequence, Type, TypeAlias, Union, cast
 
 import casbin_async_sqlalchemy_adapter as sqlalchemy_adapter
 from cachetools import Cache, LRUCache, cachedmethod
@@ -19,6 +19,8 @@ from app.users.schema import User
 from app.utils.singleton import Singleton
 
 from .actions import AuthorizationAction
+
+Model: TypeAlias = Union[Type[DataProduct], Type[Dataset], None]
 
 
 class Authorization(metaclass=Singleton):
@@ -44,10 +46,10 @@ class Authorization(metaclass=Singleton):
     @classmethod
     def enforce(
         cls,
-        model: Union[Type[DataProduct], Type[Dataset]],
         action: AuthorizationAction,
+        model: Model = None,
         object_id: str = "object_id",
-    ) -> Callable[[Request, User], None]:
+    ) -> Callable[[Request, User, Session], None]:
         def inner(
             request: Request,
             user: User = Depends(get_authenticated_user),
@@ -76,11 +78,11 @@ class Authorization(metaclass=Singleton):
     @staticmethod
     def resolve_domain(
         db: Session,
-        model: Union[Type[DataProduct], Type[Dataset]],
+        model: Model,
         id_: str,
         default: str = "*",
     ) -> str:
-        if id_ == default:
+        if id_ == default or model is None:
             return default
         domain = db.scalars(
             select(model.domain_id).where(model.id == id_)
@@ -161,19 +163,27 @@ class Authorization(metaclass=Singleton):
         await enforcer.remove_named_grouping_policy("g2", user_id, role_id, domain_id)
         self._after_update()
 
-    async def assign_admin_role(self, *, user_id: str) -> None:
+    async def assign_global_role(self, *, user_id: str, role_id: str) -> None:
         """Creates an entry in the casbin table,
-        assigning the user the admin role."""
+        assigning the user the chosen global role."""
         enforcer: AsyncEnforcer = self._enforcer
-        await enforcer.add_named_grouping_policy("g3", user_id, "*")
+        await enforcer.add_named_grouping_policy("g3", user_id, role_id)
         self._after_update()
 
-    async def revoke_admin_role(self, *, user_id: str) -> None:
+    async def revoke_global_role(self, *, user_id: str, role_id: str) -> None:
         """Deletes the entry in the casbin table,
-        revoking the admin role for the user."""
+        revoking the chosen global role for the user."""
         enforcer: AsyncEnforcer = self._enforcer
-        await enforcer.remove_named_grouping_policy("g3", user_id, "*")
+        await enforcer.remove_named_grouping_policy("g3", user_id, role_id)
         self._after_update()
+
+    async def assign_admin_role(self, *, user_id: str) -> None:
+        """Creates an entry in the casbin table, assigning the user the admin role."""
+        await self.assign_global_role(user_id=user_id, role_id="*")
+
+    async def revoke_admin_role(self, *, user_id: str) -> None:
+        """Deletes the entry in the casbin table, assigning the user the admin role."""
+        await self.revoke_global_role(user_id=user_id, role_id="*")
 
     async def clear_assignments_for_user(self, *, user_id: str) -> None:
         """Removes all role assignments for a user inside the casbin table.
@@ -199,6 +209,14 @@ class Authorization(metaclass=Singleton):
         """
         enforcer: AsyncEnforcer = self._enforcer
         await enforcer.remove_filtered_named_grouping_policy("g2", 1, role_id)
+        self._after_update()
+
+    async def clear_assignments_for_global_role(self, *, role_id: str) -> None:
+        """Removes all assignments of a global role inside the casbin table.
+        Should be called when a global role is removed.
+        """
+        enforcer: AsyncEnforcer = self._enforcer
+        await enforcer.remove_filtered_named_grouping_policy("g3", 1, role_id)
         self._after_update()
 
     async def clear_assignments_for_resource(self, *, resource_id: str) -> None:

--- a/backend/app/core/authz/authorization.py
+++ b/backend/app/core/authz/authorization.py
@@ -48,7 +48,7 @@ class Authorization(metaclass=Singleton):
         cls,
         action: AuthorizationAction,
         model: Model = None,
-        object_id: str = "object_id",
+        object_id: str = "id",
     ) -> Callable[[Request, User, Session], None]:
         def inner(
             request: Request,

--- a/backend/app/core/authz/rbac_model.conf
+++ b/backend/app/core/authz/rbac_model.conf
@@ -7,7 +7,7 @@ p = sub, act
 [role_definition]
 g = _, _, _ ; resource roles
 g2 = _, _, _ ; domain roles
-g3 = _, _ ; admins
+g3 = _, _ ; global roles
 
 [policy_effect]
 e = some(where (p.eft == allow))
@@ -17,4 +17,5 @@ m = g3(r.sub, "*") || (( \
     p.sub == "*" \
     || g(r.sub, p.sub, r.obj) \
     || g2(r.sub, p.sub, r.dom) \
+    || g3(r.sub, p.sub) \
 ) && r.act == p.act)

--- a/backend/tests/app/core/authz/test_authorization.py
+++ b/backend/tests/app/core/authz/test_authorization.py
@@ -74,6 +74,21 @@ class TestAuthorization:
         assert authorizer.has_access(sub=user, dom=dom, obj=ANY, act=allowed) is False
 
     @pytest.mark.asyncio(loop_scope="session")
+    async def test_global_role(self, authorizer: Authorization):
+        user = "test_user"
+        role = "test_role"
+        act = AuthorizationAction.GLOBAL__REQUEST_DATASET_ACCESS
+
+        await authorizer.sync_role_permissions(role_id=role, actions=[act])
+        assert authorizer.has_access(sub=user, dom=ANY, obj=ANY, act=act) is False
+
+        await authorizer.assign_global_role(user_id=user, role_id=role)
+        assert authorizer.has_access(sub=user, dom=ANY, obj=ANY, act=act) is True
+
+        await authorizer.revoke_global_role(user_id=user, role_id=role)
+        assert authorizer.has_access(sub=user, dom=ANY, obj=ANY, act=act) is False
+
+    @pytest.mark.asyncio(loop_scope="session")
     async def test_admin_role(self, authorizer: Authorization):
         user = "test_user"
 


### PR DESCRIPTION
Forgot about this case when redesigning the casbin policy. Should be good now