### PR TITLE
Do not load product tags and improve list behavior

### DIFF
--- a/backend/app/data_products/model.py
+++ b/backend/app/data_products/model.py
@@ -1,29 +1,31 @@
 import uuid
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Column, Enum, ForeignKey, String
+from sqlalchemy import Column, Enum, ForeignKey, String, func, select
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Mapped, Session, mapped_column, relationship
+from sqlalchemy.orm import Mapped, Session, column_property, mapped_column, relationship
 
+from app.authorization.role_assignments.data_product.model import (
+    DataProductRoleAssignment,
+)
 from app.authorization.role_assignments.enums import DecisionStatus
 from app.configuration.data_product_types.model import DataProductType
 from app.configuration.domains.model import Domain
 from app.configuration.tags.model import Tag, tag_data_product_table
+from app.data_products.output_ports.model import (
+    DataProductDatasetAssociation,
+)
 from app.data_products.status import DataProductStatus
+from app.data_products.technical_assets.model import TechnicalAsset
 from app.database.database import Base, ensure_exists
 from app.shared.model import BaseORM
 
 if TYPE_CHECKING:
-    from app.authorization.role_assignments.data_product.model import (
-        DataProductRoleAssignment,
-    )
     from app.configuration.data_product_lifecycles.model import DataProductLifecycle
     from app.configuration.data_product_settings.model import DataProductSettingValue
     from app.data_products.output_ports.model import (
-        DataProductDatasetAssociation,
         Dataset,
     )
-    from app.data_products.technical_assets.model import TechnicalAsset
 
 
 class DataProduct(Base, BaseORM):
@@ -72,7 +74,7 @@ class DataProduct(Base, BaseORM):
         lazy="raise",
     )
     tags: Mapped[list[Tag]] = relationship(
-        secondary=tag_data_product_table, back_populates="data_products", lazy="joined"
+        secondary=tag_data_product_table, back_populates="data_products", lazy="raise"
     )
     data_product_settings: Mapped[list["DataProductSettingValue"]] = relationship(
         back_populates="data_product",
@@ -86,27 +88,28 @@ class DataProduct(Base, BaseORM):
         lazy="raise",
     )
 
-    @property
-    def user_count(self) -> int:
-        approved_assignments = [
-            assignment
-            for assignment in self.assignments
-            if assignment.decision == DecisionStatus.APPROVED
-        ]
-        return len(approved_assignments)
+    user_count = column_property(
+        select(func.count(DataProductRoleAssignment.id))
+        .where(DataProductRoleAssignment.data_product_id == id)
+        .where(DataProductRoleAssignment.decision == DecisionStatus.APPROVED)
+        .correlate_except(DataProductRoleAssignment)
+        .scalar_subquery()
+    )
 
-    @property
-    def dataset_count(self) -> int:
-        accepted_dataset_links = [
-            link
-            for link in self.dataset_links
-            if link.status == DecisionStatus.APPROVED
-        ]
-        return len(accepted_dataset_links)
+    dataset_count = column_property(
+        select(func.count(DataProductDatasetAssociation.id))
+        .where(DataProductDatasetAssociation.data_product_id == id)
+        .where(DataProductDatasetAssociation.status == DecisionStatus.APPROVED)
+        .correlate_except(DataProductDatasetAssociation)
+        .scalar_subquery()
+    )
 
-    @property
-    def data_outputs_count(self) -> int:
-        return len(self.data_outputs)
+    data_outputs_count = column_property(
+        select(func.count(TechnicalAsset.id))
+        .where(TechnicalAsset.owner_id == id)
+        .correlate_except(TechnicalAsset)
+        .scalar_subquery()
+    )
 
 
 def ensure_data_product_exists(

--- a/backend/app/data_products/service.py
+++ b/backend/app/data_products/service.py
@@ -158,7 +158,7 @@ class DataProductService:
         data_product = self.db.get(
             DataProductModel,
             id,
-            options=[selectinload(DataProductModel.data_product_settings)],
+            options=[selectinload(DataProductModel.tags)],
         )
         default_lifecycle = self.db.scalar(
             select(DataProductLifeCycleModel).filter(
@@ -184,10 +184,7 @@ class DataProductService:
             )
         )
         query = select(DataProductModel).options(
-            selectinload(DataProductModel.dataset_links).raiseload("*"),
-            selectinload(DataProductModel.assignments).raiseload("*"),
-            selectinload(DataProductModel.data_outputs).raiseload("*"),
-            selectinload(DataProductModel.data_product_settings).raiseload("*"),
+            selectinload(DataProductModel.tags).raiseload("*"),
         )
         if filter_to_user_with_assigment:
             query = query.filter(
@@ -265,7 +262,9 @@ class DataProductService:
         id: UUID,
         data_product: DataProductUpdate,
     ) -> UpdateDataProductResponse:
-        current_data_product = ensure_data_product_exists(id, self.db)
+        current_data_product = ensure_data_product_exists(
+            id, self.db, options=[selectinload(DataProductModel.tags)]
+        )
         update_data_product = data_product.model_dump(exclude_unset=True)
 
         if (

--- a/backend/tests/app/data_products/test_router.py
+++ b/backend/tests/app/data_products/test_router.py
@@ -162,7 +162,7 @@ class TestDataProductsRouter:
     def test_get_data_products(self, client):
         data_product = DataProductFactory()
         response = client.get(ENDPOINT)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         data = response.json()
         assert len(data) == 1
         assert data["data_products"][0]["id"] == str(data_product.id)

--- a/backend/tests/app/database/test_sql_alchemy_best_practices.py
+++ b/backend/tests/app/database/test_sql_alchemy_best_practices.py
@@ -12,7 +12,6 @@ ignore_list = {
     "Platform": ["services"],
     "User": ["data_product_roles", "dataset_roles"],
     "Dataset": ["tags"],
-    "DataProduct": ["tags"],
 }
 
 


### PR DESCRIPTION
Product tags are not automatically loaded.
Also started using count queries instead of properties for user_count etc. This is done in the same query that loads all the data and is a lot faste then
having to do multiple select ins just for these counts

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested
