### PR TITLE
Correct disabling of posthog analytics

### DIFF
--- a/frontend/src/config/posthog-config.ts
+++ b/frontend/src/config/posthog-config.ts
@@ -1,14 +1,13 @@
 import posthog from 'posthog-js';
 
-posthog.init(config.POSTHOG_KEY, {
-    api_host: config.POSTHOG_HOST,
-    autocapture: false,
-    capture_pageview: false,
-    disable_session_recording: true,
-    person_profiles: 'identified_only',
-});
-
 if (config.POSTHOG_ENABLED) {
+    posthog.init(config.POSTHOG_KEY, {
+        api_host: config.POSTHOG_HOST,
+        autocapture: false,
+        capture_pageview: false,
+        disable_session_recording: true,
+        person_profiles: 'identified_only',
+    });
     posthog.opt_in_capturing(); // technically redundant (is default)
 } else {
     posthog.opt_out_capturing();

--- a/helm/templates/configmap_backend.yaml
+++ b/helm/templates/configmap_backend.yaml
@@ -32,3 +32,10 @@ data:
   WEBHOOK_URL: {{ .Values.webhook.url }}
   {{- end }}
   NAMESPACE_MAX_LENGTH: {{ .Values.namespace_max_length }}
+  {{- if .Values.posthog.enabled }}
+  POSTHOG_ENABLED: "true"
+  {{- else }}
+  POSTHOG_ENABLED: "false"
+  {{- end }}
+  POSTHOG_API_KEY: {{ .Values.posthog.key }}
+  POSTHOG_HOST: {{ .Values.posthog.host }}

--- a/helm/templates/configmap_frontend.yaml
+++ b/helm/templates/configmap_frontend.yaml
@@ -13,7 +13,7 @@ data:
                 THEME_CONFIGURATION: "{{ .Values.theme_configuration }}",
                 POSTHOG_KEY: "{{ .Values.posthog.key }}",
                 POSTHOG_HOST: "{{ .Values.posthog.host }}",
-                POSTHOG_ENABLED: "{{ .Values.posthog.enabled }}",
+                POSTHOG_ENABLED: {{ .Values.posthog.enabled }},
             }
         })();
 kind: ConfigMap


### PR DESCRIPTION
Posthog analytics were always enabled (because of the stringified boolean in Helm)
If disabled Posthog used to still be booted and send some initial events.