### PR TITLE
Make layout more uniform

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.0.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
     "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
     "files": { "ignoreUnknown": false, "includes": ["**", "!**/config.docker.js", "!**/*.d.ts"] },
     "formatter": {

--- a/frontend/src/components/form/searchbar/searchbar.module.scss
+++ b/frontend/src/components/form/searchbar/searchbar.module.scss
@@ -1,1 +1,4 @@
 @use '@/styles/globals';
+
+.searchContainer {}
+

--- a/frontend/src/components/layout/navbar/breadcrumbs/breadcrumbs.component.tsx
+++ b/frontend/src/components/layout/navbar/breadcrumbs/breadcrumbs.component.tsx
@@ -1,7 +1,8 @@
-import Icon, {
+import {
     CompassOutlined,
     HomeOutlined,
     SettingOutlined,
+    ShopOutlined,
     TeamOutlined,
     UnorderedListOutlined,
 } from '@ant-design/icons';
@@ -10,9 +11,7 @@ import type { BreadcrumbItemType, BreadcrumbSeparatorType } from 'antd/es/breadc
 import { type ReactNode, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router';
-
-import dataProductOutlineIcon from '@/assets/icons/data-product-outline-icon.svg?react';
-import datasetOutlineIcon from '@/assets/icons/dataset-outline-icon.svg?react';
+import { DataProductOutlined, DatasetOutlined } from '@/components/icons';
 import { BreadcrumbLink } from '@/components/layout/navbar/breadcrumbs/breadcrumb-link/breadcrumb-link.component.tsx';
 import { TabKeys as DataOutputTabKeys } from '@/pages/data-output/components/data-output-tabs/data-output-tabkeys';
 import { TabKeys as DataProductTabKeys } from '@/pages/data-product/components/data-product-tabs/data-product-tabkeys';
@@ -34,7 +33,6 @@ import {
     isEnvironmentConfigCreatePage,
     isEnvironmentConfigsPage,
 } from '@/utils/routes.helper.ts';
-
 import styles from './breadcrumbs.module.scss';
 
 type BreadcrumbType = Partial<BreadcrumbItemType & BreadcrumbSeparatorType> & { icon?: ReactNode };
@@ -97,7 +95,7 @@ export const Breadcrumbs = () => {
                     Object.assign(breadcrumbItem, {
                         title: (
                             <Space classNames={{ item: styles.breadcrumbItem }}>
-                                <Icon component={dataProductOutlineIcon} />
+                                <DataProductOutlined />
                                 {t('Data Products')}
                             </Space>
                         ),
@@ -112,7 +110,7 @@ export const Breadcrumbs = () => {
                     Object.assign(breadcrumbItem, {
                         title: (
                             <Space classNames={{ item: styles.breadcrumbItem }}>
-                                <Icon component={datasetOutlineIcon} />
+                                <ShopOutlined />
                                 {t('Marketplace')}
                             </Space>
                         ),
@@ -137,7 +135,7 @@ export const Breadcrumbs = () => {
                     Object.assign(breadcrumbItem, {
                         title: (
                             <Space classNames={{ item: styles.breadcrumbItem }}>
-                                <Icon component={CompassOutlined} />
+                                <CompassOutlined />
                                 {t('Explorer')}
                             </Space>
                         ),
@@ -203,7 +201,11 @@ export const Breadcrumbs = () => {
                     });
 
                     // Case for data product and dataset
-                    if (dataProduct && !isFetchingDataProduct && pathnames.includes('data-products')) {
+                    if (
+                        dataProduct &&
+                        !isFetchingDataProduct &&
+                        pathnames.includes(ApplicationPaths.DataProducts.replace('/', ''))
+                    ) {
                         if (
                             isDataProductEditPage(path, dataProduct.id) ||
                             (dataOutput && isDataOutputEditPage(path, dataOutput.id, dataProduct.id))
@@ -239,7 +241,11 @@ export const Breadcrumbs = () => {
                             }
                         }
                     }
-                    if (dataset && !isFetchingDataset && pathnames.includes('datasets')) {
+                    if (
+                        dataset &&
+                        !isFetchingDataset &&
+                        pathnames.includes(ApplicationPaths.Datasets.replace('/', ''))
+                    ) {
                         if (isDatasetEditPage(path, dataset.id)) {
                             Object.assign(breadcrumbItem, {
                                 title: <Space classNames={{ item: styles.breadcrumbItem }}>{t('Edit')}</Space>,
@@ -248,9 +254,15 @@ export const Breadcrumbs = () => {
                             Object.assign(breadcrumbItem, {
                                 path: `${path}#${DatasetTabKeys.About}`,
                                 title: (
-                                    <Typography.Text ellipsis={{ tooltip: dataset.name }} rootClassName={styles.title}>
-                                        {dataset.name}
-                                    </Typography.Text>
+                                    <Space>
+                                        <DatasetOutlined />
+                                        <Typography.Text
+                                            ellipsis={{ tooltip: dataset.name }}
+                                            rootClassName={styles.title}
+                                        >
+                                            {dataset.name}
+                                        </Typography.Text>
+                                    </Space>
                                 ),
                             });
                         }

--- a/frontend/src/components/layout/sidebar/sidebar.component.tsx
+++ b/frontend/src/components/layout/sidebar/sidebar.component.tsx
@@ -3,6 +3,7 @@ import {
     FileSearchOutlined,
     HomeOutlined,
     SettingOutlined,
+    ShopOutlined,
     TeamOutlined,
     UnorderedListOutlined,
 } from '@ant-design/icons';
@@ -12,7 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { Link, useMatches } from 'react-router';
 
 import { SidebarLogo } from '@/components/branding/sidebar-logo/sidebar-logo.tsx';
-import { DataProductOutlined, DatasetOutlined, ProductLogo } from '@/components/icons';
+import { DataProductOutlined, ProductLogo } from '@/components/icons';
 import { useCheckAccessQuery } from '@/store/features/authorization/authorization-api-slice.ts';
 import { useGetVersionQuery } from '@/store/features/version/version-api-slice';
 import { AuthorizationAction } from '@/types/authorization/rbac-actions.ts';
@@ -21,9 +22,9 @@ import { ApplicationPaths } from '@/types/navigation.ts';
 import styles from './sidebar.module.scss';
 
 export const Sidebar = () => {
+    const { t } = useTranslation();
     const matches = useMatches();
     const { data: version } = useGetVersionQuery();
-    const { t } = useTranslation();
 
     let navigationMenuItems: MenuProps['items'] = [
         {
@@ -38,8 +39,13 @@ export const Sidebar = () => {
         },
         {
             label: <Link to={ApplicationPaths.Datasets}>{t('Marketplace')}</Link>,
-            icon: <DatasetOutlined />,
+            icon: <ShopOutlined />,
             key: ApplicationPaths.Datasets,
+        },
+        {
+            label: <Link to={ApplicationPaths.Explorer}>{t('Explorer')}</Link>,
+            icon: <CompassOutlined />,
+            key: ApplicationPaths.Explorer,
         },
         {
             label: <Link to={ApplicationPaths.People}>{t('People')}</Link>,
@@ -52,16 +58,11 @@ export const Sidebar = () => {
             key: ApplicationPaths.AuditLogs,
         },
         {
-            label: <Link to={ApplicationPaths.Explorer}>{t('Explorer')}</Link>,
-            icon: <CompassOutlined />,
-            key: ApplicationPaths.Explorer,
-        },
-        {
             label: (
                 <a
                     href={`https://d33vpinjygaq6n.cloudfront.net/docs/${version?.version.split('.').slice(0, 2).join('.')}.x/intro`}
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                 >
                     {t('Documentation')}
                 </a>

--- a/frontend/src/pages/data-product/components/data-product-tabs/data-product-tabs.tsx
+++ b/frontend/src/pages/data-product/components/data-product-tabs/data-product-tabs.tsx
@@ -1,7 +1,7 @@
 import Icon, {
+    CompassOutlined,
     HistoryOutlined,
     InfoCircleOutlined,
-    PartitionOutlined,
     SettingOutlined,
     TeamOutlined,
 } from '@ant-design/icons';
@@ -70,12 +70,6 @@ export function DataProductTabs({ dataProductId, isLoading }: Props) {
                 children: <DatasetTab dataProductId={dataProductId} />,
             },
             {
-                label: t('Team'),
-                key: TabKeys.Team,
-                icon: <TeamOutlined />,
-                children: <TeamTab dataProductId={dataProductId} />,
-            },
-            {
                 label: t('Data Outputs'),
                 key: TabKeys.DataOutputs,
                 icon: <Icon component={dataOutputOutlineIcon} />,
@@ -84,8 +78,14 @@ export function DataProductTabs({ dataProductId, isLoading }: Props) {
             {
                 label: t('Explorer'),
                 key: TabKeys.Explorer,
-                icon: <PartitionOutlined />,
+                icon: <CompassOutlined />,
                 children: <Explorer id={dataProductId} type={'dataproduct'} />,
+            },
+            {
+                label: t('Team'),
+                key: TabKeys.Team,
+                icon: <TeamOutlined />,
+                children: <TeamTab dataProductId={dataProductId} />,
             },
             {
                 label: t('Settings'),

--- a/frontend/src/pages/dataset/components/dataset-tabs/dataset-tabs.tsx
+++ b/frontend/src/pages/dataset/components/dataset-tabs/dataset-tabs.tsx
@@ -1,10 +1,4 @@
-import {
-    HistoryOutlined,
-    InfoCircleOutlined,
-    PartitionOutlined,
-    SettingOutlined,
-    TeamOutlined,
-} from '@ant-design/icons';
+import { CompassOutlined, HistoryOutlined, InfoCircleOutlined, SettingOutlined, TeamOutlined } from '@ant-design/icons';
 import { Tabs } from 'antd';
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -70,12 +64,6 @@ export function DatasetTabs({ datasetId, isLoading }: Props) {
                 children: <DataOutputTab datasetId={datasetId} />,
             },
             {
-                label: t('Team'),
-                key: TabKeys.Team,
-                icon: <TeamOutlined />,
-                children: <TeamTab datasetId={datasetId} />,
-            },
-            {
                 label: t('Consuming Data Products'),
                 key: TabKeys.DataProduct,
                 icon: <DataProductOutlined />,
@@ -84,8 +72,14 @@ export function DatasetTabs({ datasetId, isLoading }: Props) {
             {
                 label: t('Explorer'),
                 key: TabKeys.Explorer,
-                icon: <PartitionOutlined />,
+                icon: <CompassOutlined />,
                 children: <Explorer id={datasetId} type={'dataset'} />,
+            },
+            {
+                label: t('Team'),
+                key: TabKeys.Team,
+                icon: <TeamOutlined />,
+                children: <TeamTab datasetId={datasetId} />,
             },
             {
                 label: t('Settings'),

--- a/frontend/src/styles/_globals.scss
+++ b/frontend/src/styles/_globals.scss
@@ -74,7 +74,6 @@ h6 {
 
         .ant-tabs-tabpane {
             height: 100%;
-            overflow-y: auto;
         }
     }
 }


### PR DESCRIPTION
- Change icon of the marketplace to <ShopOutlined />
- Use <CompassOutlined /> as icon for the explorer everywhere
- Standardize on order of tabs in the menu as in the detail pages.
  Proposed order: Home/About > Data Products > Marketplace/Datasets > Explorer > People/Team > Settings