### PR TITLE
Revert "Bump python from 3.12.9-slim-bookworm to 3.13.3-slim-bookworm in /backend"

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 ARG PLATFORM=linux/amd64
-FROM --platform=${PLATFORM} python:3.13.3-slim-bookworm@sha256:21e39cf1815802d4c6f89a0d3a166cc67ce58f95b6d1639e68a394c99310d2e5 AS base-image
+FROM --platform=${PLATFORM} python:3.12.9-slim-bookworm@sha256:48a11b7ba705fd53bf15248d1f94d36c39549903c5d59edcfa2f3f84126e7b44 AS base-image
 
 FROM base-image AS build-stage
 


### PR DESCRIPTION
Reverts conveyordata/data-product-portal#978