### PR TITLE
Fix rbac migration to not depend on code

### DIFF
--- a/.github/workflows/alembic-workflow.yml
+++ b/.github/workflows/alembic-workflow.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   incremental_migration_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         name: Git checkout

--- a/backend/app/authorization/roles/model.py
+++ b/backend/app/authorization/roles/model.py
@@ -4,6 +4,7 @@ from sqlalchemy import Column, Integer, SmallInteger, String
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import mapped_column
 
+from app.authorization.roles.schema import Prototype
 from app.database.database import Base
 from app.shared.model import BaseORM
 
@@ -14,6 +15,6 @@ class Role(Base, BaseORM):
     id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String)
     scope = Column(String)
-    prototype = Column(SmallInteger)
+    prototype = Column(SmallInteger, default=Prototype.CUSTOM)
     description = Column(String)
     permissions = Column(ARRAY(Integer))

--- a/backend/app/authorization/roles/service.py
+++ b/backend/app/authorization/roles/service.py
@@ -5,7 +5,6 @@ from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.authorization.roles import ADMIN_UUID
 from app.authorization.roles.model import Role as RoleModel
 from app.authorization.roles.schema import (
     CreateRole,
@@ -14,7 +13,6 @@ from app.authorization.roles.schema import (
     Scope,
     UpdateRole,
 )
-from app.core.authz import Action
 from app.database.database import ensure_exists
 
 
@@ -80,106 +78,9 @@ class RoleService:
         result.sort()
         return result
 
-    def initialize_prototype_roles(self) -> bool:
-        """Initializes the roles that are expected to be present in other parts of the
-        application. This function will first check which roles are already present,
-        and only create the missing ones.
-
-        Returns: True if a role was added, False otherwise.
-        """
-        modified = False
-
-        if self.find_prototype(Scope.GLOBAL, Prototype.ADMIN) is None:
-            modified = True
-            model = RoleModel(
-                id=ADMIN_UUID,
-                scope=Scope.GLOBAL,
-                prototype=Prototype.ADMIN,
-                name="Admin",
-                description="Administrators have blanket permissions",
-                permissions=[],
-            )
-            self.db.add(model)
-            self.db.commit()
-
-        if self.find_prototype(Scope.GLOBAL, Prototype.EVERYONE) is None:
-            modified = True
-            self.create_role(
-                CreateRole(
-                    name="Everyone",
-                    scope=Scope.GLOBAL,
-                    description="This is the role that is used as fallback for users that don't have another role",  # noqa: E501
-                    permissions=[
-                        Action.GLOBAL__CREATE_DATAPRODUCT,
-                        Action.GLOBAL__CREATE_EXPLORATION,
-                        Action.GLOBAL__CREATE_OUTPUT_PORT,
-                        Action.GLOBAL__REQUEST_DATAPRODUCT_ACCESS,
-                        Action.GLOBAL__REQUEST_OUTPUT_PORT_ACCESS,
-                    ],
-                ),
-                prototype=Prototype.EVERYONE,
-            )
-
-        if self.find_prototype(Scope.DATASET, Prototype.OWNER) is None:
-            modified = True
-            self.create_role(
-                CreateRole(
-                    name="Owner",
-                    scope=Scope.DATASET,
-                    description="The owner of a Dataset",
-                    permissions=[
-                        Action.OUTPUT_PORT__UPDATE_PROPERTIES,
-                        Action.OUTPUT_PORT__UPDATE_SETTINGS,
-                        Action.OUTPUT_PORT__UPDATE_STATUS,
-                        Action.OUTPUT_PORT__DELETE,
-                        Action.OUTPUT_PORT__CREATE_USER,
-                        Action.OUTPUT_PORT__UPDATE_USER,
-                        Action.OUTPUT_PORT__DELETE_USER,
-                        Action.OUTPUT_PORT__APPROVE_USER_REQUEST,
-                        Action.OUTPUT_PORT__APPROVE_TECHNICAL_ASSET_LINK_REQUEST,
-                        Action.OUTPUT_PORT__REVOKE_TECHNICAL_ASSET_LINK,
-                        Action.OUTPUT_PORT__APPROVE_DATAPRODUCT_ACCESS_REQUEST,
-                        Action.OUTPUT_PORT__REVOKE_DATAPRODUCT_ACCESS,
-                        Action.OUTPUT_PORT__READ_INTEGRATIONS,
-                        Action.OUTPUT_PORT__UPDATE_DATA_QUALITY,
-                    ],
-                ),
-                prototype=Prototype.OWNER,
-            )
-
-        if self.find_prototype(Scope.DATA_PRODUCT, Prototype.OWNER) is None:
-            modified = True
-            self.create_role(
-                CreateRole(
-                    name="Owner",
-                    scope=Scope.DATA_PRODUCT,
-                    description="The owner of a Data Product",
-                    permissions=[
-                        Action.DATA_PRODUCT__UPDATE_PROPERTIES,
-                        Action.DATA_PRODUCT__UPDATE_SETTINGS,
-                        Action.DATA_PRODUCT__UPDATE_STATUS,
-                        Action.DATA_PRODUCT__DELETE,
-                        Action.DATA_PRODUCT__CREATE_USER,
-                        Action.DATA_PRODUCT__UPDATE_USER,
-                        Action.DATA_PRODUCT__DELETE_USER,
-                        Action.DATA_PRODUCT__APPROVE_USER_REQUEST,
-                        Action.DATA_PRODUCT__CREATE_TECHNICAL_ASSET,
-                        Action.DATA_PRODUCT__UPDATE_TECHNICAL_ASSET,
-                        Action.DATA_PRODUCT__DELETE_TECHNICAL_ASSET,
-                        Action.DATA_PRODUCT__REQUEST_TECHNICAL_ASSET_LINK,
-                        Action.DATA_PRODUCT__REQUEST_OUTPUT_PORT_ACCESS,
-                        Action.DATA_PRODUCT__REVOKE_OUTPUT_PORT_ACCESS,
-                        Action.DATA_PRODUCT__READ_INTEGRATIONS,
-                    ],
-                ),
-                prototype=Prototype.OWNER,
-            )
-
-        return modified
-
-    def find_prototype(self, scope: Scope, prototype: Prototype) -> Optional[Role]:
+    def find_prototype(self, scope: Scope, prototype: Prototype) -> Role:
         return self.db.scalars(
             select(RoleModel)
             .where(RoleModel.scope == scope)
             .where(RoleModel.prototype == prototype)
-        ).one_or_none()
+        ).one()

