### PR TITLE
Prevent unnecessary eager loading on get all calls

### DIFF
--- a/backend/app/data_outputs/service.py
+++ b/backend/app/data_outputs/service.py
@@ -104,6 +104,8 @@ class DataOutputService:
             db.scalars(
                 select(DataOutputModel).options(
                     joinedload(DataOutputModel.dataset_links)
+                    .joinedload(DataOutputDatasetAssociationModel.dataset)
+                    .raiseload("*"),
                 )
             )
             .unique()

--- a/backend/app/data_products/model.py
+++ b/backend/app/data_products/model.py
@@ -65,7 +65,7 @@ class DataProduct(Base, BaseORM):
         cascade="all, delete-orphan",
         order_by="DataProductRoleAssignment.decision, "
         "DataProductRoleAssignment.requested_on",
-        lazy="joined",
+        lazy="raise",
     )
     dataset_links: Mapped[list["DataProductDatasetAssociation"]] = relationship(
         "DataProductDatasetAssociation",


### PR DESCRIPTION
Fetching all datasets was slowed down due to latest changes with adding `assignments` to the `DataProduct` model with a default `joined` strategy.

Resolved the issue and also added some extra tweaks, which try to avoid similar issues in the future and are generally beneficial for performance of the get all calls:
- Set the default loading strategy of assignments on data products to raise
- Put wildcard raiseload at the end of each loading option to stop further eager loading
- Directly query the database for the graph endpoint to ensure correct loading strategy