### PR TITLE
Fix namespace issues

### DIFF
--- a/backend/app/data_outputs/service.py
+++ b/backend/app/data_outputs/service.py
@@ -12,6 +12,7 @@ from app.core.namespace.validation import (
     DataOutputNamespaceValidator,
     NamespaceLengthLimits,
     NamespaceSuggestion,
+    NamespaceValidityType,
 )
 from app.data_outputs.model import DataOutput as DataOutputModel
 from app.data_outputs.model import ensure_data_output_exists
@@ -108,6 +109,15 @@ class DataOutputService:
         db: Session,
         authenticated_user: User,
     ) -> dict[str, UUID]:
+        if (
+            validity := self.namespace_validator.validate_namespace(
+                data_output.namespace, db, id
+            ).validity
+        ) != NamespaceValidityType.VALID:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid namespace: {validity.value}",
+            )
         data_output = DataOutputCreate(
             **data_output.parse_pydantic_schema(), owner_id=id
         )

--- a/backend/app/data_products/service.py
+++ b/backend/app/data_products/service.py
@@ -278,6 +278,20 @@ class DataProductService:
         current_data_product = ensure_data_product_exists(id, db)
         update_data_product = data_product.model_dump(exclude_unset=True)
 
+        if (
+            current_data_product.namespace != data_product.namespace
+            and (
+                validity := self.namespace_validator.validate_namespace(
+                    data_product.namespace, db
+                ).validity
+            )
+            != NamespaceValidityType.VALID
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid namespace: {validity.value}",
+            )
+
         for k, v in update_data_product.items():
             if k == "memberships":
                 self._update_memberships(current_data_product, v, db)

--- a/backend/app/datasets/service.py
+++ b/backend/app/datasets/service.py
@@ -172,6 +172,20 @@ class DatasetService:
         current_dataset = ensure_dataset_exists(id, db)
         updated_dataset = dataset.model_dump(exclude_unset=True)
 
+        if (
+            current_dataset.namespace != dataset.namespace
+            and (
+                validity := self.namespace_validator.validate_namespace(
+                    dataset.namespace, db
+                ).validity
+            )
+            != NamespaceValidityType.VALID
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid namespace: {validity.value}",
+            )
+
         for k, v in updated_dataset.items():
             if k == "owners":
                 current_dataset = self._update_owners(current_dataset, db, v)

--- a/backend/tests/app/data_product_settings/test_router.py
+++ b/backend/tests/app/data_product_settings/test_router.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import pytest
 from tests.factories import DataProductSettingFactory
 
@@ -144,6 +146,38 @@ class TestDataProductSettingsRouter:
 
         assert response.status_code == 200
         assert response.json()["validity"] == NamespaceValidityType.VALID
+
+    @pytest.mark.usefixtures("admin")
+    def test_create_data_product_setting_duplicate_namespace(
+        self, default_setting_payload, client
+    ):
+        DataProductSettingFactory(
+            namespace=default_setting_payload["namespace"],
+            scope=default_setting_payload["scope"],
+        )
+
+        response = self.create_data_product_setting(client, default_setting_payload)
+        assert response.status_code == 400
+
+    @pytest.mark.usefixtures("admin")
+    def test_create_data_product_setting_invalid_characters_namespace(
+        self, default_setting_payload, client
+    ):
+        create_payload = deepcopy(default_setting_payload)
+        create_payload["namespace"] = "!"
+
+        response = self.create_data_product_setting(client, create_payload)
+        assert response.status_code == 400
+
+    @pytest.mark.usefixtures("admin")
+    def test_create_data_product_setting_invalid_length_namespace(
+        self, default_setting_payload, client
+    ):
+        create_payload = deepcopy(default_setting_payload)
+        create_payload["namespace"] = "a" * 256
+
+        response = self.create_data_product_setting(client, create_payload)
+        assert response.status_code == 400
 
     @staticmethod
     def create_data_product_setting(client, data_product_setting_payload):

--- a/backend/tests/app/data_product_settings/test_router.py
+++ b/backend/tests/app/data_product_settings/test_router.py
@@ -179,6 +179,27 @@ class TestDataProductSettingsRouter:
         response = self.create_data_product_setting(client, create_payload)
         assert response.status_code == 400
 
+    @pytest.mark.usefixtures("admin")
+    def test_update_data_product_setting_duplicate_namespace(self, client):
+        namespace = "namespace"
+        DataProductSettingFactory(namespace=namespace, scope="dataproduct")
+        data_product_setting = DataProductSettingFactory(scope="dataproduct")
+
+        update_payload = {
+            "namespace": namespace,
+            "tooltip": "tooltip",
+            "name": "name",
+            "type": "checkbox",
+            "category": "category",
+            "default": "False",
+            "order": 3,
+            "scope": "dataproduct",
+        }
+        response = self.update_data_product_setting(
+            client, update_payload, data_product_setting.id
+        )
+        assert response.status_code == 400
+
     @staticmethod
     def create_data_product_setting(client, data_product_setting_payload):
         return client.post(ENDPOINT, json=data_product_setting_payload)

