### PR TITLE
SQL Alchemy loading strategy improvements

### DIFF
--- a/backend/app/core/auth/auth.py
+++ b/backend/app/core/auth/auth.py
@@ -16,13 +16,13 @@ from app.users.schema_request import UserCreate
 
 
 def update_db_user(oidc_user: OIDCIdentity, token: JWTToken, db: Session) -> User:
-    db_user = db.query(UserModel).filter(UserModel.external_id == token.sub).first()
+    db_user = db.scalar(select(UserModel).where(UserModel.external_id == token.sub))
     if db_user:
         db_user.email = oidc_user.email
         db_user.first_name = oidc_user.name
         db_user.last_name = oidc_user.family_name
     else:
-        db_user = db.query(UserModel).filter(UserModel.email == oidc_user.email).first()
+        db_user = db.scalar(select(UserModel).where(UserModel.email == oidc_user.email))
         if db_user:
             db_user.external_id = oidc_user.sub
             db_user.first_name = oidc_user.name

--- a/backend/app/core/auth/service.py
+++ b/backend/app/core/auth/service.py
@@ -1,3 +1,4 @@
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.auth.credentials import AWSCredentials
@@ -22,8 +23,13 @@ class AuthService:
                     environment = env.name
                     break
         data_product_id = (
-            db.query(DataProductModel)
-            .get_one(DataProductModel.namespace, data_product_name)
+            db.execute(
+                select(DataProductModel).where(
+                    DataProductModel.namespace == data_product_name
+                )
+            )
+            .unique()
+            .scalar_one()
             .id
         )
         role_arn = DataProductService().get_data_product_role_arn(

--- a/backend/app/data_outputs/model.py
+++ b/backend/app/data_outputs/model.py
@@ -48,7 +48,7 @@ class DataOutput(Base, BaseORM):
         back_populates="data_output",
         cascade="all, delete-orphan",
         order_by="DataOutputDatasetAssociation.status.desc()",
-        lazy="joined",
+        lazy="raise",
     )
     tags: Mapped[list[Tag]] = relationship(
         secondary=tag_data_output_table, back_populates="data_outputs", lazy="joined"

--- a/backend/app/data_outputs/service.py
+++ b/backend/app/data_outputs/service.py
@@ -290,21 +290,8 @@ class DataOutputService:
         return {"id": current_data_output.id}
 
     def get_graph_data(self, id: UUID, level: int, db: Session) -> Graph:
-        dataOutput = db.get(
-            DataOutputModel,
-            id,
-            options=[
-                joinedload(DataOutputModel.dataset_links),
-                # Eagerly load to avoid data product to be cached in session with
-                # fields that raise on access
-                joinedload(DataOutputModel.owner).options(
-                    joinedload(DataProductModel.dataset_links),
-                    joinedload(DataProductModel.data_outputs),
-                ),
-            ],
-        )
-        # DataProductService will start with getting the data product and receive this
-        # from cache as it has already been loaded
+        dataOutput = db.get(DataOutputModel, id)
+
         graph = DataProductService().get_graph_data(dataOutput.owner_id, level, db)
 
         for node in graph.nodes:

--- a/backend/app/data_outputs/service.py
+++ b/backend/app/data_outputs/service.py
@@ -30,6 +30,7 @@ from app.data_outputs_datasets.model import (
 from app.data_product_memberships.enums import DataProductUserRole
 from app.data_products.model import DataProduct as DataProductModel
 from app.data_products.service import DataProductService
+from app.datasets.model import Dataset as DatasetModel
 from app.datasets.model import ensure_dataset_exists
 from app.graph.graph import Graph
 from app.role_assignments.enums import DecisionStatus
@@ -184,7 +185,9 @@ class DataOutputService:
         db: Session,
         background_tasks: BackgroundTasks,
     ):
-        dataset = ensure_dataset_exists(dataset_id, db)
+        dataset = ensure_dataset_exists(
+            dataset_id, db, options=[joinedload(DatasetModel.data_product_links)]
+        )
         data_output = ensure_data_output_exists(
             id, db, options=[joinedload(DataOutputModel.dataset_links)]
         )

--- a/backend/app/data_outputs/service.py
+++ b/backend/app/data_outputs/service.py
@@ -288,8 +288,20 @@ class DataOutputService:
 
     def get_graph_data(self, id: UUID, level: int, db: Session) -> Graph:
         dataOutput = db.get(
-            DataOutputModel, id, options=[joinedload(DataOutputModel.dataset_links)]
+            DataOutputModel,
+            id,
+            options=[
+                joinedload(DataOutputModel.dataset_links),
+                # Eagerly load to avoid data product to be cached in session with
+                # fields that raise on access
+                joinedload(DataOutputModel.owner).options(
+                    joinedload(DataProductModel.dataset_links),
+                    joinedload(DataProductModel.data_outputs),
+                ),
+            ],
         )
+        # DataProductService will start with getting the data product and receive this
+        # from cache as it has already been loaded
         graph = DataProductService().get_graph_data(dataOutput.owner_id, level, db)
 
         for node in graph.nodes:

--- a/backend/app/data_outputs_datasets/service.py
+++ b/backend/app/data_outputs_datasets/service.py
@@ -4,7 +4,7 @@ from uuid import UUID
 import pytz
 from fastapi import HTTPException, status
 from sqlalchemy import asc, select
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session
 
 from app.core.aws.refresh_infrastructure_lambda import RefreshInfrastructureLambda
 from app.data_outputs_datasets.model import (
@@ -65,11 +65,7 @@ class DataOutputDatasetService:
         db.commit()
 
     def remove_data_output_link(self, id: UUID, db: Session, authenticated_user: User):
-        current_link = db.get(
-            DataOutputDatasetAssociationModel,
-            id,
-            options=[joinedload(DataOutputDatasetAssociationModel.data_output)],
-        )
+        current_link = db.get(DataOutputDatasetAssociationModel, id)
 
         if not current_link:
             raise HTTPException(
@@ -94,13 +90,6 @@ class DataOutputDatasetService:
         return (
             db.scalars(
                 select(DataOutputDatasetAssociationModel)
-                .options(
-                    joinedload(DataOutputDatasetAssociationModel.dataset).joinedload(
-                        Dataset.owners
-                    ),
-                    joinedload(DataOutputDatasetAssociationModel.data_output),
-                    joinedload(DataOutputDatasetAssociationModel.requested_by),
-                )
                 .filter(
                     DataOutputDatasetAssociationModel.status == DecisionStatus.PENDING,
                 )

--- a/backend/app/data_outputs_datasets/service.py
+++ b/backend/app/data_outputs_datasets/service.py
@@ -11,7 +11,7 @@ from app.data_outputs_datasets.model import (
     DataOutputDatasetAssociation as DataOutputDatasetAssociationModel,
 )
 from app.data_outputs_datasets.schema_response import DataOutputDatasetAssociationsGet
-from app.datasets.model import Dataset as DatasetModel
+from app.datasets.model import Dataset as Dataset
 from app.role_assignments.enums import DecisionStatus
 from app.users.model import User as UserModel
 from app.users.schema import User
@@ -96,7 +96,7 @@ class DataOutputDatasetService:
                 select(DataOutputDatasetAssociationModel)
                 .options(
                     joinedload(DataOutputDatasetAssociationModel.dataset).joinedload(
-                        DatasetModel.owners
+                        Dataset.owners
                     ),
                     joinedload(DataOutputDatasetAssociationModel.data_output),
                     joinedload(DataOutputDatasetAssociationModel.requested_by),
@@ -106,7 +106,7 @@ class DataOutputDatasetService:
                 )
                 .filter(
                     DataOutputDatasetAssociationModel.dataset.has(
-                        DatasetModel.owners.any(UserModel.id == authenticated_user.id)
+                        Dataset.owners.any(UserModel.id == authenticated_user.id)
                     )
                 )
                 .order_by(asc(DataOutputDatasetAssociationModel.requested_on))

--- a/backend/app/data_outputs_datasets/service.py
+++ b/backend/app/data_outputs_datasets/service.py
@@ -7,13 +7,11 @@ from sqlalchemy import asc, select
 from sqlalchemy.orm import Session, joinedload
 
 from app.core.aws.refresh_infrastructure_lambda import RefreshInfrastructureLambda
-from app.data_outputs.model import ensure_data_output_exists
 from app.data_outputs_datasets.model import (
     DataOutputDatasetAssociation as DataOutputDatasetAssociationModel,
 )
 from app.data_outputs_datasets.schema_response import DataOutputDatasetAssociationsGet
 from app.datasets.model import Dataset as DatasetModel
-from app.datasets.model import ensure_dataset_exists
 from app.role_assignments.enums import DecisionStatus
 from app.users.model import User as UserModel
 from app.users.schema import User
@@ -72,21 +70,21 @@ class DataOutputDatasetService:
             id,
             options=[joinedload(DataOutputDatasetAssociationModel.data_output)],
         )
+
         if not current_link:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Dataset data output link {id} not found",
             )
+
         dataset = current_link.dataset
-        ensure_dataset_exists(dataset.id, db)
         if authenticated_user not in dataset.owners and not authenticated_user.is_admin:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Only dataset owners can execute this action",
             )
-        linked_data_output = current_link.data_output
-        data_output = ensure_data_output_exists(linked_data_output.id, db)
-        data_output.dataset_links.remove(current_link)
+
+        db.delete(current_link)
         RefreshInfrastructureLambda().trigger()
         db.commit()
 

--- a/backend/app/data_outputs_datasets/service.py
+++ b/backend/app/data_outputs_datasets/service.py
@@ -11,7 +11,7 @@ from app.data_outputs_datasets.model import (
     DataOutputDatasetAssociation as DataOutputDatasetAssociationModel,
 )
 from app.data_outputs_datasets.schema_response import DataOutputDatasetAssociationsGet
-from app.datasets.model import Dataset as Dataset
+from app.datasets.model import Dataset as DatasetModel
 from app.role_assignments.enums import DecisionStatus
 from app.users.model import User as UserModel
 from app.users.schema import User
@@ -95,7 +95,7 @@ class DataOutputDatasetService:
                 )
                 .filter(
                     DataOutputDatasetAssociationModel.dataset.has(
-                        Dataset.owners.any(UserModel.id == authenticated_user.id)
+                        DatasetModel.owners.any(UserModel.id == authenticated_user.id)
                     )
                 )
                 .order_by(asc(DataOutputDatasetAssociationModel.requested_on))

--- a/backend/app/data_products/model.py
+++ b/backend/app/data_products/model.py
@@ -64,7 +64,7 @@ class DataProduct(Base, BaseORM):
         back_populates="data_product",
         cascade="all, delete-orphan",
         order_by="DataProductDatasetAssociation.status.desc()",
-        lazy="joined",
+        lazy="raise",
     )
     tags: Mapped[list[Tag]] = relationship(
         secondary=tag_data_product_table, back_populates="data_products", lazy="joined"
@@ -80,7 +80,7 @@ class DataProduct(Base, BaseORM):
         "DataOutput",
         back_populates="owner",
         cascade="all, delete-orphan",
-        lazy="joined",
+        lazy="raise",
     )
 
     @property