--- a/backend/app/data_products/output_ports/router.py
+++ b/backend/app/data_products/output_ports/router.py
@@ -1,7 +1,7 @@
 from typing import Sequence
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from app.authorization.role_assignments.enums import DecisionStatus
@@ -58,11 +58,6 @@ def _assign_owner_role_assignments(
     dataset_id: UUID, owners: Sequence[UUID], db: Session, actor: User
 ) -> None:
     owner_role = RoleService(db).find_prototype(Scope.DATASET, Prototype.OWNER)
-    if owner_role is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Owner role not found",
-        )
 
     assignment_service = RoleAssignmentService(db)
     event_service = EventService(db)

--- a/backend/app/data_products/router.py
+++ b/backend/app/data_products/router.py
@@ -1,7 +1,7 @@
 from typing import Optional, Sequence
 from uuid import UUID
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
+from fastapi import APIRouter, BackgroundTasks, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.abstract_data_product.schema_response import InputPort
@@ -120,11 +120,6 @@ def _assign_owner_role_assignments(
     data_product_id: UUID, owners: Sequence[UUID], db: Session, actor: User
 ) -> None:
     owner_role = RoleService(db).find_prototype(Scope.DATA_PRODUCT, Prototype.OWNER)
-    if not owner_role:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Owner role not found",
-        )
 
     assignment_service = RoleAssignmentService(db)
     for owner_id in owners:

--- a/backend/app/database/alembic/versions/2025_04_16_1658-6fd335d0dcfe_migrate_rbac.py
+++ b/backend/app/database/alembic/versions/2025_04_16_1658-6fd335d0dcfe_migrate_rbac.py
@@ -9,7 +9,7 @@ Create Date: 2025-04-16 16:58:38.284751
 from datetime import datetime
 from enum import Enum
 from typing import Optional, Sequence, Union
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import sqlalchemy as sa
 from alembic import op
@@ -24,9 +24,8 @@ from app.authorization.role_assignments.global_.model import GlobalRoleAssignmen
 from app.authorization.role_assignments.output_port.model import (
     DatasetRoleAssignment,
 )
-from app.authorization.roles.model import Role as RoleModel
-from app.authorization.roles.schema import CreateRole, Prototype, Scope
-from app.authorization.roles.service import RoleService
+from app.authorization.roles import ADMIN_UUID
+from app.authorization.roles.schema import Prototype, Scope
 from app.authorization.service import AuthorizationService
 from app.core.authz import Action, Authorization
 
@@ -91,7 +90,6 @@ class DataProductUserRole(str, Enum):
 class RoleMigrationService:
     def __init__(self, db: Session, data_product_membership):
         self.db = db
-        self.role_service = RoleService(db)
         self.data_product_membership = data_product_membership
 
     def migrate(self):
@@ -109,21 +107,25 @@ class RoleMigrationService:
         if not memberships:
             return
 
