### PR TITLE
Fix short rev-parse to match 7 chars again

### DIFF
--- a/.github/workflows/docker-build-main.yml
+++ b/.github/workflows/docker-build-main.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - name: Get commit hash
         id: vars
-        run: echo "version=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: echo "version=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
     outputs:
         version: ${{ steps.vars.outputs.version }}
   backend:


### PR DESCRIPTION
These guys trolled us by suddenly changing their default 7 into a default 8