--- a/backend/app/data_products/model.py
+++ b/backend/app/data_products/model.py
@@ -57,12 +57,14 @@ class DataProduct(Base, BaseORM):
         order_by="DataProductMembership.status, "
         "DataProductMembership.requested_on, "
         "DataProductMembership.role",
+        lazy="joined",
     )
     dataset_links: Mapped[list["DataProductDatasetAssociation"]] = relationship(
         "DataProductDatasetAssociation",
         back_populates="data_product",
         cascade="all, delete-orphan",
         order_by="DataProductDatasetAssociation.status.desc()",
+        lazy="joined",
     )
     tags: Mapped[list[Tag]] = relationship(
         secondary=tag_data_product_table, back_populates="data_products", lazy="joined"
@@ -78,6 +80,7 @@ class DataProduct(Base, BaseORM):
         "DataOutput",
         back_populates="owner",
         cascade="all, delete-orphan",
+        lazy="joined",
     )
 
     @property

--- a/backend/app/data_products/service.py
+++ b/backend/app/data_products/service.py
@@ -47,7 +47,7 @@ from app.data_products_datasets.model import (
     DataProductDatasetAssociation as DataProductDatasetModel,
 )
 from app.datasets.enums import DatasetAccessType
-from app.datasets.model import Dataset as Dataset
+from app.datasets.model import Dataset as DatasetModel
 from app.datasets.model import ensure_dataset_exists
 from app.environment_platform_configurations.model import (
     EnvironmentPlatformConfiguration as EnvironmentPlatformConfigurationModel,
@@ -78,7 +78,7 @@ class DataProductService:
             options=[
                 joinedload(DataProductModel.dataset_links)
                 .joinedload(DataProductDatasetModel.dataset)
-                .joinedload(Dataset.data_output_links),
+                .joinedload(DatasetModel.data_output_links),
                 joinedload(DataProductModel.data_outputs).joinedload(
                     DataOutputModel.dataset_links
                 ),
@@ -324,7 +324,7 @@ class DataProductService:
 
     def _send_email_for_dataset_link(
         self,
-        dataset: Dataset,
+        dataset: DatasetModel,
         data_product: DataProductModel,
         authenticated_user: User,
         background_tasks: BackgroundTasks,
@@ -369,7 +369,7 @@ class DataProductService:
         dataset = ensure_dataset_exists(
             dataset_id,
             db,
-            options=[joinedload(Dataset.data_product_links)],
+            options=[joinedload(DatasetModel.data_product_links)],
         )
         data_product = ensure_data_product_exists(
             id, db, options=[joinedload(DataProductModel.dataset_links)]
@@ -554,7 +554,7 @@ class DataProductService:
                 joinedload(DataProductModel.data_outputs)
                 .joinedload(DataOutputModel.dataset_links)
                 .joinedload(DataOutputDatasetAssociation.dataset)
-                .joinedload(Dataset.data_product_links),
+                .joinedload(DatasetModel.data_product_links),
             ],
             # As this is also called from the DataOutputService, we need to ensure
             # that the DataOutput for which this is called is not loaded from cache,

--- a/backend/app/data_products/service.py
+++ b/backend/app/data_products/service.py
@@ -27,6 +27,7 @@ from app.core.namespace.validation import (
 )
 from app.data_outputs.model import DataOutput as DataOutputModel
 from app.data_outputs.schema_response import DataOutputGet
+from app.data_outputs_datasets.model import DataOutputDatasetAssociation
 from app.data_product_lifecycles.model import (
     DataProductLifecycle as DataProductLifeCycleModel,
 )
@@ -550,8 +551,15 @@ class DataProductService:
             id,
             options=[
                 joinedload(DataProductModel.dataset_links),
-                joinedload(DataProductModel.data_outputs),
+                joinedload(DataProductModel.data_outputs)
+                .joinedload(DataOutputModel.dataset_links)
+                .joinedload(DataOutputDatasetAssociation.dataset)
+                .joinedload(Dataset.data_product_links),
             ],
+            # As this is also called from the DataOutputService, we need to ensure
+            # that the DataOutput for which this is called is not loaded from cache,
+            # but instead loaded anew with all necessary fields eagerly loaded
+            populate_existing=True,
         )
         nodes = [
             Node(

--- a/backend/app/data_products/service.py
+++ b/backend/app/data_products/service.py
@@ -244,8 +244,7 @@ class DataProductService:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Data Product {id} not found",
             )
-        data_product.memberships = []
-        data_product.dataset_links = []
+
         for output in data_product.data_outputs:
             db.delete(output)
         db.delete(data_product)

--- a/backend/app/data_products/service.py
+++ b/backend/app/data_products/service.py
@@ -47,7 +47,7 @@ from app.data_products_datasets.model import (
     DataProductDatasetAssociation as DataProductDatasetModel,
 )
 from app.datasets.enums import DatasetAccessType
-from app.datasets.model import Dataset as DatasetModel
+from app.datasets.model import Dataset as Dataset
 from app.datasets.model import ensure_dataset_exists
 from app.environment_platform_configurations.model import (
     EnvironmentPlatformConfiguration as EnvironmentPlatformConfigurationModel,
@@ -78,7 +78,7 @@ class DataProductService:
             options=[
                 joinedload(DataProductModel.dataset_links)
                 .joinedload(DataProductDatasetModel.dataset)
-                .joinedload(DatasetModel.data_output_links)
+                .joinedload(Dataset.data_output_links)
                 .joinedload(DataOutputDatasetAssociation.data_output),
                 joinedload(DataProductModel.memberships),
                 joinedload(DataProductModel.data_outputs).joinedload(
@@ -344,7 +344,7 @@ class DataProductService:
 
     def _send_email_for_dataset_link(
         self,
-        dataset: DatasetModel,
+        dataset: Dataset,
         data_product: DataProductModel,
         authenticated_user: User,
         background_tasks: BackgroundTasks,
@@ -389,7 +389,7 @@ class DataProductService:
         dataset = ensure_dataset_exists(
             dataset_id,
             db,
-            options=[joinedload(DatasetModel.data_product_links)],
+            options=[joinedload(Dataset.data_product_links)],
         )
         data_product = ensure_data_product_exists(
             id, db, options=[joinedload(DataProductModel.dataset_links)]

--- a/backend/app/data_products_datasets/model.py
+++ b/backend/app/data_products_datasets/model.py
@@ -18,40 +18,56 @@ from app.shared.model import BaseORM, utcnow
 
 class DataProductDatasetAssociation(Base, BaseORM):
     __tablename__ = "data_products_datasets"
+
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    status: Mapped[DecisionStatus] = mapped_column(
+        Enum(DecisionStatus),
+        default=DecisionStatus.PENDING,
+    )
+    requested_on = Column(DateTime(timezone=False), server_default=utcnow())
+    approved_on = Column(DateTime(timezone=False))
+    denied_on = Column(DateTime(timezone=False))
+
+    # Foreign keys
     data_product_id: Mapped[uuid.UUID] = mapped_column(
         "data_product_id", ForeignKey("data_products.id")
     )
     dataset_id: Mapped[uuid.UUID] = mapped_column(
         "dataset_id", ForeignKey("datasets.id")
     )
+    requested_by_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))
+    approved_by_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))
+    denied_by_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))
+
+    # Relationships
     dataset: Mapped["Dataset"] = relationship(
         "Dataset",
         back_populates="data_product_links",
         order_by="Dataset.name",
+        lazy="joined",
     )
     data_product: Mapped["DataProduct"] = relationship(
-        "DataProduct", back_populates="dataset_links", order_by="DataProduct.name"
+        "DataProduct",
+        back_populates="dataset_links",
+        order_by="DataProduct.name",
+        lazy="joined",
     )
-    status: Mapped[DecisionStatus] = mapped_column(
-        Enum(DecisionStatus),
-        default=DecisionStatus.PENDING,
-    )
-    requested_by_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))
     requested_by: Mapped["User"] = relationship(
-        foreign_keys=[requested_by_id], back_populates="requested_datasets"
+        foreign_keys=[requested_by_id],
+        back_populates="requested_datasets",
+        lazy="joined",
     )
