### PR TITLE
Fixing docker-compose basic demo

### DIFF
--- a/demo/basic/compose.yaml
+++ b/demo/basic/compose.yaml
@@ -32,7 +32,9 @@ services:
       - ../../frontend/config.docker.js:/app/dist/config.js
 
   provisioner:
-    build: ./provisioner
+    build:
+      context: ../..
+      dockerfile: demo/basic/provisioner/Dockerfile
     env_file:
       - .env.portal
     volumes:

--- a/demo/basic/provisioner/Dockerfile
+++ b/demo/basic/provisioner/Dockerfile
@@ -19,10 +19,11 @@ ENV POETRY_NO_INTERACTION=1 \
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y curl
 
-COPY requirements-poetry.txt .
+COPY demo/basic/provisioner/requirements-poetry.txt .
 RUN pip install -r requirements-poetry.txt --require-hashes
 
-COPY poetry.lock pyproject.toml /
+COPY demo/basic/provisioner/poetry.lock demo/basic/provisioner/pyproject.toml /
+COPY sdk /sdk
 RUN poetry install --no-root
 
 FROM base-image
@@ -30,9 +31,9 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y curl
 
 COPY --from=build-stage /usr/local /usr/local
 
-COPY ./provisioner ./provisioner
-COPY ./templates ./templates
-COPY ./VERSION ./VERSION
+COPY demo/basic/provisioner/provisioner ./provisioner
+COPY demo/basic/provisioner/templates ./templates
+COPY demo/basic/provisioner/VERSION ./VERSION
 
 EXPOSE 6060
 


### PR DESCRIPTION
- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested

When running the basic demo in docker, the building of the provisioner fails as it can't be installed due to the local reference that is outside of the context.