### PR TITLE
Use word instead of job

### DIFF
--- a/backend/tests/factories/role.py
+++ b/backend/tests/factories/role.py
@@ -13,7 +13,7 @@ class RoleFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = Role
 
     id = factory.Faker("uuid4")
-    name = factory.Faker("job")
+    name = factory.Faker("word")
     scope = factory.Faker(
         "random_element", elements=("global", "data_product", "dataset")
     )


### PR DESCRIPTION
Sometimes the backend tests fail because Roles are created that already exist for the scope.
My suspicion is that fakers Jobs have less options than word.
Conceptually Job is more correct but for the usecase of tests it does not really matter. I want to reduce the likelihood of duplicates without forcing a name in every role creation.