### PR TITLE
Events referencing only the object itself are not rendered correctly and crash the entire history page

### DIFF
--- a/frontend/src/components/history/history-table-event-name.tsx
+++ b/frontend/src/components/history/history-table-event-name.tsx
@@ -21,10 +21,8 @@ export function HistoryTableEventName({ record, resourceId, type }: HistoryTable
     const { t } = useTranslation();
     const navigate = useNavigate();
 
-    console.log(record);
     const { target_id, subject_id, subject_type, target_type, deleted_subject_identifier, deleted_target_identifier } =
         record;
-    console.log(!(subject_id === resourceId && type === subject_type));
     if (!(subject_id === resourceId && type === subject_type)) {
         const path = getEventReferenceEntityLinkPath(
             subject_id,

--- a/frontend/src/components/history/history-table-event-name.tsx
+++ b/frontend/src/components/history/history-table-event-name.tsx
@@ -21,9 +21,10 @@ export function HistoryTableEventName({ record, resourceId, type }: HistoryTable
     const { t } = useTranslation();
     const navigate = useNavigate();
 
+    console.log(record);
     const { target_id, subject_id, subject_type, target_type, deleted_subject_identifier, deleted_target_identifier } =
         record;
-
+    console.log(!(subject_id === resourceId && type === subject_type));
     if (!(subject_id === resourceId && type === subject_type)) {
         const path = getEventReferenceEntityLinkPath(
             subject_id,
@@ -77,6 +78,5 @@ export function HistoryTableEventName({ record, resourceId, type }: HistoryTable
             </Typography.Text>
         );
     }
-
-    throw new Error(`Unable to render event ${record}`);
+    return <Typography.Text>{getEventTypeDisplayName(t, record.name, undefined, '', <></>)}</Typography.Text>;
 }

--- a/frontend/src/utils/history.helper.tsx
+++ b/frontend/src/utils/history.helper.tsx
@@ -6,7 +6,7 @@ import { EventReferenceEntity } from '@/types/events/event-reference-entity';
 import { EventType } from '@/types/events/event-types';
 import { createDataOutputIdPath, createDataProductIdPath, createDatasetIdPath } from '@/types/navigation';
 
-export function getTypeDisplayName(t: TFunction, type: EventReferenceEntity): string {
+export function getTypeDisplayName(t: TFunction, type: EventReferenceEntity | undefined): string {
     switch (type) {
         case EventReferenceEntity.Dataset:
             return t('Dataset');
@@ -16,6 +16,8 @@ export function getTypeDisplayName(t: TFunction, type: EventReferenceEntity): st
             return t('Data Output');
         case EventReferenceEntity.User:
             return t('User');
+        default:
+            return t('Unknown');
     }
 }
 
@@ -77,7 +79,7 @@ export function getEventReferenceEntityLinkPath(
 export function getEventTypeDisplayName(
     t: TFunction,
     event_type: EventType,
-    entity_reference: EventReferenceEntity,
+    entity_reference: EventReferenceEntity | undefined,
     entity: string,
     element: ReactElement,
 ): ReactNode {


### PR DESCRIPTION
Events only show information about other subjects or targets.
Events that don't have this information (e.g. update of tags on a data product) are currently bugged.
When this event happens on a subject, the entire history page crashes because of a single unrenderable event.