### PR TITLE
Fix cascading delete bug on output port summaries, add multiple tests

### DIFF
--- a/backend/app/data_products/output_ports/model.py
+++ b/backend/app/data_products/output_ports/model.py
@@ -101,7 +101,10 @@ class Dataset(Base, BaseORM):
         back_populates="datasets", lazy="joined"
     )
     quality_summary: Mapped[Optional[DataQualitySummary]] = relationship(
-        foreign_keys=[DataQualitySummary.output_port_id], lazy="joined", uselist=False
+        foreign_keys=[DataQualitySummary.output_port_id],
+        lazy="joined",
+        uselist=False,
+        cascade="all, delete-orphan",
     )
 
     @property

--- a/backend/app/database/alembic/versions/2026_03_20_1514-d838b01d5e6a_add_foreign_key_on_data_quality_output_.py
+++ b/backend/app/database/alembic/versions/2026_03_20_1514-d838b01d5e6a_add_foreign_key_on_data_quality_output_.py
@@ -1,0 +1,37 @@
+"""add foreign key on data quality output ports
+
+Revision ID: d838b01d5e6a
+Revises: a1b2c3d4e5f6
+Create Date: 2026-03-20 15:14:27.775713
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d838b01d5e6a"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add foreign key constraint to output_port_data_quality_summaries table
+    op.create_foreign_key(
+        "fk_output_port_data_quality_summaries_output_port_id",
+        "output_port_data_quality_summaries",
+        "datasets",
+        ["output_port_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_output_port_data_quality_summaries_output_port_id",
+        "output_port_data_quality_summaries",
+        type_="foreignkey",
+    )

--- a/backend/tests/app/data_products/output_ports/curated_queries/test_router.py
+++ b/backend/tests/app/data_products/output_ports/curated_queries/test_router.py
@@ -15,7 +15,8 @@ from tests.factories import (
     UserFactory,
 )
 
-ENDPOINT = "/api/datasets"
+OLD_ENDPOINT = "/api/datasets"
+ENDPOINT = "/api/v2/data_products"
 
 
 def _assign_update_role(session, dataset):
@@ -23,7 +24,10 @@ def _assign_update_role(session, dataset):
     user = UserFactory(external_id=settings.DEFAULT_USERNAME)
     role = RoleFactory(
         scope=Scope.DATASET,
-        permissions=[AuthorizationAction.OUTPUT_PORT__UPDATE_PROPERTIES],
+        permissions=[
+            AuthorizationAction.OUTPUT_PORT__UPDATE_PROPERTIES,
+            AuthorizationAction.OUTPUT_PORT__DELETE,
+        ],
     )
     DatasetRoleAssignmentFactory(
         user_id=user.id, role_id=role.id, dataset_id=dataset.id
@@ -52,13 +56,34 @@ class TestCuratedQueriesRouter:
         }
 
         put_response = client.put(
-            f"{ENDPOINT}/{dataset.id}/usage/curated_queries", json=payload
+            f"{OLD_ENDPOINT}/{dataset.id}/usage/curated_queries", json=payload
         )
         assert put_response.status_code == 200
         body = put_response.json()
         assert len(body["dataset_curated_queries"]) == 2
         assert body["dataset_curated_queries"][0]["title"] == "Top enrolling sites"
         assert body["dataset_curated_queries"][1]["title"] == "New deviations"
+
+    def test_delete_output_port_curated_query(self, client, session):
+        dataset = DatasetFactory()
+        _assign_update_role(session, dataset)
+
+        service = DatasetCuratedQueryService(session)
+        service.replace_curated_queries(
+            dataset.id,
+            [
+                OutputPortCuratedQueryInput(
+                    title="Existing query",
+                    description="Stored during setup",
+                    query_text="SELECT 1",
+                )
+            ],
+        )
+        response = client.delete(
+            f"{ENDPOINT}/{dataset.data_product.id}/output_ports/{dataset.id}"
+        )
+
+        assert response.status_code == 200
 
     def test_curated_queries_get(self, client, session):
         dataset = DatasetFactory()
@@ -76,7 +101,7 @@ class TestCuratedQueriesRouter:
             ],
         )
 
-        get_response = client.get(f"{ENDPOINT}/{dataset.id}/usage/curated_queries")
+        get_response = client.get(f"{OLD_ENDPOINT}/{dataset.id}/usage/curated_queries")
         assert get_response.status_code == 200
         data = get_response.json()
         assert len(data["dataset_curated_queries"]) == 1

--- a/backend/tests/app/data_products/output_ports/data_quality/test_router.py
+++ b/backend/tests/app/data_products/output_ports/data_quality/test_router.py
@@ -27,7 +27,10 @@ def _assign_update_role(session, dataset):
     user = UserFactory(external_id=settings.DEFAULT_USERNAME)
     role = RoleFactory(
         scope=Scope.DATASET,
-        permissions=[AuthorizationAction.OUTPUT_PORT__UPDATE_DATA_QUALITY],
+        permissions=[
+            AuthorizationAction.OUTPUT_PORT__UPDATE_DATA_QUALITY,
+            AuthorizationAction.OUTPUT_PORT__DELETE,
+        ],
     )
     DatasetRoleAssignmentFactory(
         user_id=user.id, role_id=role.id, dataset_id=dataset.id
@@ -113,6 +116,24 @@ class TestDataQualityRouter:
         assert get_response.status_code == 404
         data = get_response.json()
         assert "No data quality summary found for output port" in data["detail"]
+
+    def test_delete_output_port_data_quality_summary(self, client, session):
+        dataset = DatasetFactory()
+        _assign_update_role(session, dataset)
+
+        service = OutputPortDataQualityService(session)
+        service.save_data_quality_summary(
+            dataset.id,
+            OutputPortDataQualitySummary(
+                created_at=datetime.now(UTC) - timedelta(days=1),
+                overall_status=DataQualityStatus.FAILURE,
+                technical_assets=[],
+            ),
+        )
+        response = client.delete(
+            f"{ENDPOINT}/{dataset.data_product.id}/output_ports/{dataset.id}"
+        )
+        assert response.status_code == 200
 
     def test_get_latest_data_quality_result(self, client, session):
         dataset = DatasetFactory()

--- a/backend/tests/app/data_products/technical_assets/test_router.py
+++ b/backend/tests/app/data_products/technical_assets/test_router.py
@@ -245,6 +245,20 @@ class TestTechnicalAssetsRouter:
         response = self.delete_data_output(client, data_output.id)
         assert response.status_code == 200
 
+    def test_remove_data_output_with_tags(self, client: TestClient):
+        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        data_product = DataProductFactory()
+        role = RoleFactory(
+            scope=Scope.DATA_PRODUCT,
+            permissions=[Action.DATA_PRODUCT__DELETE_TECHNICAL_ASSET],
+        )
+        DataProductRoleAssignmentFactory(
+            user_id=user.id, role_id=role.id, data_product_id=data_product.id
+        )
+        data_output = TechnicalAssetFactory(owner=data_product, tags=[TagFactory()])
+        response = self.delete_data_output(client, data_output.id)
+        assert response.status_code == 200
+
     def test_update_status_not_owner(self, client: TestClient):
         do = TechnicalAssetFactory()
         response = self.update_data_output_status(client, {"status": "active"}, do.id)

--- a/backend/tests/app/data_products/test_router.py
+++ b/backend/tests/app/data_products/test_router.py
@@ -307,6 +307,11 @@ class TestDataProductsRouter:
         response = self.delete_data_product(client, data_product.id)
         assert response.status_code == 403
 
+    def test_remove_data_product_with_tag(self, client):
+        data_product = DataProductFactory(tags=[TagFactory()])
+        response = self.delete_data_product(client, data_product.id)
+        assert response.status_code == 403
+
     def test_remove_data_product(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         data_product = DataProductFactory()

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -17,6 +17,7 @@ sidebar_position: 200
 ### bugfixes
 
 - **[Output ports]**: In output port card, the remove button to unlink an asset from an output port was not grayed out when missing permissions.
+- **[Output ports]**: Deleting output ports with a quality summary caused errors.
 - **[Output ports]**: Linking and unlinking technical assets to output ports was denied.
 - **[Technical Asset Creation]**: Broken technical asset creation flow is fixed.
 - **[Add user to Data Product]**: Bad authorization resolves caused issues with this specific action.


### PR DESCRIPTION
I add multiple different tests to cover certain common cascading delete issues.
Of the ones I added only the quality summary was not correctly working

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md)
- [x] When updating the UI please provide screenshots or videos to the reviewers