--- a/backend/tests/app/data_products/test_router.py
+++ b/backend/tests/app/data_products/test_router.py
@@ -427,6 +427,18 @@ class TestDataProductsRouter:
         assert response.status_code == 200
         assert response.json()["validity"] == NamespaceValidityType.VALID
 
+    def test_update_data_product_duplicate_namespace(self, payload, client):
+        namespace = "namespace"
+        DataProductFactory(namespace=namespace)
+        data_product = DataProductMembershipFactory(
+            user=UserFactory(external_id="sub")
+        ).data_product
+        update_payload = deepcopy(payload)
+        update_payload["namespace"] = namespace
+        response = self.update_data_product(client, update_payload, data_product.id)
+
+        assert response.status_code == 400
+
     @staticmethod
     def create_data_product(client, default_data_product_payload):
         return client.post(ENDPOINT, json=default_data_product_payload)

--- a/backend/tests/app/datasets/test_router.py
+++ b/backend/tests/app/datasets/test_router.py
@@ -405,6 +405,24 @@ class TestDatasetsRouter:
             == NamespaceValidityType.DUPLICATE_NAMESPACE.value
         )
 
+    def test_update_dataset_duplicate_namespace(self, client):
+        namespace = "namespace"
+        DatasetFactory(namespace=namespace)
+        ds = DatasetFactory(owners=[UserFactory(external_id="sub")])
+        update_payload = {
+            "name": "new_name",
+            "namespace": namespace,
+            "description": "new_description",
+            "tag_ids": [],
+            "access_type": "public",
+            "owners": [str(ds.owners[0].id)],
+            "domain_id": str(ds.domain_id),
+        }
+
+        response = self.update_default_dataset(client, update_payload, ds.id)
+
+        assert response.status_code == 400
+
     @staticmethod
     def create_default_dataset(client, default_dataset_payload):
         return client.post(ENDPOINT, json=default_dataset_payload)

--- a/backend/tests/factories/data_product.py
+++ b/backend/tests/factories/data_product.py
@@ -14,7 +14,7 @@ class DataProductFactory(factory.alchemy.SQLAlchemyModelFactory):
 
     id = factory.Faker("uuid4")
     name = factory.Faker("word")
-    namespace = "namespace"
+    namespace = factory.Faker("word")
     description = factory.Faker("text", max_nb_chars=20)
     about = factory.Faker("text", max_nb_chars=20)
     status = DataProductStatus.PENDING.value

--- a/backend/tests/factories/data_product_setting.py
+++ b/backend/tests/factories/data_product_setting.py
@@ -8,7 +8,7 @@ class DataProductSettingFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = DataProductSetting
 
     id = factory.Faker("uuid4")
-    namespace = "namespace"
+    namespace = factory.Faker("word")
     tooltip = factory.Faker("text", max_nb_chars=20)
     name = factory.Faker("word")
     type = "checkbox"

--- a/backend/tests/factories/dataset.py
+++ b/backend/tests/factories/dataset.py
@@ -14,7 +14,7 @@ class DatasetFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = Dataset
 
     id = factory.Faker("uuid4")
-    namespace = "namespace"
+    namespace = factory.Faker("word")
     name = factory.Faker("word")
     description = factory.Faker("text", max_nb_chars=20)
     about = factory.Faker("text", max_nb_chars=20)

--- a/backend/tests/factories/platform.py
+++ b/backend/tests/factories/platform.py
@@ -8,4 +8,4 @@ class PlatformFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = Platform
 
     id = factory.Faker("uuid4")
-    name = "AWS"
+    name = factory.Faker("word")

--- a/backend/tests/factories/platform_service.py
+++ b/backend/tests/factories/platform_service.py
@@ -10,6 +10,6 @@ class PlatformServiceFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = PlatformService
 
     id = factory.Faker("uuid4")
-    name = "S3"
+    name = factory.Faker("word")
 
     platform = factory.SubFactory(PlatformFactory)