-    requested_on = Column(DateTime(timezone=False), server_default=utcnow())
-    approved_by_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))
     approved_by: Mapped["User"] = relationship(
-        foreign_keys=[approved_by_id], back_populates="approved_datasets"
+        foreign_keys=[approved_by_id],
+        back_populates="approved_datasets",
+        lazy="joined",
     )
-    approved_on = Column(DateTime(timezone=False))
-    denied_by_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))
     denied_by: Mapped["User"] = relationship(
-        foreign_keys=[denied_by_id], back_populates="denied_datasets"
+        foreign_keys=[denied_by_id],
+        back_populates="denied_datasets",
+        lazy="joined",
     )
-    denied_on = Column(DateTime(timezone=False))
+
     __table_args__ = (
         UniqueConstraint(
             "data_product_id", "dataset_id", name="unique_data_product_dataset"

--- a/backend/app/data_products_datasets/service.py
+++ b/backend/app/data_products_datasets/service.py
@@ -11,7 +11,7 @@ from app.data_products_datasets.model import (
     DataProductDatasetAssociation as DataProductDatasetAssociationModel,
 )
 from app.data_products_datasets.schema_response import DataProductDatasetAssociationsGet
-from app.datasets.model import Dataset as Dataset
+from app.datasets.model import Dataset as DatasetModel
 from app.role_assignments.enums import DecisionStatus
 from app.users.model import User as UserModel
 from app.users.schema import User
@@ -72,7 +72,7 @@ class DataProductDatasetService:
                 )
                 .where(
                     DataProductDatasetAssociationModel.dataset.has(
-                        Dataset.owners.any(UserModel.id == authenticated_user.id)
+                        DatasetModel.owners.any(UserModel.id == authenticated_user.id)
                     )
                 )
                 .order_by(asc(DataProductDatasetAssociationModel.requested_on))

--- a/backend/app/data_products_datasets/service.py
+++ b/backend/app/data_products_datasets/service.py
@@ -11,7 +11,7 @@ from app.data_products_datasets.model import (
     DataProductDatasetAssociation as DataProductDatasetAssociationModel,
 )
 from app.data_products_datasets.schema_response import DataProductDatasetAssociationsGet
-from app.datasets.model import Dataset as DatasetModel
+from app.datasets.model import Dataset as Dataset
 from app.role_assignments.enums import DecisionStatus
 from app.users.model import User as UserModel
 from app.users.schema import User
@@ -68,7 +68,7 @@ class DataProductDatasetService:
             db.query(DataProductDatasetAssociationModel)
             .options(
                 joinedload(DataProductDatasetAssociationModel.dataset).joinedload(
-                    DatasetModel.owners
+                    Dataset.owners
                 ),
                 joinedload(DataProductDatasetAssociationModel.data_product),
                 joinedload(DataProductDatasetAssociationModel.requested_by),
@@ -76,7 +76,7 @@ class DataProductDatasetService:
             .filter(DataProductDatasetAssociationModel.status == DecisionStatus.PENDING)
             .filter(
                 DataProductDatasetAssociationModel.dataset.has(
-                    DatasetModel.owners.any(UserModel.id == authenticated_user.id)
+                    Dataset.owners.any(UserModel.id == authenticated_user.id)
                 )
             )
             .order_by(asc(DataProductDatasetAssociationModel.requested_on))

--- a/backend/app/datasets/model.py
+++ b/backend/app/datasets/model.py
@@ -56,14 +56,14 @@ class Dataset(Base, BaseORM):
         back_populates="dataset",
         order_by="DataProductDatasetAssociation.status.desc()",
         cascade="all, delete-orphan",
-        lazy="joined",
+        lazy="raise",
     )
     data_output_links: Mapped[list["DataOutputDatasetAssociation"]] = relationship(
         "DataOutputDatasetAssociation",
         back_populates="dataset",
         order_by="DataOutputDatasetAssociation.status.desc()",
         cascade="all, delete-orphan",
-        lazy="joined",
+        lazy="raise",
     )
     tags: Mapped[list[Tag]] = relationship(
         secondary=tag_dataset_table, back_populates="datasets", lazy="joined"

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -16,7 +16,7 @@ from app.data_products_datasets.model import (
     DataProductDatasetAssociation as DataProductDatasetAssociationModel,
 )
 from app.database.database import get_db_session
-from app.datasets.model import Dataset as DatasetModel
+from app.datasets.model import Dataset as Dataset
 from app.role_assignments.enums import DecisionStatus
 from app.settings import settings
 from app.users.schema import User
@@ -42,7 +42,7 @@ def only_dataset_owners(
     if settings.AUTHORIZER_ENABLED:
         return
 
-    dataset = db.get(DatasetModel, id)
+    dataset = db.get(Dataset, id)
 
     if not dataset:
         raise HTTPException(

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -16,7 +16,7 @@ from app.data_products_datasets.model import (
     DataProductDatasetAssociation as DataProductDatasetAssociationModel,
 )
 from app.database.database import get_db_session
-from app.datasets.model import Dataset as Dataset
+from app.datasets.model import Dataset as DatasetModel
 from app.role_assignments.enums import DecisionStatus
 from app.settings import settings
 from app.users.schema import User
@@ -42,7 +42,7 @@ def only_dataset_owners(
     if settings.AUTHORIZER_ENABLED:
         return
 
-    dataset = db.get(Dataset, id)
+    dataset = db.get(DatasetModel, id)
 
     if not dataset:
         raise HTTPException(

--- a/backend/app/users/model.py
+++ b/backend/app/users/model.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 class User(Base, BaseORM):
     __tablename__ = "users"
+
     id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     email = Column(String, unique=True)
     external_id = Column(String)
@@ -26,61 +27,87 @@ class User(Base, BaseORM):
     last_name = Column(String)
     is_admin = Column(Boolean, server_default="false", nullable=False)
 
+    # Relationships - Data Products
     data_product_memberships: Mapped[list["DataProductMembership"]] = relationship(
         "DataProductMembership",
         foreign_keys="DataProductMembership.user_id",
         back_populates="user",
+        # Deliberately lazy:
+        #  - Used in limited cases, only on a single user
+        #  - Complicates get_authenticated_user
+        #  - Private dataset test cases become more complex
+        #    (need to manipulate the session to avoid a user being cached with a
+        #     membership field with raise load strategy)
+        lazy="select",
     )
     approved_memberships: Mapped[list["DataProductMembership"]] = relationship(
         "DataProductMembership",
         foreign_keys="DataProductMembership.approved_by_id",
         back_populates="approved_by",
+        lazy="raise",
     )
     denied_memberships: Mapped[list["DataProductMembership"]] = relationship(
         "DataProductMembership",
         foreign_keys="DataProductMembership.denied_by_id",
         back_populates="denied_by",
+        lazy="raise",
     )
     requested_memberships: Mapped[list["DataProductMembership"]] = relationship(
         "DataProductMembership",
         foreign_keys="DataProductMembership.requested_by_id",
         back_populates="requested_by",
+        lazy="raise",
     )
     data_products: Mapped[list["DataProduct"]] = association_proxy(
         "data_product_memberships", "data_product"
     )
+
+    # Relationships - Datasets
     owned_datasets: Mapped[list["Dataset"]] = relationship(
-        secondary=datasets_owner_table, back_populates="owners"
+        secondary=datasets_owner_table,
+        back_populates="owners",
+        # Deliberately lazy:
+        #  - Used in limited cases, only on a single user
+        #  - Complicates get_authenticated_user
+        lazy="select",
     )
     requested_datasets: Mapped[list["DataProductDatasetAssociation"]] = relationship(
         "DataProductDatasetAssociation",
         foreign_keys="DataProductDatasetAssociation.requested_by_id",
         back_populates="requested_by",
+        lazy="raise",
     )
     denied_datasets: Mapped[list["DataProductDatasetAssociation"]] = relationship(
         "DataProductDatasetAssociation",
         foreign_keys="DataProductDatasetAssociation.denied_by_id",
         back_populates="denied_by",
+        lazy="raise",
     )
     approved_datasets: Mapped[list["DataProductDatasetAssociation"]] = relationship(
         "DataProductDatasetAssociation",
         foreign_keys="DataProductDatasetAssociation.approved_by_id",
         back_populates="approved_by",
+        lazy="raise",
     )
+
+    # Relationships - Data outputs
     requested_dataoutputs: Mapped[list["DataOutputDatasetAssociation"]] = relationship(
         "DataOutputDatasetAssociation",
         foreign_keys="DataOutputDatasetAssociation.requested_by_id",
         back_populates="requested_by",
+        lazy="raise",
     )
     denied_dataoutputs: Mapped[list["DataOutputDatasetAssociation"]] = relationship(
         "DataOutputDatasetAssociation",
         foreign_keys="DataOutputDatasetAssociation.denied_by_id",
         back_populates="denied_by",
+        lazy="raise",
     )
     approved_dataoutputs: Mapped[list["DataOutputDatasetAssociation"]] = relationship(
         "DataOutputDatasetAssociation",
         foreign_keys="DataOutputDatasetAssociation.approved_by_id",
         back_populates="approved_by",
+        lazy="raise",
     )
 
 

--- a/backend/app/users/service.py
+++ b/backend/app/users/service.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from sqlalchemy import asc
+from sqlalchemy import asc, select
 from sqlalchemy.orm import Session
 
 from app.users.model import User as UserModel
@@ -10,14 +10,12 @@ from app.users.schema_response import UsersGet
 
 
 class UserService:
-
     def get_users(self, db: Session) -> list[UsersGet]:
-        return (
-            db.query(UserModel)
+        return db.scalars(
+            select(UserModel)
             .where(UserModel.email != "systemaccount@noreply.com")
             .order_by(asc(UserModel.last_name), asc(UserModel.first_name))
-            .all()
-        )
+        ).all()
 
     def remove_user(self, id: UUID, db: Session) -> None:
         user = ensure_user_exists(id, db)

--- a/backend/tests/app/datasets/test_model.py
+++ b/backend/tests/app/datasets/test_model.py
@@ -1,3 +1,5 @@
+from sqlalchemy.orm import joinedload
+from tests import test_session
 from tests.factories import (
     DataProductDatasetAssociationFactory,
     DataProductMembershipFactory,
@@ -6,22 +8,26 @@ from tests.factories import (
 )
 
 from app.datasets.enums import DatasetAccessType
+from app.datasets.model import Dataset
 
 
 class TestDatasetsModel:
     def test_private_dataset_not_visible(self):
         user = UserFactory(external_id="sub")
         ds = DatasetFactory(access_type=DatasetAccessType.PRIVATE)
+        ds = self.get_dataset(ds)
         assert ds.isVisibleToUser(user) is False
 
     def test_get_private_dataset_by_owner(self, client):
         ds_owner = UserFactory(external_id="sub")
         ds = DatasetFactory(access_type=DatasetAccessType.PRIVATE, owners=[ds_owner])
+        ds = self.get_dataset(ds)
         assert ds.isVisibleToUser(ds_owner) is True
 
     def test_get_private_dataset_by_admin(self, client):
         admin = UserFactory(external_id="sub", is_admin=True)
         ds = DatasetFactory(access_type=DatasetAccessType.PRIVATE)
+        ds = self.get_dataset(ds)
         assert ds.isVisibleToUser(admin) is True
 
     def test_get_private_dataset_by_member_of_consuming_data_product(self, client):
@@ -29,4 +35,14 @@ class TestDatasetsModel:
         ds = DatasetFactory(access_type=DatasetAccessType.PRIVATE)
         dp = DataProductMembershipFactory(user=user).data_product
         DataProductDatasetAssociationFactory(data_product=dp, dataset=ds)
+        ds = self.get_dataset(ds)
         assert ds.isVisibleToUser(user) is True
+
+    @staticmethod
+    def get_dataset(dataset: Dataset) -> Dataset:
+        return test_session.get(
+            Dataset,
+            dataset.id,
+            options=[joinedload(Dataset.data_product_links)],
+            populate_existing=True,
+        )


### PR DESCRIPTION
Changes:
- Finished assigning default loading strategies to the different models with a focus on avoiding lazy loading
- Added the necessary loading options to all queries (removed some if unnecessary)
- Converted legacy `session.query` API while going over each query

Reasoning behind loading strategies:
- Eagerly load as much as possible using the joined load strategy
- Deliberately cut eager loading as a default in between data products, datasets and data outputs to avoid long (recursive) query chains. By using the default `raise` loading strategy, SQL Alchemy will throw an error when these links between objects are accessed without assigning a loading strategy at query time. This avoids accidental lazy loading.
- The relationships from metadata (e.g. tags, domain, ...) to data products, datasets and data outputs also use the `raise` loading strategy.

Excluded:
- Platform & services as this will still need a general rework
- Role & role assignments to avoid adding extra changes (and possible issues) on top