### PR TITLE
Revert "Bump python from 3.13.7-slim-bookworm to 3.14.1-slim-bookworm in /backend"

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 ARG PLATFORM=linux/amd64
-FROM --platform=${PLATFORM} python:3.14.1-slim-bookworm@sha256:5d17fc066275d26bb2ffe05bc89367dc665310200b5f4cfa8b294e97dc679bff AS base-image
+FROM --platform=${PLATFORM} python:3.13.7-slim-bookworm@sha256:adafcc17694d715c905b4c7bebd96907a1fd5cf183395f0ebc4d3428bd22d92d AS base-image
 
 FROM base-image AS build-stage
 


### PR DESCRIPTION
Reverts conveyordata/data-product-portal#2198