--- a/frontend/src/components/data-products/data-output-form/data-output-form.component.tsx
+++ b/frontend/src/components/data-products/data-output-form/data-output-form.component.tsx
@@ -257,6 +257,7 @@ export function DataOutputForm({ mode, formRef, dataProductId, modalCallbackOnSu
                 max_length={namespaceLengthLimits?.max_length}
                 canEditNamespace={canEditNamespace}
                 toggleCanEditNamespace={() => setCanEditNamespace((prev) => !prev)}
+                validationRequired
                 validateNamespace={validateNamespaceCallback}
             />
             <Form.Item<DataOutputCreateFormSchema>

--- a/frontend/src/components/data-products/data-product-form/data-product-form.component.tsx
+++ b/frontend/src/components/data-products/data-product-form/data-product-form.component.tsx
@@ -260,6 +260,7 @@ export function DataProductForm({ mode, dataProductId }: Props) {
                 editToggleDisabled={mode === 'edit'}
                 canEditNamespace={canEditNamespace}
                 toggleCanEditNamespace={() => setCanEditNamespace((prev) => !prev)}
+                validationRequired={mode === 'create'}
                 validateNamespace={validateNamespaceCallback}
             />
             <Form.Item<DataProductCreateFormSchema>

--- a/frontend/src/components/datasets/components/dataset-form.component.tsx
+++ b/frontend/src/components/datasets/components/dataset-form.component.tsx
@@ -258,6 +258,7 @@ export function DatasetForm({ mode, datasetId }: Props) {
                 editToggleDisabled={mode === 'edit'}
                 canEditNamespace={canEditNamespace}
                 toggleCanEditNamespace={() => setCanEditNamespace((prev) => !prev)}
+                validationRequired={mode === 'create'}
                 validateNamespace={validateNamespaceCallback}
             />
             <Form.Item<DatasetCreateFormSchema>

--- a/frontend/src/components/namespace/namespace-form-item.tsx
+++ b/frontend/src/components/namespace/namespace-form-item.tsx
@@ -14,6 +14,7 @@ type Props = {
     editToggleDisabled?: boolean;
     canEditNamespace?: boolean;
     toggleCanEditNamespace?: () => void;
+    validationRequired?: boolean;
     validateNamespace?: (namespace: string) => Promise<NamespaceValidationResponse>;
 };
 
@@ -26,6 +27,7 @@ export function NamespaceFormItem({
     editToggleDisabled = false,
     canEditNamespace = false,
     toggleCanEditNamespace,
+    validationRequired = false,
     validateNamespace = async () => {
         return { validity: ValidationType.VALID };
     },
@@ -41,34 +43,44 @@ export function NamespaceFormItem({
                     hasFeedback
                     validateFirst
                     validateDebounce={DEBOUNCE}
-                    rules={[
-                        {
-                            required: canEditNamespace,
-                            message: t('Please input a namespace'),
-                        },
-                        {
-                            validator: async (_, value) => {
-                                if (!canEditNamespace && !value) {
-                                    return Promise.resolve();
-                                }
+                    rules={
+                        validationRequired
+                            ? [
+                                  {
+                                      required: canEditNamespace,
+                                      message: t('Please input a namespace'),
+                                  },
+                                  {
+                                      validator: async (_, value) => {
+                                          if (!canEditNamespace && !value) {
+                                              return Promise.resolve();
+                                          }
 
-                                const validationResponse = await validateNamespace(value);
+                                          const validationResponse = await validateNamespace(value);
 
-                                switch (validationResponse.validity) {
-                                    case ValidationType.VALID:
-                                        return Promise.resolve();
-                                    case ValidationType.INVALID_LENGTH:
-                                        return Promise.reject(new Error(t('Namespace is too long')));
-                                    case ValidationType.INVALID_CHARACTERS:
-                                        return Promise.reject(new Error(t('Namespace contains invalid characters')));
-                                    case ValidationType.DUPLICATE_NAMESPACE:
-                                        return Promise.reject(new Error(t('This namespace is already in use')));
-                                    default:
-                                        return Promise.reject(new Error(t('Unknown namespace validation error')));
-                                }
-                            },
-                        },
-                    ]}
+                                          switch (validationResponse.validity) {
+                                              case ValidationType.VALID:
+                                                  return Promise.resolve();
+                                              case ValidationType.INVALID_LENGTH:
+                                                  return Promise.reject(new Error(t('Namespace is too long')));
+                                              case ValidationType.INVALID_CHARACTERS:
+                                                  return Promise.reject(
+                                                      new Error(t('Namespace contains invalid characters')),
+                                                  );
+                                              case ValidationType.DUPLICATE_NAMESPACE:
+                                                  return Promise.reject(
+                                                      new Error(t('This namespace is already in use')),
+                                                  );
+                                              default:
+                                                  return Promise.reject(
+                                                      new Error(t('Unknown namespace validation error')),
+                                                  );
+                                          }
+                                      },
+                                  },
+                              ]
+                            : []
+                    }
                 >
                     <Input
                         disabled={!canEditNamespace}

--- a/frontend/src/pages/settings/components/settings-tabs/components/data-product-settings-table/new-data-product-setting-modal.component.tsx
+++ b/frontend/src/pages/settings/components/settings-tabs/components/data-product-settings-table/new-data-product-setting-modal.component.tsx
@@ -262,6 +262,7 @@ export const CreateSettingModal: React.FC<CreateSettingModalProps> = ({ isOpen, 
                     editToggleDisabled={mode === 'edit'}
                     canEditNamespace={canEditNamespace}
                     toggleCanEditNamespace={() => setCanEditNamespace((prev) => !prev)}
+                    validationRequired={mode === 'create'}
                     validateNamespace={validateNamespaceCallback}
                 />
                 <Form.Item


### PR DESCRIPTION
Fixes the following issues:

- Editing blocked of everything that has a namespace due to namespace validation being triggered and returning duplicate namespace error
- Missing backend validation of namespaces on creation of data product settings and data outputs