### PR TITLE
Feature/posthog extra events v2 clean

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
   rev: v1.16.1
   hooks:
     - id: mypy
+      language_version: python3.12
       additional_dependencies:
       - types-cachetools
       - types-requests
@@ -42,6 +43,7 @@ repos:
   rev: 7.1.1
   hooks:
     - id: flake8
+      language_version: python3.12
       additional_dependencies: [flake8-black]
 - repo: https://github.com/psf/black-pre-commit-mirror
   rev: 25.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
     - id: isort
       name: isort (python)
 - repo: https://github.com/gitleaks/gitleaks
-  rev: v8.23.2
+  rev: v8.27.2
   hooks:
     - id: gitleaks
 - repo: local

--- a/backend/app/core/namespace/validation.py
+++ b/backend/app/core/namespace/validation.py
@@ -1,6 +1,6 @@
 import re
 from enum import Enum
-from typing import ClassVar, Optional
+from typing import Final, Optional
 
 from pydantic import BaseModel
 from sqlalchemy import UUID, and_, exists, select
@@ -33,7 +33,7 @@ class NamespaceLengthLimits(BaseModel):
 
 
 class NamespaceValidator:
-    max_length: ClassVar[int] = settings.NAMESPACE_MAX_LENGTH
+    max_length: Final[int] = settings.NAMESPACE_MAX_LENGTH
 
     def __init__(self, model: Base):
         self.model = model

--- a/backend/app/core/namespace/validation.py
+++ b/backend/app/core/namespace/validation.py
@@ -1,6 +1,6 @@
 import re
 from enum import Enum
-from typing import ClassVar, Final, Optional
+from typing import ClassVar, Optional
 
 from pydantic import BaseModel
 from sqlalchemy import UUID, and_, exists, select
@@ -33,7 +33,7 @@ class NamespaceLengthLimits(BaseModel):
 
 
 class NamespaceValidator:
-    max_length: ClassVar[Final[int]] = settings.NAMESPACE_MAX_LENGTH
+    max_length: ClassVar[int] = settings.NAMESPACE_MAX_LENGTH
 
     def __init__(self, model: Base):
         self.model = model

--- a/frontend/src/components/data-products/data-product-form/data-product-form.component.tsx
+++ b/frontend/src/components/data-products/data-product-form/data-product-form.component.tsx
@@ -1,11 +1,12 @@
 import { Button, Col, Form, type FormProps, Input, Popconfirm, Row, Select, Skeleton, Space } from 'antd';
+import posthog from 'posthog-js';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import { useDebouncedCallback } from 'use-debounce';
-
 import { NamespaceFormItem } from '@/components/namespace/namespace-form-item';
 import { FORM_GRID_WRAPPER_COLS, MAX_DESCRIPTION_INPUT_LENGTH } from '@/constants/form.constants.ts';
+import { PosthogEvents } from '@/constants/posthog.constants';
 import { useCheckAccessQuery } from '@/store/features/authorization/authorization-api-slice.ts';
 import { useGetAllDataProductLifecyclesQuery } from '@/store/features/data-product-lifecycles/data-product-lifecycles-api-slice';
 import { useGetAllDataProductTypesQuery } from '@/store/features/data-product-types/data-product-types-api-slice.ts';
