### PR TITLE
change release workflow to include readable release-notes.

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   prep-version:
@@ -240,3 +240,37 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${repo_owner}/${repo_name}/dispatches" \
             -d "{\"event_type\": \"${event_type}\", \"client_payload\": {\"tag\": \"${version}\", \"chart_version\": \"${chart}\", \"env\": \"demo_prd\", \"integration\": true}}"
+  create-gh-release-notes:
+    name: Create GitHub release notes and release
+    runs-on: ubuntu-latest
+    needs: ["backend", "frontend", "cli", "release-docs"]
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+      - name: Create release notes in github
+        env:
+          tag: ${{ github.ref_name }}
+        id: create_release_notes
+        run: |
+          VERSION="${tag#v}"
+          echo "Release notes for version $VERSION"
+          RELEASENOTES=$(awk -v ver="$VERSION" '/^## / { if (p) { exit }; if ($2 == ver) { p=1; next } } p && NF' docs/docs/release-notes.md | sed 's/"/\\"/g')
+          {
+          echo 'RELEASENOTES<<EOF'
+          echo "${RELEASENOTES}"
+          echo EOF
+          } >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+        run: |
+          echo "Creating release for version $tag"
+          echo "${{ steps.create_release_notes.outputs.RELEASENOTES }}"
+          gh release create "$tag" --title "$tag" --notes "${{ steps.create_release_notes.outputs.RELEASENOTES }}"
+          echo "Release created successfully"


### PR DESCRIPTION
Update release workflow.

Do not autogenerate the release notes anymore by github as they are unreadable.

- We take the relevant part from docs/docs/release-notes (## section until the next ##).
- We escape " characters in the release-notes as otherwise the pipeline breaks.