-        owner_role = self.role_service.find_prototype(
-            Scope.DATA_PRODUCT, Prototype.OWNER
-        )
-        if owner_role is None:
-            raise Exception(
-                "Unable to transfer product memberships: owner role does not exist"
+        owner_role_id = self.db.scalar(
+            sa.select(_roles_table.c.id).where(
+                _roles_table.c.prototype == Prototype.OWNER,
+                _roles_table.c.scope == Scope.DATA_PRODUCT,
             )
+        )
 
         # Create the member role if it doesn't exist
-        member_role = self.db.scalars(
-            sa.select(RoleModel).filter_by(name="Member", scope=Scope.DATA_PRODUCT)
-        ).one_or_none()
-        if member_role is None:
-            member_role = self.role_service.create_role(
-                CreateRole(
+        member_role_id = self.db.scalar(
+            sa.select(_roles_table.c.id).where(
+                _roles_table.c.name == "Member",
+                _roles_table.c.scope == Scope.DATA_PRODUCT,
+            )
+        )
+        if member_role_id is None:
+            member_role_id = uuid4()
+            self.db.execute(
+                sa.insert(_roles_table).values(
+                    id=member_role_id,
                     name="Member",
                     scope=Scope.DATA_PRODUCT,
                     description="A member of the data product",
@@ -132,14 +134,15 @@ class RoleMigrationService:
                         Action.DATA_PRODUCT__REQUEST_OUTPUT_PORT_ACCESS,
                         Action.DATA_PRODUCT__READ_INTEGRATIONS,
                     ],
+                    created_on=sa.func.now(),
                 )
             )
 
         for membership in memberships:
             role_id = (
-                owner_role.id
+                owner_role_id
                 if membership.role == DataProductUserRole.OWNER
-                else member_role.id
+                else member_role_id
             )
             decision, decided_by_id, decided_on = self.map_decision(membership)
             self.db.add(
@@ -181,11 +184,12 @@ class RoleMigrationService:
         datasets = self.db.scalars(sa.select(dataset_table)).unique().all()
         if not datasets:
             return
-        owner_role = self.role_service.find_prototype(Scope.DATASET, Prototype.OWNER)
-        if owner_role is None:
-            raise Exception(
-                "Unable to transfer dataset memberships: owner role does not exist"
+        owner_role_id = self.db.scalar(
+            sa.select(_roles_table.c.id).where(
+                _roles_table.c.prototype == Prototype.OWNER,
+                _roles_table.c.scope == Scope.DATASET,
             )
+        )
 
         for dataset in datasets:
             for owner in dataset.owners:
@@ -193,7 +197,7 @@ class RoleMigrationService:
                     DatasetRoleAssignment(
                         dataset_id=dataset.id,
                         user_id=owner.id,
-                        role_id=owner_role.id,
+                        role_id=owner_role_id,
                         decision=DecisionStatus.APPROVED,
                         requested_on=dataset.updated_on,
                         decided_on=dataset.updated_on,
@@ -205,24 +209,109 @@ class RoleMigrationService:
         users = self.db.execute(sa.sql.text("""select * from users""")).all()
         if not users:
             return
-        admin_role = self.role_service.find_prototype(Scope.GLOBAL, Prototype.ADMIN)
-        if admin_role is None:
-            raise ValueError(
-                "Unable to transfer global memberships: admin role does not exist"
+        admin_role_id = self.db.scalar(
+            sa.select(_roles_table.c.id).where(
+                _roles_table.c.prototype == Prototype.ADMIN,
+                _roles_table.c.scope == Scope.GLOBAL,
             )
+        )
 
         for user in users:
             if user.is_admin:
                 self.db.add(
                     GlobalRoleAssignment(
                         user_id=user.id,
-                        role_id=admin_role.id,
+                        role_id=admin_role_id,
                         decision=DecisionStatus.APPROVED,
                         requested_on=user.updated_on,
                         decided_on=user.updated_on,
                     )
                 )
         self.db.commit()
+
+
+_roles_table = sa.Table(
+    "roles",
+    sa.MetaData(),
+    sa.Column("id", PGUUID(as_uuid=True), primary_key=True),
+    sa.Column("name", sa.String),
+    sa.Column("scope", sa.String),
+    sa.Column("prototype", sa.SmallInteger),
+    sa.Column("description", sa.String),
+    sa.Column("permissions", sa.ARRAY(sa.Integer)),
+    sa.Column("created_on", sa.DateTime),
+)
+
+_PROTOTYPE_ROLES = [
+    {
+        "id": ADMIN_UUID,
+        "name": "Admin",
+        "scope": Scope.GLOBAL,
+        "prototype": Prototype.ADMIN,
+        "description": "Administrators have blanket permissions",
+        "permissions": [],
+    },
+    {
+        "id": uuid4(),
+        "name": "Everyone",
+        "scope": Scope.GLOBAL,
+        "prototype": Prototype.EVERYONE,
+        "description": "This is the role that is used as fallback for users that don't have another role",
+        "permissions": [
+            int(Action.GLOBAL__CREATE_DATAPRODUCT),
+            int(Action.GLOBAL__CREATE_OUTPUT_PORT),
+            int(Action.GLOBAL__REQUEST_DATAPRODUCT_ACCESS),
+            int(Action.GLOBAL__REQUEST_OUTPUT_PORT_ACCESS),
+        ],
+    },
+    {
+        "id": uuid4(),
+        "name": "Owner",
+        "scope": Scope.DATASET,
+        "prototype": Prototype.OWNER,
+        "description": "The owner of a Dataset",
+        "permissions": [
+            int(Action.OUTPUT_PORT__UPDATE_PROPERTIES),
+            int(Action.OUTPUT_PORT__UPDATE_SETTINGS),
+            int(Action.OUTPUT_PORT__UPDATE_STATUS),
+            int(Action.OUTPUT_PORT__DELETE),
+            int(Action.OUTPUT_PORT__CREATE_USER),
+            int(Action.OUTPUT_PORT__UPDATE_USER),
+            int(Action.OUTPUT_PORT__DELETE_USER),
+            int(Action.OUTPUT_PORT__APPROVE_USER_REQUEST),
+            int(Action.OUTPUT_PORT__APPROVE_TECHNICAL_ASSET_LINK_REQUEST),
+            int(Action.OUTPUT_PORT__REVOKE_TECHNICAL_ASSET_LINK),
+            int(Action.OUTPUT_PORT__APPROVE_DATAPRODUCT_ACCESS_REQUEST),
+            int(Action.OUTPUT_PORT__REVOKE_DATAPRODUCT_ACCESS),
+            int(Action.OUTPUT_PORT__READ_INTEGRATIONS),
+            int(Action.OUTPUT_PORT__UPDATE_DATA_QUALITY),
+        ],
+    },
+    {
+        "id": uuid4(),
+        "name": "Owner",
+        "scope": Scope.DATA_PRODUCT,
+        "prototype": Prototype.OWNER,
+        "description": "The owner of a Data Product",
+        "permissions": [
+            int(Action.DATA_PRODUCT__UPDATE_PROPERTIES),
+            int(Action.DATA_PRODUCT__UPDATE_SETTINGS),
+            int(Action.DATA_PRODUCT__UPDATE_STATUS),
+            int(Action.DATA_PRODUCT__DELETE),
+            int(Action.DATA_PRODUCT__CREATE_USER),
+            int(Action.DATA_PRODUCT__UPDATE_USER),
+            int(Action.DATA_PRODUCT__DELETE_USER),
+            int(Action.DATA_PRODUCT__APPROVE_USER_REQUEST),
+            int(Action.DATA_PRODUCT__CREATE_TECHNICAL_ASSET),
+            int(Action.DATA_PRODUCT__UPDATE_TECHNICAL_ASSET),
+            int(Action.DATA_PRODUCT__DELETE_TECHNICAL_ASSET),
+            int(Action.DATA_PRODUCT__REQUEST_TECHNICAL_ASSET_LINK),
+            int(Action.DATA_PRODUCT__REQUEST_OUTPUT_PORT_ACCESS),
+            int(Action.DATA_PRODUCT__REVOKE_OUTPUT_PORT_ACCESS),
+            int(Action.DATA_PRODUCT__READ_INTEGRATIONS),
+        ],
+    },
+]
 
 
 def upgrade() -> None:
@@ -232,10 +321,22 @@ def upgrade() -> None:
 
     data_product_membership = metadata.tables["data_product_memberships"]
 
+    for role in _PROTOTYPE_ROLES:
+        session.execute(
+            sa.insert(_roles_table).values(
+                id=role["id"],
+                name=role["name"],
+                scope=role["scope"],
+                prototype=role["prototype"],
+                description=role["description"],
+                permissions=role["permissions"],
+                created_on=sa.func.now(),
+            )
+        )
+
     service = RoleMigrationService(
         db=session, data_product_membership=data_product_membership
     )
-    service.role_service.initialize_prototype_roles()
     service.migrate()
 
 

--- a/backend/app/database/alembic/versions/2026_04_24_1534-b1b690376725_ensure_only_one_prototype_role_exists_.py
+++ b/backend/app/database/alembic/versions/2026_04_24_1534-b1b690376725_ensure_only_one_prototype_role_exists_.py
@@ -1,0 +1,39 @@
+"""Ensure only one prototype role exists per scope
+
+Revision ID: b1b690376725
+Revises: 63243c53dd67
+Create Date: 2026-04-24 15:34:54.005335
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b1b690376725"
+down_revision: Union[str, None] = "6449af439bdd"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "uq_roles_prototype_scope",
+            "roles",
+            ["prototype", "scope"],
+            unique=True,
+            postgresql_where=sa.text("prototype != 0"),
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "uq_roles_prototype_scope",
+            table_name="roles",
+            postgresql_concurrently=True,
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.routing import APIRoute
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from app.authorization.roles.service import RoleService
 from app.authorization.service import AuthorizationService
 from app.core.auth.device_flows.background_tasks import cleanup_device_flow_table_task
 from app.core.auth.jwt import oidc
@@ -65,10 +64,10 @@ async def log_middleware(request: Request, call_next):
 
 @asynccontextmanager
 async def lifespan(_: FastAPI):
-    db = next(database.get_db_session())
-    resync = RoleService(db).initialize_prototype_roles()
-    if resync or settings.AUTHORIZER_STARTUP_SYNC:
-        AuthorizationService(db).reload_enforcer()
+    with database.SessionLocal() as db:
+        if settings.AUTHORIZER_STARTUP_SYNC:
+            AuthorizationService(db).reload_enforcer()
+        db.commit()
 
     backend_analytics(API_VERSION)
     admin_task = asyncio.create_task(check_expired_admins())

--- a/backend/tests/app/authorization/role_assignments/data_product/test_router.py
+++ b/backend/tests/app/authorization/role_assignments/data_product/test_router.py
@@ -6,7 +6,7 @@ from fastapi import status
 from fastapi.testclient import TestClient
 
 from app.authorization.role_assignments.enums import DecisionStatus
-from app.authorization.roles.schema import Prototype, Role, Scope
+from app.authorization.roles.schema import Role, Scope
 from app.core.authz import Action
 from app.settings import settings
 from tests.factories import (
@@ -177,9 +177,8 @@ class TestDataProductRoleAssignmentsRouter:
         DataProductRoleAssignmentFactory(
             user_id=user.id, role_id=authz_role.id, data_product_id=data_product.id
         )
-
+        role = RoleFactory.data_product_owner()
         user_1, user_2 = UserFactory.create_batch(2)
-        role: Role = RoleFactory(scope=Scope.DATA_PRODUCT, prototype=Prototype.OWNER)
         assignment_1 = DataProductRoleAssignmentFactory(
             data_product_id=data_product.id,
             user_id=user_1.id,
@@ -323,13 +322,12 @@ class TestDataProductRoleAssignmentsRouter:
     def test_modify_last_owner(self, client: TestClient):
         data_product: DataProduct = DataProductFactory()
         user: User = UserFactory()
-        owner: Role = RoleFactory(scope=Scope.DATA_PRODUCT, prototype=Prototype.OWNER)
-        role: Role = RoleFactory(scope=Scope.DATA_PRODUCT, prototype=Prototype.CUSTOM)
+        role: Role = RoleFactory(scope=Scope.DATA_PRODUCT)
 
         assignment: DataProductRoleAssignment = DataProductRoleAssignmentFactory(
             data_product_id=data_product.id,
             user_id=user.id,
-            role_id=owner.id,
+            role_id=RoleFactory.data_product_owner().id,
             decision=DecisionStatus.APPROVED,
         )
 

--- a/backend/tests/app/authorization/role_assignments/global_/test_auth.py
+++ b/backend/tests/app/authorization/role_assignments/global_/test_auth.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING
 
 from app.authorization.role_assignments.enums import DecisionStatus
 from app.authorization.role_assignments.global_.auth import GlobalAuthAssignment
-from app.authorization.roles import ADMIN_UUID
 from app.authorization.roles.schema import Role, Scope
 from app.core.authz import Authorization
 from tests.factories import GlobalRoleAssignmentFactory, RoleFactory, UserFactory
@@ -29,7 +28,7 @@ class TestAuth:
 
     def test_add_admin(self, authorizer: Authorization):
         user: User = UserFactory()
-        admin: Role = RoleFactory(scope=Scope.GLOBAL, id=ADMIN_UUID)
+        admin = RoleFactory.admin()
         assert not authorizer.has_admin_role(user_id=str(user.id))
         GlobalRoleAssignmentFactory(
             user_id=user.id,
@@ -58,7 +57,7 @@ class TestAuth:
 
     def test_remove_admin(self, authorizer: Authorization):
         user: User = UserFactory()
-        admin: Role = RoleFactory(scope=Scope.GLOBAL, id=ADMIN_UUID)
+        admin = RoleFactory.admin()
         assert not authorizer.has_admin_role(user_id=str(user.id))
         assignment: GlobalRoleAssignment = GlobalRoleAssignmentFactory(
             user_id=user.id,
@@ -73,7 +72,6 @@ class TestAuth:
     def test_swap(self, authorizer: Authorization):
         user: User = UserFactory()
         role: Role = RoleFactory(scope=Scope.GLOBAL)
-        admin: Role = RoleFactory(scope=Scope.GLOBAL, id=ADMIN_UUID)
 
         assignment: GlobalRoleAssignment = GlobalRoleAssignmentFactory(
             user_id=user.id,
@@ -85,7 +83,7 @@ class TestAuth:
         assert authorizer.has_global_role(user_id=str(user.id), role_id=str(role.id))
         assert not authorizer.has_admin_role(user_id=str(user.id))
 
-        assignment.role_id = admin.id
+        assignment.role_id = RoleFactory.admin().id
         GlobalAuthAssignment(assignment, previous_role_id=role.id).swap()
 
         assert not authorizer.has_global_role(

--- a/backend/tests/app/authorization/role_assignments/output_port/test_router.py
+++ b/backend/tests/app/authorization/role_assignments/output_port/test_router.py
@@ -6,7 +6,7 @@ from fastapi import status
 from fastapi.testclient import TestClient
 
 from app.authorization.role_assignments.enums import DecisionStatus
-from app.authorization.roles.schema import Prototype, Role, Scope
+from app.authorization.roles.schema import Role, Scope
 from app.core.authz import Action
 from app.settings import settings
 from tests.factories import (
@@ -342,7 +342,7 @@ class TestDatasetRoleAssignmentsRouter:
         )
 
         user_1, user_2 = UserFactory.create_batch(2)
-        role: Role = RoleFactory(scope=Scope.DATASET, prototype=Prototype.OWNER)
+        role = RoleFactory.dataset_owner()
         assignment_1 = DatasetRoleAssignmentFactory(
             dataset_id=dataset.id,
             user_id=user_1.id,

--- a/backend/tests/app/authorization/roles/test_router.py
+++ b/backend/tests/app/authorization/roles/test_router.py
@@ -17,13 +17,11 @@ class TestRolesRouter:
     }
 
     def test_get_roles(self, client: TestClient):
-        role: Role = RoleFactory(scope="global")
         response = client.get(f"{ENDPOINT}/global")
 
         assert response.status_code == 200
         data = response.json()
-        assert len(data["roles"]) == 1
-        assert data["roles"][0]["scope"] == role.scope
+        assert len(data["roles"]) == 2  # We return the 2 global roles
 
     @pytest.mark.usefixtures("admin")
     def test_create_role(self, client: TestClient):
@@ -107,11 +105,11 @@ class TestRolesRouter:
         role: Role = RoleFactory(scope=Scope.DATASET)
         response = client.get(f"{ENDPOINT}/{role.scope}")
         assert response.status_code == 200
-        assert len(response.json()["roles"]) == 1
+        roles_before = len(response.json()["roles"])
 
         response = client.delete(f"{ENDPOINT}/{role.id}")
         assert response.status_code == 200
 
         response = client.get(f"{ENDPOINT}/{role.scope}")
         assert response.status_code == 200
-        assert len(response.json()["roles"]) == 0
+        assert roles_before - len(response.json()["roles"]) == 1

--- a/backend/tests/app/data_products/output_ports/curated_queries/test_router.py
+++ b/backend/tests/app/data_products/output_ports/curated_queries/test_router.py
@@ -1,5 +1,4 @@
 from app.authorization.roles.schema import Scope
-from app.authorization.roles.service import RoleService
 from app.core.authz.actions import AuthorizationAction
 from app.data_products.output_ports.curated_queries.schema_request import (
     OutputPortCuratedQueryInput,
@@ -19,7 +18,6 @@ ENDPOINT = "/api/v2/data_products"
 
 
 def _assign_update_role(session, dataset):
-    RoleService(db=session).initialize_prototype_roles()
     user = UserFactory(external_id=settings.DEFAULT_USERNAME)
     role = RoleFactory(
         scope=Scope.DATASET,

--- a/backend/tests/app/data_products/output_ports/data_quality/test_router.py
+++ b/backend/tests/app/data_products/output_ports/data_quality/test_router.py
@@ -1,7 +1,6 @@
 from datetime import UTC, datetime, timedelta
 
 from app.authorization.roles.schema import Scope
-from app.authorization.roles.service import RoleService
 from app.core.authz.actions import AuthorizationAction
 from app.data_products.output_ports.data_quality.enums import DataQualityStatus
 from app.data_products.output_ports.data_quality.schema_request import (
@@ -23,7 +22,6 @@ ENDPOINT = "/api/v2/data_products"
 
 
 def _assign_update_role(session, dataset):
-    RoleService(db=session).initialize_prototype_roles()
     user = UserFactory(external_id=settings.DEFAULT_USERNAME)
     role = RoleFactory(
         scope=Scope.DATASET,
@@ -63,9 +61,8 @@ class TestDataQualityRouter:
         assert body["overall_status"] == payload["overall_status"]
         assert body["details_url"] == payload["details_url"]
 
-    def test_post_data_quality_no_permissions(self, client, session):
+    def test_post_data_quality_no_permissions(self, client):
         dataset = DatasetFactory()
-        RoleService(db=session).initialize_prototype_roles()
 
         payload = {
             "overall_status": "success",

--- a/backend/tests/app/data_products/output_ports/test_router.py
+++ b/backend/tests/app/data_products/output_ports/test_router.py
@@ -2,8 +2,7 @@ from copy import deepcopy
 
 import pytest
 
-from app.authorization.roles.schema import Prototype, Scope
-from app.authorization.roles.service import RoleService
+from app.authorization.roles.schema import Scope
 from app.core.authz.actions import AuthorizationAction
 from app.data_products.output_ports.enums import OutputPortAccessType
 from app.data_products.output_ports.model import Dataset
@@ -52,8 +51,7 @@ def dataset_payload():
 class TestDatasetsRouter:
     invalid_id = "00000000-0000-0000-0000-000000000000"
 
-    def test_create_dataset(self, session, dataset_payload, client):
-        RoleService(db=session).initialize_prototype_roles()
+    def test_create_dataset(self, dataset_payload, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,
@@ -66,11 +64,10 @@ class TestDatasetsRouter:
         created_dataset = self.create_output_port(
             client, dataset_payload["data_product_id"], dataset_payload
         )
-        assert created_dataset.status_code == 200
+        assert created_dataset.status_code == 200, created_dataset.text
         assert "id" in created_dataset.json()
 
     def test_create_output_port(self, session, dataset_payload, client):
-        RoleService(db=session).initialize_prototype_roles()
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,
@@ -88,7 +85,6 @@ class TestDatasetsRouter:
         assert "id" in created_dataset.json()
 
     def test_create_output_port_type_public(self, session, dataset_payload, client):
-        RoleService(db=session).initialize_prototype_roles()
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,
@@ -110,23 +106,7 @@ class TestDatasetsRouter:
         )
         assert output_port.access_type == OutputPortAccessType.UNRESTRICTED.value
 
-    def test_create_dataset_no_owner_role(self, dataset_payload, client):
-        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        role = RoleFactory(
-            scope=Scope.GLOBAL,
-            permissions=[AuthorizationAction.GLOBAL__CREATE_OUTPUT_PORT],
-        )
-        GlobalRoleAssignmentFactory(
-            user_id=user.id,
-            role_id=role.id,
-        )
-        created_dataset = self.create_output_port(
-            client, dataset_payload["data_product_id"], dataset_payload
-        )
-        assert created_dataset.status_code == 400
-
     def test_create_dataset_no_owners(self, session, dataset_payload, client):
-        RoleService(db=session).initialize_prototype_roles()
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,
@@ -144,7 +124,6 @@ class TestDatasetsRouter:
         assert created_dataset.status_code == 422
 
     def test_create_dataset_duplicate_namespace(self, session, dataset_payload, client):
-        RoleService(db=session).initialize_prototype_roles()
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,
@@ -164,7 +143,6 @@ class TestDatasetsRouter:
     def test_create_dataset_invalid_characters_namespace(
         self, session, dataset_payload, client
     ):
-        RoleService(db=session).initialize_prototype_roles()
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,
@@ -185,7 +163,6 @@ class TestDatasetsRouter:
     def test_create_dataset_invalid_length_namespace(
         self, session, dataset_payload, client
     ):
-        RoleService(db=session).initialize_prototype_roles()
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,
@@ -563,7 +540,7 @@ class TestDatasetsRouter:
 
     def test_get_private_dataset_by_owner(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        role = RoleFactory(scope=Scope.DATASET, prototype=Prototype.OWNER)
+        role = RoleFactory.dataset_owner()
         ds = DatasetFactory(access_type=OutputPortAccessType.PRIVATE)
         DatasetRoleAssignmentFactory(user_id=user.id, role_id=role.id, dataset_id=ds.id)
         response = self.get_output_port(client, ds.id, ds.data_product.id)
@@ -596,7 +573,7 @@ class TestDatasetsRouter:
 
     def test_get_private_datasets_by_owner(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        role = RoleFactory(scope=Scope.DATA_PRODUCT, prototype=Prototype.OWNER)
+        role = RoleFactory.data_product_owner()
         ds = DatasetFactory(access_type=OutputPortAccessType.PRIVATE)
         DatasetRoleAssignmentFactory(user_id=user.id, role_id=role.id, dataset_id=ds.id)
         response = client.get(ENDPOINT.format(ds.data_product.id))
@@ -679,10 +656,7 @@ class TestDatasetsRouter:
 
         assert response.status_code == 400
 
-    def test_history_event_created_on_create_dataset(
-        self, session, dataset_payload, client
-    ):
-        RoleService(db=session).initialize_prototype_roles()
+    def test_history_event_created_on_create_dataset(self, dataset_payload, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,
@@ -705,8 +679,7 @@ class TestDatasetsRouter:
         )
         assert len(history.json()["events"]) == 2
 
-    def test_get_output_port_history(self, session, dataset_payload, client):
-        RoleService(db=session).initialize_prototype_roles()
+    def test_get_output_port_history(self, dataset_payload, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,

--- a/backend/tests/app/data_products/output_ports/test_service.py
+++ b/backend/tests/app/data_products/output_ports/test_service.py
@@ -1,7 +1,6 @@
 from sqlalchemy.orm import selectinload
 
-from app.authorization.roles import ADMIN_UUID
-from app.authorization.roles.schema import Prototype, Scope
+from app.authorization.roles.schema import Scope
 from app.data_products.output_ports.enums import OutputPortAccessType
 from app.data_products.output_ports.model import Dataset
 from app.data_products.output_ports.service import OutputPortService
@@ -30,7 +29,7 @@ class TestDatasetsService:
 
     def test_get_private_dataset_by_owner(self):
         owner = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        role = RoleFactory(scope=Scope.DATASET, prototype=Prototype.OWNER)
+        role = RoleFactory.dataset_owner()
         ds = DatasetFactory(access_type=OutputPortAccessType.PRIVATE)
         DatasetRoleAssignmentFactory(
             role_id=role.id, dataset_id=ds.id, user_id=owner.id
@@ -40,7 +39,7 @@ class TestDatasetsService:
 
     def test_get_private_dataset_by_admin(self):
         admin = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        role = RoleFactory(scope=Scope.GLOBAL, prototype=Prototype.ADMIN, id=ADMIN_UUID)
+        role = RoleFactory.admin()
         GlobalRoleAssignmentFactory(role_id=role.id, user_id=admin.id)
         ds = DatasetFactory(access_type=OutputPortAccessType.PRIVATE)
         ds = self.get_dataset(ds)
@@ -91,7 +90,7 @@ class TestDatasetsService:
 
         # Create another private output port owned by a different user
         owner = UserFactory()
-        owner_role = RoleFactory(scope=Scope.DATASET, prototype=Prototype.OWNER)
+        owner_role = RoleFactory.dataset_owner()
         owned_private_dataset = DatasetFactory(
             name="Owner Private Dataset", access_type=OutputPortAccessType.PRIVATE
         )
@@ -129,7 +128,7 @@ class TestDatasetsService:
         """Test that owners can see their own private output ports in search results"""
         # Create a user who will own a private dataset
         owner = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        owner_role = RoleFactory(scope=Scope.DATASET, prototype=Prototype.OWNER)
+        owner_role = RoleFactory.dataset_owner()
 
         # Create a private output port owned by this user
         private_dataset = DatasetFactory(

--- a/backend/tests/app/data_products/test_router.py
+++ b/backend/tests/app/data_products/test_router.py
@@ -7,7 +7,6 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.authorization.roles.schema import Scope
-from app.authorization.roles.service import RoleService
 from app.core.authz import Action
 from app.resource_names.service import ResourceNameValidityType
 from app.settings import settings
@@ -57,8 +56,7 @@ def payload():
 class TestDataProductsRouter:
     invalid_id = "00000000-0000-0000-0000-000000000000"
 
-    def test_create_data_product(self, payload, client, session):
-        RoleService(db=session).initialize_prototype_roles()
+    def test_create_data_product(self, payload, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,
@@ -72,21 +70,7 @@ class TestDataProductsRouter:
         assert created_data_product.status_code == 200
         assert "id" in created_data_product.json()
 
-    def test_create_data_product_no_owner_role(self, payload, client):
-        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        role = RoleFactory(
-            scope=Scope.GLOBAL,
-            permissions=[Action.GLOBAL__CREATE_DATAPRODUCT],
-        )
-        GlobalRoleAssignmentFactory(
-            user_id=user.id,
-            role_id=role.id,
-        )
-        created_data_product = self.create_data_product(client, payload)
-        assert created_data_product.status_code == 400
-
-    def test_create_data_product_no_owners(self, session, payload, client):
-        RoleService(db=session).initialize_prototype_roles()
+    def test_create_data_product_no_owners(self, payload, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,
@@ -102,8 +86,7 @@ class TestDataProductsRouter:
         created_data_product = self.create_data_product(client, create_payload)
         assert created_data_product.status_code == 422
 
-    def test_create_data_product_duplicate_name(self, session, payload, client):
-        RoleService(db=session).initialize_prototype_roles()
+    def test_create_data_product_duplicate_name(self, payload, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,
@@ -119,8 +102,7 @@ class TestDataProductsRouter:
         created_data_product = self.create_data_product(client, payload)
         assert created_data_product.status_code == 400
 
-    def test_create_data_product_duplicate_namespace(self, session, payload, client):
-        RoleService(db=session).initialize_prototype_roles()
+    def test_create_data_product_duplicate_namespace(self, payload, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,
@@ -139,7 +121,6 @@ class TestDataProductsRouter:
     def test_create_data_product_invalid_characters_namespace(
         self, session, payload, client
     ):
-        RoleService(db=session).initialize_prototype_roles()
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,
@@ -159,7 +140,6 @@ class TestDataProductsRouter:
     def test_create_data_product_invalid_length_namespace(
         self, session, payload, client
     ):
-        RoleService(db=session).initialize_prototype_roles()
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,
@@ -558,8 +538,7 @@ class TestDataProductsRouter:
 
         assert response.status_code == 400
 
-    def test_get_data_product_event_history(self, payload, client: TestClient, session):
-        RoleService(db=session).initialize_prototype_roles()
+    def test_get_data_product_event_history(self, payload, client: TestClient):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,
@@ -580,9 +559,8 @@ class TestDataProductsRouter:
         assert len(history_response.json()["events"]) == 2
 
     def test_history_event_created_on_data_product_creation(
-        self, payload, client: TestClient, session
+        self, payload, client: TestClient
     ):
-        RoleService(db=session).initialize_prototype_roles()
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.GLOBAL,

--- a/backend/tests/app/search_output_ports/test_router.py
+++ b/backend/tests/app/search_output_ports/test_router.py
@@ -6,8 +6,6 @@ from alembic import command
 from alembic.config import Config
 
 from app.authorization.role_assignments.enums import DecisionStatus
-from app.authorization.roles.schema import Prototype, Scope
-from app.authorization.roles.service import RoleService
 from app.data_products.output_ports.model import Dataset
 from app.data_products.output_ports.schema_response import (
     GetDataProductOutputPortsResponse,
@@ -48,7 +46,7 @@ class TestOutputPortSearchRouter:
         ds_1, _, _ = self.setup(session)
 
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        role = RoleFactory(scope=Scope.DATASET, prototype=Prototype.OWNER)
+        role = RoleFactory.dataset_owner()
         DatasetRoleAssignmentFactory(
             dataset=ds_1,
             user_id=user.id,
@@ -205,7 +203,6 @@ class TestOutputPortSearchRouter:
 
     @staticmethod
     def setup(session) -> tuple[Dataset, Dataset, Dataset]:
-        RoleService(db=session).initialize_prototype_roles()
         ds_1 = DatasetFactory(name="Customer Data")
         ds_2 = DatasetFactory(name="Sales Data")
         ds_3 = DatasetFactory(name="Internal Metrics")
@@ -221,7 +218,6 @@ class TestOutputPortSearchRouter:
         command.upgrade(cfg, "heads")
 
         seed_cmd(path="./sample_data.sql")
-        RoleService(db=session).initialize_prototype_roles()
 
         start_time = time.perf_counter()
         OutputPortService(db=session).recalculate_search_for_all_output_ports()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -109,7 +109,10 @@ def default_dataset_payload() -> dict[str, Any]:
 def clear_db(session: scoped_session[Session]) -> None:
     """Clear database after each test."""
     for table in reversed(Base.metadata.sorted_tables):
-        session.execute(table.delete())
+        if table.name == "roles":
+            session.execute(table.delete().where(table.c.prototype == 0))
+        else:
+            session.execute(table.delete())
     session.commit()
     AuthorizationService._clear_casbin_table()
 

--- a/backend/tests/factories/role.py
+++ b/backend/tests/factories/role.py
@@ -2,10 +2,11 @@ from typing import Final
 
 import factory
 from faker import Faker
+from sqlalchemy import select
 
 from app.authorization.roles import ADMIN_UUID
 from app.authorization.roles.model import Role
-from app.authorization.roles.schema import Prototype, Scope
+from app.authorization.roles.schema import Prototype
 from app.core.authz.actions import AuthorizationAction
 from app.core.authz.authorization import Authorization
 from tests import test_session
@@ -22,7 +23,6 @@ class RoleFactory(factory.alchemy.SQLAlchemyModelFactory):
     scope = factory.Faker(
         "random_element", elements=("global", "data_product", "dataset")
     )
-    prototype = Prototype.CUSTOM
     description = factory.Faker("text")
     permissions = factory.Faker(
         "random_elements", elements=list(map(int, AuthorizationAction)), unique=True
@@ -39,6 +39,20 @@ class RoleFactory(factory.alchemy.SQLAlchemyModelFactory):
 
     @classmethod
     def admin(cls):
-        return cls(
-            id=ADMIN_UUID, name="Admin", scope=Scope.GLOBAL, prototype=Prototype.ADMIN
+        return test_session.get(Role, ADMIN_UUID)
+
+    @classmethod
+    def data_product_owner(cls) -> Role:
+        return test_session.scalar(
+            select(Role)
+            .where(Role.prototype == Prototype.OWNER)
+            .where(Role.scope == "data_product")
+        )
+
+    @classmethod
+    def dataset_owner(cls) -> Role:
+        return test_session.scalar(
+            select(Role)
+            .where(Role.prototype == Prototype.OWNER)
+            .where(Role.scope == "dataset")
         )


### PR DESCRIPTION
Before you were enticed to change the function
`initialize_prototype_roles` which shouldn't be
changed since it was part of migration.

However it was required by some tests to function, and other tests created the prototype roles themselves.

Changed tests to not clean up prototype roles
and reused them.

There are still some issues with the migration since the role object is still used in part of it. But
that is for another PR

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested
