### PR TITLE
When new data product / dataset is created, propagate the new owner roles to casbin

### DIFF
--- a/backend/app/data_products/router.py
+++ b/backend/app/data_products/router.py
@@ -35,6 +35,7 @@ from app.events.schema_response import EventGet
 from app.events.service import EventService
 from app.graph.graph import Graph
 from app.notifications.service import NotificationService
+from app.role_assignments.data_product.auth import DataProductAuthAssignment
 from app.role_assignments.data_product.schema import (
     CreateRoleAssignment,
     UpdateRoleAssignment,
@@ -169,10 +170,11 @@ def _assign_owner_role_assignments(
             ),
             actor=actor,
         )
-        assignment_service.update_assignment(
+        assignment = assignment_service.update_assignment(
             UpdateRoleAssignment(id=response.id, decision=DecisionStatus.APPROVED),
             actor=actor,
         )
+        DataProductAuthAssignment(assignment).add()
         EventService(db).create_event(
             CreateEvent(
                 name=EventType.DATA_PRODUCT_ROLE_ASSIGNMENT_CREATED,

--- a/backend/app/datasets/router.py
+++ b/backend/app/datasets/router.py
@@ -29,6 +29,7 @@ from app.events.schema_response import EventGet
 from app.events.service import EventService
 from app.graph.graph import Graph
 from app.notifications.service import NotificationService
+from app.role_assignments.dataset.auth import DatasetAuthAssignment
 from app.role_assignments.dataset.schema import (
     CreateRoleAssignment,
     UpdateRoleAssignment,
@@ -158,10 +159,11 @@ def _assign_owner_role_assignments(
             ),
             actor=actor,
         )
-        assignment_service.update_assignment(
+        assignment = assignment_service.update_assignment(
             UpdateRoleAssignment(id=assignment.id, decision=DecisionStatus.APPROVED),
             actor=actor,
         )
+        DatasetAuthAssignment(assignment).add()
         event_service.create_event(
             CreateEvent(
                 name=EventType.DATASET_ROLE_ASSIGNMENT_CREATED,


### PR DESCRIPTION
New data products or datasets create the role assignments but they are not propagated to casbin correctly.