### PR TITLE
Configure flake8 max line lenght

### DIFF
--- a/backend/.flake8
+++ b/backend/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88


### PR DESCRIPTION
The default for flake8 is 79, but for
black the default is 88.
So I set them to to same value

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md)
- [x] When updating the UI please provide screenshots or videos to the reviewers