@@ -27,7 +28,6 @@ import type { DataProductCreate, DataProductCreateFormSchema, DataProductUpdateR
 import { ApplicationPaths, createDataProductIdPath } from '@/types/navigation.ts';
 import { useGetDataProductOwnerIds } from '@/utils/data-product-user-role.helper.ts';
 import { selectFilterOptionByLabel, selectFilterOptionByLabelAndValue } from '@/utils/form.helper.ts';
-
 import styles from './data-product-form.module.scss';
 
 const { TextArea } = Input;
@@ -117,6 +117,8 @@ export function DataProductForm({ mode, dataProductId }: Props) {
                 };
                 const response = await createDataProduct(request).unwrap();
                 dispatchMessage({ content: t('Data product created successfully'), type: 'success' });
+
+                posthog.capture(PosthogEvents.CREATE_DATA_PRODUCT_COMPLETED);
 
                 navigate(createDataProductIdPath(response.id));
             } else if (mode === 'edit' && dataProductId) {

--- a/frontend/src/config/posthog-config.ts
+++ b/frontend/src/config/posthog-config.ts
@@ -2,7 +2,7 @@ import posthog from 'posthog-js';
 
 posthog.init(config.POSTHOG_KEY, {
     api_host: config.POSTHOG_HOST,
-    autocapture: true,
+    autocapture: false,
     capture_pageview: true,
     person_profiles: 'never', // do not link events with personal information (profiles)
 });

--- a/frontend/src/constants/posthog.constants.ts
+++ b/frontend/src/constants/posthog.constants.ts
@@ -5,5 +5,9 @@ export enum PosthogEvents {
     MARKETPLACE_DATASET_TAB_CLICKED = 'marketplace_dataset_tab_clicked',
     MARKETPLACE_FILTER_USED = 'marketplace_filter_used',
 
+    DATA_PRODUCTS_TAB_CLICKED = 'data_products_tab_clicked',
     DATA_PRODUCTS_FILTER_USED = 'data_products_filter_used',
+    DATA_PRODUCTS_PLATFORM_ACCESS = 'data_products_platform_access',
+    CREATE_DATA_PRODUCT_STARTED = 'create_data_product_started',
+    CREATE_DATA_PRODUCT_COMPLETED = 'create_data_product_completed',
 }

--- a/frontend/src/pages/data-product/components/data-product-actions/data-product-actions.component.tsx
+++ b/frontend/src/pages/data-product/components/data-product-actions/data-product-actions.component.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import { DataAccessTileGrid } from '@/components/data-access/data-access-tile-grid/data-access-tile-grid.tsx';
+import posthog from '@/config/posthog-config';
+import { PosthogEvents } from '@/constants/posthog.constants';
 import { DataProductRequestAccessButton } from '@/pages/data-product/components/data-product-request-access-button/data-product-request-access-button.tsx';
 import { selectCurrentUser } from '@/store/features/auth/auth-slice.ts';
 import { useCheckAccessQuery } from '@/store/features/authorization/authorization-api-slice';
@@ -21,7 +23,6 @@ import { AuthorizationAction } from '@/types/authorization/rbac-actions';
 import { type DataPlatform, DataPlatforms } from '@/types/data-platform';
 import { DecisionStatus } from '@/types/roles';
 import { getDataPlatforms } from '@/utils/data-platforms';
-
 import styles from './data-product-actions.module.scss';
 
 type Props = {
@@ -80,6 +81,10 @@ export function DataProductActions({ dataProductId }: Props) {
     }
 
     async function handleAccessToData(environment: string, dataPlatform: DataPlatform) {
+        posthog.capture(PosthogEvents.DATA_PRODUCTS_PLATFORM_ACCESS, {
+            platform_name: dataPlatform,
+        });
+
         switch (dataPlatform) {
             case DataPlatforms.AWS:
                 try {

--- a/frontend/src/pages/data-product/components/data-product-tabs/data-product-tabs.tsx
+++ b/frontend/src/pages/data-product/components/data-product-tabs/data-product-tabs.tsx
@@ -15,6 +15,8 @@ import datasetOutlineIcon from '@/assets/icons/dataset-outline-icon.svg?react';
 import { Explorer } from '@/components/explorer/explorer';
 import { HistoryTab } from '@/components/history/history-tab';
 import { LoadingSpinner } from '@/components/loading/loading-spinner/loading-spinner.tsx';
+import posthog from '@/config/posthog-config';
+import { PosthogEvents } from '@/constants/posthog.constants';
 import { AboutTab } from '@/pages/data-product/components/data-product-tabs/about-tab/about-tab.tsx';
 import { DataOutputTab } from '@/pages/data-product/components/data-product-tabs/data-output-tab/data-output-tab.tsx';
 import { TabKeys } from '@/pages/data-product/components/data-product-tabs/data-product-tabkeys.ts';
@@ -22,7 +24,6 @@ import { DatasetTab } from '@/pages/data-product/components/data-product-tabs/da
 import { TeamTab } from '@/pages/data-product/components/data-product-tabs/team-tab/team-tab.tsx';
 import { useGetDataProductHistoryQuery } from '@/store/features/data-products/data-products-api-slice';
 import { EventReferenceEntity } from '@/types/events/event-reference-entity';
-
 import styles from './data-product-tabs.module.scss';
 import { SettingsTab } from './settings-tab/settings-tab';
 
@@ -47,6 +48,12 @@ export function DataProductTabs({ dataProductId, isLoading }: Props) {
         { skip: !dataProductId },
     );
     const [activeTab, setActiveTab] = useState(location.hash.slice(1) || TabKeys.About);
+
+    useEffect(() => {
+        posthog.capture(PosthogEvents.DATA_PRODUCTS_TAB_CLICKED, {
+            tab_name: activeTab,
+        });
+    }, [activeTab]);
 
     useEffect(() => {
         const hash = location.hash.slice(1);

--- a/frontend/src/pages/data-products/components/data-products-table/data-products-table.component.tsx
+++ b/frontend/src/pages/data-products/components/data-products-table/data-products-table.component.tsx
@@ -83,7 +83,10 @@ export function DataProductsTable() {
                     </Form.Item>
                 </Form>
                 <Space>
-                    <Link to={ApplicationPaths.DataProductNew}>
+                    <Link
+                        to={ApplicationPaths.DataProductNew}
+                        onClick={() => posthog.capture(PosthogEvents.CREATE_DATA_PRODUCT_STARTED)}
+                    >
                         <Button className={styles.formButton} type={'primary'} disabled={!canCreateDataProduct}>
                             {t('Create Data Product')}
                         </Button>


### PR DESCRIPTION
Added additional capturing of events for Posthog (4 events, enumerated in `frontend/src/constants/posthog.constants.ts`).

To let all pre-commit tests pass locally:
 - updated gitleaks version and specified python version in `.pre-commit-config.yaml`
 - removed ClassVar in `backend/app/core/namespace/validation.py`. [PEP 591](https://peps.python.org/pep-0591/) specifies they shouldn't be used together (and in some python versions, they're not allowed to be used together).