### PR TITLE
Small improvements for frontend build

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.idea
+Dockerfile

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,10 +5,7 @@ WORKDIR /app
 COPY . .
 
 # Install all the dependencies
-RUN npm ci
-
-# Build the application in production mode
-RUN npm run build:prd
+RUN --mount=type=cache,target=/app/node_modules npm ci && npm run build:prd
 
 # Use official nginx image as the base image
 FROM --platform=${PLATFORM} nginx:1.29.2-alpine@sha256:7c1b9a91514d1eb5288d7cd6e91d9f451707911bfaea9307a3acbc811d4aa82e
@@ -17,11 +14,10 @@ FROM --platform=${PLATFORM} nginx:1.29.2-alpine@sha256:7c1b9a91514d1eb5288d7cd6e
 COPY --from=build-stage /app/dist /app/dist
 
 # Copy the nginx config
-COPY --from=build-stage /app/deploy/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY deploy/nginx/nginx.conf /etc/nginx/nginx.conf
 
 # Copy the entrypoint and configuration setup scripts
-COPY --from=build-stage /app/deploy/entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
+COPY --chmod=+x deploy/entrypoint.sh /app/entrypoint.sh
 
 WORKDIR /app
 


### PR DESCRIPTION
Utilise caching volume when installing
node modules to ensure we can reuse the folder.

Also migrated copy + run into single copy with chmod.

Also added .dockerignore to ensure we do not copy
node modules from local machine