### PR TITLE
Remove popover from cart button

### DIFF
--- a/frontend/src/components/cart/cart-button.component.tsx
+++ b/frontend/src/components/cart/cart-button.component.tsx
@@ -1,20 +1,15 @@
 import { ShoppingCartOutlined } from '@ant-design/icons';
-import { Badge, Button, Flex, Popover } from 'antd';
+import { Badge, Button } from 'antd';
 import { useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router';
-import { CartOverview } from '@/components/cart/cart-overview.component.tsx';
 import styles from '@/components/layout/navbar/cli-download/cli-download-button.module.scss';
-import { useAppDispatch } from '@/store';
-import { clearCart, selectCartDatasetIds } from '@/store/features/cart/cart-slice.ts';
+import { selectCartDatasetIds } from '@/store/features/cart/cart-slice.ts';
 import { useGetAllDatasetsQuery } from '@/store/features/datasets/datasets-api-slice.ts';
 import { ApplicationPaths } from '@/types/navigation.ts';
 
 export const CartButton = () => {
-    const { t } = useTranslation();
-    const dispatch = useAppDispatch();
-    const { data: datasets, isFetching } = useGetAllDatasetsQuery();
+    const { data: datasets } = useGetAllDatasetsQuery();
     const cartDatasetIds = useSelector(selectCartDatasetIds);
     const cartDatasets = useMemo(() => {
         if (!datasets || cartDatasetIds.length === 0) {
@@ -23,40 +18,10 @@ export const CartButton = () => {
         return datasets?.filter((dataset) => cartDatasetIds.includes(dataset.id));
     }, [datasets, cartDatasetIds]);
     return (
-        <Popover
-            content={
-                <div style={{ width: '500px' }}>
-                    <CartOverview
-                        cartDatasets={cartDatasets}
-                        loading={isFetching}
-                        footer={
-                            <Flex justify={'flex-end'} gap={'small'}>
-                                <Button
-                                    onClick={() => {
-                                        dispatch(clearCart());
-                                    }}
-                                    disabled={cartDatasets.length === 0}
-                                >
-                                    {t('Clear cart')}
-                                </Button>
-                                <Link to={ApplicationPaths.MarketplaceCart}>
-                                    <Button type="primary" disabled={cartDatasets.length === 0}>
-                                        {t('Checkout')}
-                                    </Button>
-                                </Link>
-                            </Flex>
-                        }
-                    />
-                </div>
-            }
-            trigger={'hover'}
-            placement="bottom"
-        >
-            <Badge count={cartDatasets?.length}>
-                <Link to={ApplicationPaths.MarketplaceCart}>
-                    <Button shape={'circle'} className={styles.iconButton} icon={<ShoppingCartOutlined />} />
-                </Link>
-            </Badge>
-        </Popover>
+        <Badge count={cartDatasets?.length}>
+            <Link to={ApplicationPaths.MarketplaceCart}>
+                <Button shape={'circle'} className={styles.iconButton} icon={<ShoppingCartOutlined />} />
+            </Link>
+        </Badge>
     );
 };

--- a/frontend/src/pages/cart/cart.page.tsx
+++ b/frontend/src/pages/cart/cart.page.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Link, useNavigate } from 'react-router';
-import { CartOverview } from '@/components/cart/cart-overview.component.tsx';
+import { CartOverview } from '@/pages/cart/components/cart-overview.component.tsx';
 import { TabKeys as DataProductTabKeys } from '@/pages/data-product/components/data-product-tabs/data-product-tabkeys.ts';
 import { useAppDispatch } from '@/store';
 import { selectCurrentUser } from '@/store/features/auth/auth-slice.ts';
@@ -146,13 +146,6 @@ export function Cart() {
                     loading={fetchingDatasets}
                     cartDatasets={cartDatasets}
                     overlappingDatasetIds={overlappingDatasetIds}
-                    footer={
-                        <Flex justify={'flex-end'}>
-                            {t('{{count}} output ports', {
-                                count: cartDatasets?.length || 0,
-                            })}
-                        </Flex>
-                    }
                     selectedDataProductId={selectedDataProductId}
                 />
             </Col>
@@ -194,7 +187,7 @@ export function Cart() {
                                 style={{ marginBottom: 16 }}
                             />
                         )}
-                        <Form.Item<FieldType>
+                        <Form.Item<CartFormData>
                             name="justification"
                             label={'Business justification'}
                             rules={[

--- a/frontend/src/pages/cart/components/cart-overview.component.tsx
+++ b/frontend/src/pages/cart/components/cart-overview.component.tsx
@@ -1,6 +1,5 @@
 import { DeleteOutlined, WarningOutlined } from '@ant-design/icons';
 import { Button, Card, Descriptions, Flex, List, Space, Tag, Tooltip, Typography } from 'antd';
-import type * as React from 'react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
@@ -100,7 +99,6 @@ function CartOverviewItem({ dataset, overlapping, selectedDataProductId }: CartO
 }
 
 type CartOverviewProps = {
-    footer?: React.ReactNode;
     cartDatasets?: DatasetsGetContractSingle[];
     overlappingDatasetIds?: string[];
     loading?: boolean;
@@ -108,7 +106,6 @@ type CartOverviewProps = {
 };
 
 export const CartOverview = ({
-    footer,
     cartDatasets,
     loading,
     overlappingDatasetIds,
@@ -123,7 +120,13 @@ export const CartOverview = ({
     return (
         <Card title={<Typography.Title level={3}>Checkout summary</Typography.Title>}>
             <List
-                footer={footer}
+                footer={
+                    <Flex justify={'flex-end'}>
+                        {t('{{count}} output ports', {
+                            count: cartDatasets?.length || 0,
+                        })}
+                    </Flex>
+                }
                 style={{ width: '100%' }}
                 loading={loading}
                 dataSource={cartDatasets}


### PR DESCRIPTION
It was confusing that clicking on the cart
brought you to checkout, but also it had
the popover.

After some investigation we noticed that 2 out
of the 3 online stores we tested just bring you
to the checkout page.
And only one had the popover, but on click
instead. Which meant more clicks, so decided
to reduce clicks to 1 and bring you to check out
in one click.

In support of: #1917