### PR TITLE
Exclude requester from approver email recipients (closes #3265)

### DIFF
--- a/backend/app/abstract_data_product/service.py
+++ b/backend/app/abstract_data_product/service.py
@@ -170,11 +170,15 @@ class AbstractDataProductService:
                     dataset_link.dataset_id,
                     Action.OUTPUT_PORT__APPROVE_DATAPRODUCT_ACCESS_REQUEST,
                 )
-                background_tasks.add_task(
-                    email.send_dataset_link_email(
-                        dataset_link.consuming_abstract_data_product,
-                        dataset_link.dataset,
-                        requester=deepcopy(actor),
-                        approvers=[deepcopy(approver) for approver in approvers],
+                other_approvers = [a for a in approvers if a != actor]
+                if other_approvers:
+                    background_tasks.add_task(
+                        email.send_dataset_link_email(
+                            dataset_link.consuming_abstract_data_product,
+                            dataset_link.dataset,
+                            requester=deepcopy(actor),
+                            approvers=[
+                                deepcopy(approver) for approver in other_approvers
+                            ],
+                        )
                     )
-                )

--- a/backend/app/authorization/role_assignments/data_product/router.py
+++ b/backend/app/authorization/role_assignments/data_product/router.py
@@ -139,12 +139,14 @@ def request_data_product_role_assignment(
         data_product_id=role_assignment.data_product_id,
         action=Action.DATA_PRODUCT__APPROVE_USER_REQUEST,
     )
-    background_tasks.add_task(
-        email.send_role_assignment_request_email,
-        deepcopy(role_assignment.user),
-        deepcopy(role_assignment.data_product),
-        [deepcopy(approver) for approver in approvers],
-    )
+    other_approvers = [a for a in approvers if a != user]
+    if other_approvers:
+        background_tasks.add_task(
+            email.send_role_assignment_request_email,
+            deepcopy(role_assignment.user),
+            deepcopy(role_assignment.data_product),
+            [deepcopy(approver) for approver in other_approvers],
+        )
     return role_assignment
 
 

--- a/backend/app/data_products/output_port_technical_assets_link/router.py
+++ b/backend/app/data_products/output_port_technical_assets_link/router.py
@@ -178,13 +178,14 @@ def link_output_port_to_technical_asset(
         dataset_link.dataset_id,
         Action.OUTPUT_PORT__APPROVE_TECHNICAL_ASSET_LINK_REQUEST,
     )
-    if authenticated_user not in approvers:
+    other_approvers = [a for a in approvers if a != authenticated_user]
+    if other_approvers:
         background_tasks.add_task(
             email.send_link_dataset_email(
                 dataset_link.dataset,
                 dataset_link.data_output,
                 requester=deepcopy(authenticated_user),
-                approvers=[deepcopy(approver) for approver in approvers],
+                approvers=[deepcopy(approver) for approver in other_approvers],
             )
         )
     return LinkTechnicalAssetsToOutputPortResponse(link_id=dataset_link.id)


### PR DESCRIPTION
Closes #3265.

## Summary

When a user requested an output-port link, dataset access, or data-product role and was themselves one of the approvers, they got the resulting "Action Required" email about their own request. This filters the requester out of the approver-email recipients at the three call sites that triggered it.

## Changes

- \`backend/app/data_products/output_port_technical_assets_link/router.py\` — replaced the all-or-nothing \`if authenticated_user not in approvers\` guard with a \`other_approvers\` filter so the email still goes to the rest of the approver set when the requester happens to be one of them.
- \`backend/app/abstract_data_product/service.py\` — the input-port path added in #3253 sent to the full approver set; now filters \`actor\` out before mailing.
- \`backend/app/authorization/role_assignments/data_product/router.py\` (\`request_data_product_role_assignment\`) — same filter for the role-request flow. The sibling \`create_data_product_role_assignment\` path already short-circuits via the auto-approval branch (\`is_admin or user.id in approvers\`), so it didn't need a change.

When the filtered list is empty (requester was the sole approver), no email is sent — that preserves the existing auto-approval behavior covered by \`test_dataset_link_auto_approval_no_email_sent\`.

## Verification

- \`python3 -m py_compile\` on all three files passes.
- I don't have a local poetry/pytest env, so the existing CI suite is the test of record. The single-approver test referenced above asserts \`mock_send_email.assert_not_called()\`, which still holds (filtered list is empty -> branch not taken). The manual-approval test asserts \`assert_called_once()\`, also still holds (requester has no approve permission, so they're not in \`approvers\` to begin with).