### PR TITLE
Fixed an error when seeding the database

### DIFF
--- a/backend/app/db_tool.py
+++ b/backend/app/db_tool.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 
 import typer
@@ -27,7 +26,7 @@ def seed_cmd(path: str = typer.Argument(..., help="Path to the seed script.")):
     print("[bold green]Seeding :seedling:[/bold green]")
     print("Seeding started -> source =", path)
     try:
-        asyncio.run(seed_db(path))
+        seed_db(path)
         print("Seeding finished successfully")
     except Exception as e:
         print("Something went wrong when seeding", e)


### PR DESCRIPTION
Introduced when switching authorization from sync to async #1132

Seeding still happened, but it threw an error message just before the end

```sh
Something went wrong when seeding a coroutine was expected, got None
```