### PR TITLE
Owner triggers rerender

### DIFF
--- a/frontend/src/components/data-products/data-product-form/data-product-form.component.tsx
+++ b/frontend/src/components/data-products/data-product-form/data-product-form.component.tsx
@@ -56,6 +56,8 @@ export function DataProductForm({ mode, dataProductId }: Props) {
     const [updateDataProduct, { isLoading: isUpdating }] = useUpdateDataProductMutation();
     const [deleteDataProduct, { isLoading: isArchiving }] = useRemoveDataProductMutation();
     const [fetchNamespace, { data: namespaceSuggestion }] = useLazyGetDataProductNamespaceSuggestionQuery();
+
+    const ownerIds = useGetDataProductOwnerIds(currentDataProduct?.id);
     const [validateNamespace] = useLazyValidateDataProductNamespaceQuery();
     const { data: namespaceLengthLimits } = useGetDataProductNamespaceLengthLimitsQuery();
 
@@ -198,8 +200,6 @@ export function DataProductForm({ mode, dataProductId }: Props) {
         }
     }, [form, mode, canEditNamespace, namespaceSuggestion]);
 
-    const ownerIds = useGetDataProductOwnerIds(currentDataProduct?.id);
-
     useEffect(() => {
         if (currentDataProduct && mode === 'edit') {
             form.setFieldsValue({
@@ -210,10 +210,17 @@ export function DataProductForm({ mode, dataProductId }: Props) {
                 lifecycle_id: currentDataProduct.lifecycle.id,
                 domain_id: currentDataProduct.domain.id,
                 tag_ids: currentDataProduct.tags.map((tag) => tag.id),
+            });
+        }
+    }, [currentDataProduct, form, mode]);
+
+    useEffect(() => {
+        if (mode === 'edit') {
+            form.setFieldsValue({
                 owners: ownerIds,
             });
         }
-    }, [currentDataProduct, form, mode, ownerIds]);
+    }, [form, mode, ownerIds]);
 
     const validateNamespaceCallback = useCallback(
         (namespace: string) => validateNamespace(namespace).unwrap(),

--- a/frontend/src/components/datasets/dataset-form/dataset-form.component.tsx
+++ b/frontend/src/components/datasets/dataset-form/dataset-form.component.tsx
@@ -248,10 +248,17 @@ export function DatasetForm({ mode, datasetId }: Props) {
                 domain_id: currentDataset.domain.id,
                 tag_ids: currentDataset.tags.map((tag) => tag.id),
                 lifecycle_id: currentDataset.lifecycle.id,
+            });
+        }
+    }, [currentDataset, mode, form]);
+
+    useEffect(() => {
+        if (mode === 'edit') {
+            form.setFieldsValue({
                 owners: ownerIds,
             });
         }
-    }, [currentDataset, mode, form, ownerIds]);
+    }, [form, mode, ownerIds]);
 
     const validateNamespaceCallback = useCallback(
         (namespace: string) => validateNamespace(namespace).unwrap(),


### PR DESCRIPTION
Constant rerendering results in uneditable form.
I don't know why the owners are constantly being recalculated if you change the form values, because the ID does not change. But that is React specific shenanigans I believe