### PR TITLE
Put the secrets on kubernetes in a secret

### DIFF
--- a/helm/templates/configmap_backend.yaml
+++ b/helm/templates/configmap_backend.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "data-product-portal.fullname" . }}
 data:
-  POSTGRES_PASSWORD: {{ ternary .Values.global.postgresql.auth.password .Values.database.password .Values.postgres_enabled | quote }}
   POSTGRES_USER: {{ ternary .Values.global.postgresql.auth.username .Values.database.username .Values.postgres_enabled | default .Values.database.username  }}
   POSTGRES_PORT: {{ ternary .Values.global.postgresql.auth.port .Values.database.port .Values.postgres_enabled  | default .Values.database.port }}
   POSTGRES_SERVER: {{ ternary .Values.global.postgresql.auth.server .Values.database.server .Values.postgres_enabled  | default .Values.database.server }}
   POSTGRES_DB: {{ ternary .Values.global.postgresql.auth.database .Values.database.dbname .Values.postgres_enabled  | default .Values.database.dbname }}
   CORS_ALLOWED_ORIGINS: {{ .Values.host }}
-  OIDC_CLIENT_ID: {{ .Values.oidc.client_id }}
-  OIDC_CLIENT_SECRET: {{ .Values.oidc.client_secret }}
   OIDC_AUTHORITY: {{ .Values.oidc.authority }}
   OIDC_REDIRECT_URI: {{ .Values.oidc.redirect_uri }}
   FRONTEND_CONFIG_BASE_URL: {{ .Values.host }}
@@ -16,14 +16,6 @@ data:
   {{- else }}
   OIDC_ENABLED: "false"
   {{- end }}
-  CONVEYOR_API_KEY: {{ .Values.conveyor.api_key }}
-  CONVEYOR_SECRET: {{ .Values.conveyor.secret }}
-  {{- if .Values.api_key.enabled }}
-  PORTAL_API_KEY: {{ .Values.api_key.key }}
-  {{- end }}
-  INFRASTRUCTURE_LAMBDA_ARN: {{ .Values.infrastructure_lambda_arn }}
-  SMTP_HOST:  {{ .Values.smtp.host }}
-  SMTP_PORT: {{ .Values.smtp.port }}
   SMTP_USERNAME: {{ .Values.smtp.username }}
   SMTP_PASSWORD: {{ .Values.smtp.password }}
   {{- if .Values.smtp.no_login}}
@@ -41,10 +33,4 @@ data:
   {{- if .Values.webhook.url }}
   WEBHOOK_URL: {{ .Values.webhook.url }}
   {{- end }}
-  {{- if .Values.webhook.secret }}
-  WEBHOOK_SECRET: {{ .Values.webhook.secret }}
-  {{- end }}
   NAMESPACE_MAX_LENGTH: {{ .Values.namespace_max_length }}
-kind: ConfigMap
-metadata:
-  name: {{ include "data-product-portal.fullname" . }}

--- a/helm/templates/deployment_backend.yaml
+++ b/helm/templates/deployment_backend.yaml
@@ -13,8 +13,10 @@ spec:
       {{- include "data-product-portal.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap_backend.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret_backend.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
@@ -36,6 +38,8 @@ spec:
           command: ["python", "-m", "app.db_tool", "migrate"]
           envFrom:
             - configMapRef:
+                name: {{ include "data-product-portal.fullname" . }}
+            - secretRef:
                 name: {{ include "data-product-portal.fullname" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/helm/templates/secret_backend.yaml
+++ b/helm/templates/secret_backend.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "data-product-portal.fullname" . }}
+data:
+  POSTGRES_PASSWORD: {{ ternary .Values.global.postgresql.auth.password .Values.database.password .Values.postgres_enabled | quote }}
+  OIDC_CLIENT_ID: {{ .Values.oidc.client_id }}
+  OIDC_CLIENT_SECRET: {{ .Values.oidc.client_secret }}
+  CONVEYOR_API_KEY: {{ .Values.conveyor.api_key }}
+  CONVEYOR_SECRET: {{ .Values.conveyor.secret }}
+  {{- if .Values.api_key.enabled }}
+  PORTAL_API_KEY: {{ .Values.api_key.key }}
+  {{- end }}
+  SMTP_USERNAME: {{ .Values.smtp.username }}
+  SMTP_PASSWORD: {{ .Values.smtp.password }}
+  {{- if .Values.webhook.secret }}
+  WEBHOOK_SECRET: {{ .Values.webhook.secret }}
+  {{- end }}


### PR DESCRIPTION
Putting secrets in a secret in kubernetes makes the intention more clear.
Also in EKS for example secrets can be encrypted at rest thus it is best practice to use secrets for sensitive values.

I also added a checksum of the configmap and secret to the deployment, this makes sure that the new pods
are deployed when users change the config of their installation