### PR TITLE
added POSTHOG_ENABLED environment variable

### DIFF
--- a/frontend/config.docker.js
+++ b/frontend/config.docker.js
@@ -47,5 +47,6 @@ const config = (() => {
          */
         POSTHOG_KEY: 'phc_NDxOG0gXQtkPItPFJXLOAQhLmbZw7v0SbIQesSWO4gc',
         POSTHOG_HOST: 'https://eu.i.posthog.com',
+        POSTHOG_ENABLED: false,
     };
 })();

--- a/frontend/src/config/app-config.ts
+++ b/frontend/src/config/app-config.ts
@@ -53,6 +53,7 @@ interface Config {
      */
     POSTHOG_KEY: string;
     POSTHOG_HOST: string;
+    POSTHOG_ENABLED: boolean;
 }
 
 declare global {

--- a/frontend/src/config/posthog-config.ts
+++ b/frontend/src/config/posthog-config.ts
@@ -7,4 +7,11 @@ posthog.init(config.POSTHOG_KEY, {
     person_profiles: 'never', // do not link events with personal information (profiles)
 });
 
+if (config.POSTHOG_ENABLED) {
+    posthog.opt_in_capturing(); // technically redundant (is default)
+} else {
+    posthog.opt_out_capturing();
+}
+    
+
 export default posthog;

--- a/helm/templates/configmap_frontend.yaml
+++ b/helm/templates/configmap_frontend.yaml
@@ -13,6 +13,7 @@ data:
                 THEME_CONFIGURATION: "{{ .Values.theme_configuration }}",
                 POSTHOG_KEY: "{{ .Values.posthog.key }}",
                 POSTHOG_HOST: "{{ .Values.posthog.host }}",
+                POSTHOG_ENABLED: "{{ .Values.posthog.enabled }}",
             }
         })();
 kind: ConfigMap


### PR DESCRIPTION
@vlieven is this a good way to introduce an option of not letting Posthog track? The default in `frontend/config.docker.js` is set to false. I'm not sure if I should make changes elsewhere aswell. Looking forward to feedback.