### PR TITLE
Added support for input ports on create data product

### DIFF
--- a/backend/app/data_products/router.py
+++ b/backend/app/data_products/router.py
@@ -30,6 +30,7 @@ from app.data_products.schema_request import (
     DataProductUpdate,
     DataProductUsageUpdate,
     LinkInputPortsToDataProduct,
+    RequestInputPortsForDataProductRequest,
 )
 from app.data_products.schema_response import (
     CreateDataProductResponse,
@@ -40,6 +41,7 @@ from app.data_products.schema_response import (
     GetDataProductsResponse,
     GetDataProductsResponseItem,
     LinkInputPortsToDataProductPost,
+    RequestInputPortsForDataProductResponse,
     UpdateDataProductResponse,
 )
 from app.data_products.service import DataProductService
@@ -55,7 +57,7 @@ from app.graph.graph import Graph
 from app.users.notifications.service import NotificationService
 from app.users.schema import User
 
-router = APIRouter()
+router = APIRouter(tags=["Data Products"], prefix="/v2/data_products")
 
 
 @router.post(
@@ -84,6 +86,7 @@ router = APIRouter()
 )
 def create_data_product(
     data_product: DataProductCreate,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db_session),
     authenticated_user: User = Depends(get_authenticated_user),
 ) -> CreateDataProductResponse:
@@ -110,9 +113,14 @@ def create_data_product(
         extra_receiver_ids=owners,
     )
     RefreshInfrastructureLambda().trigger()
-    OutputPortService(db).recalculate_search_for_output_ports_of_product(
-        created_data_product.id
-    )
+    if data_product.input_ports is not None:
+        request_input_ports_for_data_product(
+            created_data_product.id,
+            data_product.input_ports,
+            background_tasks=background_tasks,
+            authenticated_user=authenticated_user,
+            db=db,
+        )
     return CreateDataProductResponse(id=created_data_product.id)
 
 
@@ -357,37 +365,35 @@ def set_value_for_data_product(
     RefreshInfrastructureLambda().trigger()
 
 
-_router = router
-router = APIRouter(tags=["Data Products"])
-route = "/v2/data_products"
-
-router.include_router(_router, prefix=route)
+_input_ports_responses = {
+    400: {
+        "description": "Output port not found",
+        "content": {
+            "application/json": {"example": {"detail": "Output port not found"}}
+        },
+    },
+    404: {
+        "description": "Data Product not found",
+        "content": {
+            "application/json": {"example": {"detail": "Data Product id not found"}}
+        },
+    },
+}
+_input_ports_dependencies = [
+    Depends(
+        Authorization.enforce(
+            Action.DATA_PRODUCT__REQUEST_OUTPUT_PORT_ACCESS,
+            DataProductResolver,
+        )
+    ),
+]
 
 
 @router.post(
-    f"{route}/{{id}}/link_input_ports",
-    responses={
-        400: {
-            "description": "Output port not found",
-            "content": {
-                "application/json": {"example": {"detail": "Output port not found"}}
-            },
-        },
-        404: {
-            "description": "Data Product not found",
-            "content": {
-                "application/json": {"example": {"detail": "Data Product id not found"}}
-            },
-        },
-    },
-    dependencies=[
-        Depends(
-            Authorization.enforce(
-                Action.DATA_PRODUCT__REQUEST_OUTPUT_PORT_ACCESS,
-                DataProductResolver,
-            )
-        ),
-    ],
+    "/{id}/link_input_ports",
+    responses=_input_ports_responses,
+    dependencies=_input_ports_dependencies,
+    deprecated=True,
 )
 def link_input_ports_to_data_product(
     id: UUID,
@@ -396,10 +402,36 @@ def link_input_ports_to_data_product(
     authenticated_user: User = Depends(get_authenticated_user),
     db: Session = Depends(get_db_session),
 ) -> LinkInputPortsToDataProductPost:
+    return LinkInputPortsToDataProductPost(
+        input_port_links=request_input_ports_for_data_product(
+            id,
+            RequestInputPortsForDataProductRequest(
+                output_ports=link_input_ports.input_ports,
+                justification=link_input_ports.justification,
+            ),
+            background_tasks,
+            authenticated_user,
+            db,
+        ).input_port_links
+    )
+
+
+@router.post(
+    "/{id}/input_ports",
+    responses=_input_ports_responses,
+    dependencies=_input_ports_dependencies,
+)
+def request_input_ports_for_data_product(
+    id: UUID,
+    request: RequestInputPortsForDataProductRequest,
+    background_tasks: BackgroundTasks,
+    authenticated_user: User = Depends(get_authenticated_user),
+    db: Session = Depends(get_db_session),
+) -> RequestInputPortsForDataProductResponse:
     input_ports = DataProductService(db).request_input_ports(
         id,
-        link_input_ports.input_ports,
-        link_input_ports.justification,
+        request.output_ports,
+        request.justification,
         actor=authenticated_user,
     )
 
@@ -431,12 +463,12 @@ def link_input_ports_to_data_product(
         input_ports, background_tasks, authenticated_user
     )
     RefreshInfrastructureLambda().trigger()
-    return LinkInputPortsToDataProductPost(
+    return RequestInputPortsForDataProductResponse(
         input_port_links=[dataset_link.id for dataset_link in input_ports]
     )
 
 
-@router.get(route)
+@router.get("")
 def get_data_products(
     db: Session = Depends(get_db_session),
     filter_to_user_with_assigment: Optional[UUID] = Query(default=None),
@@ -451,7 +483,7 @@ def get_data_products(
     )
 
 
-@router.get(f"{route}/{{id}}/history")
+@router.get("/{id}/history")
 def get_data_product_event_history(
     id: UUID, db: Session = Depends(get_db_session)
 ) -> GetEventHistoryResponse:
@@ -465,14 +497,14 @@ def get_data_product_event_history(
     )
 
 
-@router.get(f"{route}/{{id}}")
+@router.get("/{id}")
 def get_data_product(
     id: UUID, db: Session = Depends(get_db_session)
 ) -> GetDataProductResponse:
     return DataProductService(db).get_data_product(id)
 
 
-@router.get(f"{route}/{{id}}/input_ports")
+@router.get("/{id}/input_ports")
 def get_data_product_input_ports(
     id: UUID,
     db: Session = Depends(get_db_session),
@@ -485,7 +517,7 @@ def get_data_product_input_ports(
     )
 
 
-@router.get(f"{route}/{{id}}/rolled_up_tags")
+@router.get("/{id}/rolled_up_tags")
 def get_data_product_rolled_up_tags(
     id: UUID, db: Session = Depends(get_db_session)
 ) -> GetDataProductRolledUpTagsResponse:
@@ -495,7 +527,7 @@ def get_data_product_rolled_up_tags(
 
 
 @router.delete(
-    f"{route}/{{id}}/input_ports/{{input_port_id}}",
+    "/{id}/input_ports/{input_port_id}",
     responses={
         400: {
             "description": "Output port not found",
@@ -548,7 +580,7 @@ def unlink_input_port_from_data_product(
     RefreshInfrastructureLambda().trigger()
 
 
-@router.get(f"{route}/{{id}}/settings")
+@router.get("/{id}/settings")
 def get_data_product_settings(
     id: UUID, db: Session = Depends(get_db_session)
 ) -> GetDataProductSettingsResponse:

--- a/backend/app/data_products/schema_request.py
+++ b/backend/app/data_products/schema_request.py
@@ -19,8 +19,15 @@ class DataProductUpdate(ORMModel):
     lifecycle_id: UUID
 
 
+class RequestInputPortsForDataProductRequest(ORMModel):
+    output_ports: list[UUID]
+    justification: str
+
+
 class DataProductCreate(DataProductUpdate):
     owners: Annotated[list[UUID], MinLen(1)]
+
+    input_ports: Optional[RequestInputPortsForDataProductRequest] = None
 
 
 class DataProductAboutUpdate(ORMModel):

--- a/backend/app/data_products/schema_response.py
+++ b/backend/app/data_products/schema_response.py
@@ -71,6 +71,10 @@ class LinkInputPortsToDataProductPost(ORMModel):
     input_port_links: list[UUID]
 
 
+class RequestInputPortsForDataProductResponse(ORMModel):
+    input_port_links: list[UUID]
+
+
 class GetDataProductsResponse(ORMModel):
     data_products: Sequence[GetDataProductsResponseItem]
 

--- a/backend/app/data_products/service.py
+++ b/backend/app/data_products/service.py
@@ -172,7 +172,7 @@ class DataProductService(AbstractDataProductService):
                 detail=f"Invalid namespace: {validity.value}",
             )
 
-        data_product_schema = data_product.parse_pydantic_schema()
+        data_product_schema = data_product.model_dump(exclude={"input_ports"})
         tags = self._get_tags(data_product_schema.pop("tag_ids", []))
         _ = data_product_schema.pop("owners", [])
         model = DataProductModel(**data_product_schema, tags=tags)

--- a/backend/tests/app/data_products/output_ports/input_ports/test_router.py
+++ b/backend/tests/app/data_products/output_ports/input_ports/test_router.py
@@ -27,7 +27,7 @@ DATA_PRODUCTS_ENDPOINT = "/api/v2/data_products"
 class TestDataProductsDatasetsRouter:
     invalid_id = "00000000-0000-0000-0000-000000000000"
 
-    def test_request_data_product_link(self, client):
+    def test_request_input_ports_for_data_product(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.DATA_PRODUCT,
@@ -41,15 +41,15 @@ class TestDataProductsDatasetsRouter:
         )
         ds = DatasetFactory()
 
-        response = self.request_data_product_dataset_link(
-            client, data_product.id, ds.id
+        response = self.request_input_ports_for_data_product(
+            client, data_product.id, [ds.id]
         )
         assert response.status_code == 200
         history_response = self.get_data_product_history(client, data_product.id)
         assert history_response.status_code == 200, history_response.text
         assert len(history_response.json()) == 1
 
-    def test_request_data_product_multiple_link_old(self, client):
+    def test_request_input_ports_for_data_product_deprecated(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.DATA_PRODUCT,
@@ -61,15 +61,15 @@ class TestDataProductsDatasetsRouter:
             role_id=role.id,
             data_product_id=data_product.id,
         )
-        ds1 = DatasetFactory()
-        ds2 = DatasetFactory()
+        ds = DatasetFactory()
 
-        response = self.request_data_product_datasets_link(
-            client, data_product.id, [ds1.id, ds2.id]
+        response = self.request_input_ports_for_data_product_deprecated(
+            client, data_product.id, [ds.id]
         )
         assert response.status_code == 200
-        history = self.get_data_product_history(client, data_product.id).json()
-        assert len(history["events"]) == 2
+        history_response = self.get_data_product_history(client, data_product.id)
+        assert history_response.status_code == 200, history_response.text
+        assert len(history_response.json()) == 1
 
     def test_request_data_product_multiple_link(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
@@ -86,14 +86,14 @@ class TestDataProductsDatasetsRouter:
         ds1 = DatasetFactory()
         ds2 = DatasetFactory()
 
-        response = self.request_link_input_ports(
+        response = self.request_input_ports_for_data_product(
             client, data_product.id, [ds1.id, ds2.id]
         )
         assert response.status_code == 200, response.text
         history = self.get_data_product_history(client, data_product.id).json()
         assert len(history["events"]) == 2
 
-    def test_request_already_exists(self, client):
+    def test_request_input_ports_for_data_product_already_exists(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.DATA_PRODUCT,
@@ -107,25 +107,27 @@ class TestDataProductsDatasetsRouter:
         )
         ds = DatasetFactory()
 
-        response = self.request_data_product_dataset_link(
-            client, data_product.id, ds.id
+        response = self.request_input_ports_for_data_product(
+            client, data_product.id, [ds.id]
         )
         assert response.status_code == 200
-        response = self.request_data_product_dataset_link(
-            client, data_product.id, ds.id
+        response = self.request_input_ports_for_data_product(
+            client, data_product.id, [ds.id]
         )
         assert response.status_code == 400
 
-    def test_request_data_product_link_private_dataset_no_access(self, client):
+    def test_request_input_ports_for_data_product_private_dataset_no_access(
+        self, client
+    ):
         data_product = DataProductFactory()
         ds = DatasetFactory(access_type=OutputPortAccessType.PRIVATE)
 
-        response = self.request_data_product_dataset_link(
-            client, data_product.id, ds.id
+        response = self.request_input_ports_for_data_product(
+            client, data_product.id, [ds.id]
         )
         assert response.status_code == 403
 
-    def test_request_data_product_link_private_dataset(self, client):
+    def test_request_input_ports_for_data_product_private_dataset(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.DATA_PRODUCT,
@@ -141,8 +143,8 @@ class TestDataProductsDatasetsRouter:
         role = RoleFactory(scope=Scope.DATASET)
         DatasetRoleAssignmentFactory(user_id=user.id, role_id=role.id, dataset_id=ds.id)
 
-        response = self.request_data_product_dataset_link(
-            client, data_product.id, ds.id
+        response = self.request_input_ports_for_data_product(
+            client, data_product.id, [ds.id]
         )
         assert response.status_code == 200
 
@@ -195,7 +197,9 @@ class TestDataProductsDatasetsRouter:
         data_product = DataProductFactory()
         ds = DatasetFactory()
 
-        link = self.request_data_product_dataset_link(client, data_product.id, ds.id)
+        link = self.request_input_ports_for_data_product(
+            client, data_product.id, [ds.id]
+        )
         assert link.status_code == 200
 
     def test_approve_data_product_link(self, client):
@@ -346,8 +350,8 @@ class TestDataProductsDatasetsRouter:
         DataProductRoleAssignmentFactory(
             user_id=user.id, role_id=role.id, data_product_id=data_product.id
         )
-        response = self.request_data_product_dataset_link(
-            client, data_product.id, self.invalid_id
+        response = self.request_input_ports_for_data_product(
+            client, data_product.id, [self.invalid_id]
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -496,8 +500,8 @@ class TestDataProductsDatasetsRouter:
             data_product_id=data_product.id,
         )
         ds = DatasetFactory()
-        response = self.request_data_product_dataset_link(
-            client, data_product.id, ds.id
+        response = self.request_input_ports_for_data_product(
+            client, data_product.id, [ds.id]
         )
 
         assert response.status_code == 200
@@ -511,32 +515,24 @@ class TestDataProductsDatasetsRouter:
         assert len(history["events"]) == 2
 
     @staticmethod
-    def request_data_product_dataset_link(
+    def request_input_ports_for_data_product(
         client: TestClient,
         data_product_id: UUID,
-        dataset_id: UUID,
+        output_port_ids: list[UUID],
         justification: str = "This is my birth right!",
     ) -> Response:
-        return TestDataProductsDatasetsRouter.request_data_product_datasets_link(
-            client,
-            data_product_id,
-            [dataset_id],
-            justification,
+        return client.post(
+            f"{DATA_PRODUCTS_ENDPOINT}/{data_product_id}/input_ports",
+            json={
+                "output_ports": [
+                    str(output_port_id) for output_port_id in output_port_ids
+                ],
+                "justification": justification,
+            },
         )
 
     @staticmethod
-    def request_data_product_datasets_link(
-        client: TestClient,
-        data_product_id: UUID,
-        dataset_ids: list[UUID],
-        justification: str = "This is my birth right!",
-    ) -> Response:
-        return TestDataProductsDatasetsRouter.request_link_input_ports(
-            client, data_product_id, dataset_ids, justification
-        )
-
-    @staticmethod
-    def request_link_input_ports(
+    def request_input_ports_for_data_product_deprecated(
         client: TestClient,
         data_product_id: UUID,
         output_port_ids: list[UUID],

--- a/backend/tests/app/data_products/test_router.py
+++ b/backend/tests/app/data_products/test_router.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 from copy import deepcopy
+from typing import Any, Dict
 from uuid import UUID
 
 import pytest
@@ -36,7 +37,21 @@ ENDPOINT = "/api/v2/data_products"
 
 
 @pytest.fixture
-def payload():
+def user_with_create_data_product_rights():
+    user = UserFactory(external_id=settings.DEFAULT_USERNAME)
+    role = RoleFactory(
+        scope=Scope.GLOBAL,
+        permissions=[Action.GLOBAL__CREATE_DATAPRODUCT],
+    )
+    GlobalRoleAssignmentFactory(
+        user_id=user.id,
+        role_id=role.id,
+    )
+    return user
+
+
+@pytest.fixture
+def payload() -> Dict[str, Any]:
     domain = DomainFactory()
     lifecycle = LifecycleFactory()
     data_product_type = DataProductTypeFactory()
@@ -57,80 +72,58 @@ def payload():
 class TestDataProductsRouter:
     invalid_id = "00000000-0000-0000-0000-000000000000"
 
-    def test_create_data_product(self, payload, client):
-        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        role = RoleFactory(
-            scope=Scope.GLOBAL,
-            permissions=[Action.GLOBAL__CREATE_DATAPRODUCT],
-        )
-        GlobalRoleAssignmentFactory(
-            user_id=user.id,
-            role_id=role.id,
-        )
+    def test_create_data_product(
+        self, payload, client, user_with_create_data_product_rights
+    ):
         created_data_product = self.create_data_product(client, payload)
         assert created_data_product.status_code == 200
         assert "id" in created_data_product.json()
 
-    def test_create_data_product_no_owners(self, payload, client):
-        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        role = RoleFactory(
-            scope=Scope.GLOBAL,
-            permissions=[Action.GLOBAL__CREATE_DATAPRODUCT],
-        )
-        GlobalRoleAssignmentFactory(
-            user_id=user.id,
-            role_id=role.id,
-        )
+    def test_create_data_product_with_input_ports(
+        self, payload, client, user_with_create_data_product_rights
+    ):
+        ds = DatasetFactory()
+        payload["input_ports"] = {
+            "output_ports": [str(ds.id)],
+            "justification": "I am your king",
+        }
+        created_data_product = self.create_data_product(client, payload)
+        assert created_data_product.status_code == 200
+        assert "id" in created_data_product.json()
 
+        input_ports_response = self.get_input_ports(
+            client, created_data_product.json()["id"]
+        )
+        assert input_ports_response.status_code == 200
+        assert len(input_ports_response.json()["input_ports"]) == 1
+
+    def test_create_data_product_no_owners(
+        self, payload, client, user_with_create_data_product_rights
+    ):
         create_payload = deepcopy(payload)
         create_payload["owners"] = []
         created_data_product = self.create_data_product(client, create_payload)
         assert created_data_product.status_code == 422
 
-    def test_create_data_product_duplicate_name(self, payload, client):
-        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        role = RoleFactory(
-            scope=Scope.GLOBAL,
-            permissions=[Action.GLOBAL__CREATE_DATAPRODUCT],
-        )
-        GlobalRoleAssignmentFactory(
-            user_id=user.id,
-            role_id=role.id,
-        )
-
+    def test_create_data_product_duplicate_name(
+        self, payload, client, user_with_create_data_product_rights
+    ):
         DataProductFactory(name=payload["name"])
 
         created_data_product = self.create_data_product(client, payload)
         assert created_data_product.status_code == 400
 
-    def test_create_data_product_duplicate_namespace(self, payload, client):
-        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        role = RoleFactory(
-            scope=Scope.GLOBAL,
-            permissions=[Action.GLOBAL__CREATE_DATAPRODUCT],
-        )
-        GlobalRoleAssignmentFactory(
-            user_id=user.id,
-            role_id=role.id,
-        )
-
+    def test_create_data_product_duplicate_namespace(
+        self, payload, client, user_with_create_data_product_rights
+    ):
         DataProductFactory(namespace=payload["namespace"])
 
         created_data_product = self.create_data_product(client, payload)
         assert created_data_product.status_code == 400
 
     def test_create_data_product_invalid_characters_namespace(
-        self, session, payload, client
+        self, session, payload, client, user_with_create_data_product_rights
     ):
-        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        role = RoleFactory(
-            scope=Scope.GLOBAL,
-            permissions=[Action.GLOBAL__CREATE_DATAPRODUCT],
-        )
-        GlobalRoleAssignmentFactory(
-            user_id=user.id,
-            role_id=role.id,
-        )
 
         create_payload = deepcopy(payload)
         create_payload["namespace"] = "!"
@@ -139,17 +132,8 @@ class TestDataProductsRouter:
         assert created_data_product.status_code == 400
 
     def test_create_data_product_invalid_length_namespace(
-        self, session, payload, client
+        self, payload, client, user_with_create_data_product_rights
     ):
-        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        role = RoleFactory(
-            scope=Scope.GLOBAL,
-            permissions=[Action.GLOBAL__CREATE_DATAPRODUCT],
-        )
-        GlobalRoleAssignmentFactory(
-            user_id=user.id,
-            role_id=role.id,
-        )
 
         create_payload = deepcopy(payload)
         create_payload["namespace"] = "a" * 256
@@ -553,16 +537,9 @@ class TestDataProductsRouter:
 
         assert response.status_code == 400
 
-    def test_get_data_product_event_history(self, payload, client: TestClient):
-        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        role = RoleFactory(
-            scope=Scope.GLOBAL,
-            permissions=[Action.GLOBAL__CREATE_DATAPRODUCT],
-        )
-        GlobalRoleAssignmentFactory(
-            user_id=user.id,
-            role_id=role.id,
-        )
+    def test_get_data_product_event_history(
+        self, payload, client: TestClient, user_with_create_data_product_rights
+    ):
         created_data_product = self.create_data_product(client, payload)
         assert created_data_product.status_code == 200
         assert "id" in created_data_product.json()
@@ -574,17 +551,8 @@ class TestDataProductsRouter:
         assert len(history_response.json()["events"]) == 2
 
     def test_history_event_created_on_data_product_creation(
-        self, payload, client: TestClient
+        self, payload, client: TestClient, user_with_create_data_product_rights
     ):
-        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        role = RoleFactory(
-            scope=Scope.GLOBAL,
-            permissions=[Action.GLOBAL__CREATE_DATAPRODUCT],
-        )
-        GlobalRoleAssignmentFactory(
-            user_id=user.id,
-            role_id=role.id,
-        )
         created_data_product = self.create_data_product(client, payload)
         assert created_data_product.status_code == 200
         assert "id" in created_data_product.json()

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -1873,6 +1873,7 @@
         ],
         "summary": "Link Input Ports To Data Product",
         "operationId": "link_input_ports_to_data_product",
+        "deprecated": true,
         "parameters": [
           {
             "name": "id",
@@ -1939,6 +1940,120 @@
         }
       }
     },
+    "/api/v2/data_products/{id}/input_ports": {
+      "post": {
+        "tags": [
+          "Data Products"
+        ],
+        "summary": "Request Input Ports For Data Product",
+        "operationId": "request_input_ports_for_data_product",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RequestInputPortsForDataProductRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestInputPortsForDataProductResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Output port not found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "detail": "Output port not found"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Data Product not found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "detail": "Data Product id not found"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Data Products"
+        ],
+        "summary": "Get Data Product Input Ports",
+        "operationId": "get_data_product_input_ports",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetDataProductInputPortsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/data_products/{id}/history": {
       "get": {
         "tags": [
@@ -1965,49 +2080,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetEventHistoryResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v2/data_products/{id}/input_ports": {
-      "get": {
-        "tags": [
-          "Data Products"
-        ],
-        "summary": "Get Data Product Input Ports",
-        "operationId": "get_data_product_input_ports",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetDataProductInputPortsResponse"
                 }
               }
             }
@@ -7917,6 +7989,16 @@
             "type": "array",
             "minItems": 1,
             "title": "Owners"
+          },
+          "input_ports": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RequestInputPortsForDataProductRequest"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -12233,6 +12315,45 @@
           "data_product_id"
         ],
         "title": "RequestDataProductRoleAssignment"
+      },
+      "RequestInputPortsForDataProductRequest": {
+        "properties": {
+          "output_ports": {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array",
+            "title": "Output Ports"
+          },
+          "justification": {
+            "type": "string",
+            "title": "Justification"
+          }
+        },
+        "type": "object",
+        "required": [
+          "output_ports",
+          "justification"
+        ],
+        "title": "RequestInputPortsForDataProductRequest"
+      },
+      "RequestInputPortsForDataProductResponse": {
+        "properties": {
+          "input_port_links": {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array",
+            "title": "Input Port Links"
+          }
+        },
+        "type": "object",
+        "required": [
+          "input_port_links"
+        ],
+        "title": "RequestInputPortsForDataProductResponse"
       },
       "RequestInputPortsForExplorationRequest": {
         "properties": {

--- a/frontend/src/pages/cart-explorations/components/existing-data-product-form.tsx
+++ b/frontend/src/pages/cart-explorations/components/existing-data-product-form.tsx
@@ -14,7 +14,7 @@ import { useAppDispatch } from '@/store';
 import { selectCurrentUser } from '@/store/api/services/auth-slice.ts';
 import {
     useGetDataProductsQuery,
-    useLinkInputPortsToDataProductMutation,
+    useRequestInputPortsForDataProductMutation,
 } from '@/store/api/services/generated/dataProductsApi.ts';
 import type { SearchOutputPortsResponseItem } from '@/store/api/services/generated/outputPortsSearchApi.ts';
 import { clearCart } from '@/store/features/cart/cart-slice.ts';
@@ -36,8 +36,8 @@ export const ExistingDataProductForm = ({ cartOutputPorts, setSelectedDataProduc
     const posthog = usePostHog();
     const navigate = useNavigate();
 
-    const [requestDatasetAccessForDataProduct, { isSuccess: requestingAccessSuccess, isLoading: isRequestingAccess }] =
-        useLinkInputPortsToDataProductMutation();
+    const [requestInputPortsForDataProduct, { isSuccess: requestingAccessSuccess, isLoading: isRequestingAccess }] =
+        useRequestInputPortsForDataProductMutation();
     const [form] = Form.useForm<CartFormData>();
     const selectedDataProductId = Form.useWatch('dataProductId', form);
     useEffect(() => {
@@ -103,10 +103,10 @@ export const ExistingDataProductForm = ({ cartOutputPorts, setSelectedDataProduc
             cartSize: cartOutputPorts?.length,
         });
         clearStorage();
-        requestDatasetAccessForDataProduct({
+        requestInputPortsForDataProduct({
             id: values.dataProductId,
-            linkInputPortsToDataProduct: {
-                input_ports: cartOutputPorts?.map((dataset) => dataset.id),
+            requestInputPortsForDataProductRequest: {
+                output_ports: cartOutputPorts?.map((dataset) => dataset.id),
                 justification: values.justification,
             },
         });

--- a/frontend/src/pages/cart-explorations/components/new-data-product-form.tsx
+++ b/frontend/src/pages/cart-explorations/components/new-data-product-form.tsx
@@ -16,7 +16,6 @@ import { selectCurrentUser } from '@/store/api/services/auth-slice.ts';
 import {
     type DataProductCreate,
     useCreateDataProductMutation,
-    useLinkInputPortsToDataProductMutation,
 } from '@/store/api/services/generated/dataProductsApi.ts';
 import type { SearchOutputPortsResponseItem } from '@/store/api/services/generated/outputPortsSearchApi.ts';
 import { clearCart } from '@/store/features/cart/cart-slice.ts';
@@ -39,7 +38,6 @@ export const NewDataProductForm = ({ cartOutputPorts }: Props) => {
     const currentUser = useSelector(selectCurrentUser);
 
     const [createDataProduct] = useCreateDataProductMutation();
-    const [requestDatasetAccessForDataProduct] = useLinkInputPortsToDataProductMutation();
     const [submitting, setSubmitting] = useState(false);
     const { onValuesChange, clearStorage } = useFormPersist<NewDataProductCartFormData>(
         form,
@@ -53,13 +51,11 @@ export const NewDataProductForm = ({ cartOutputPorts }: Props) => {
                 if (cartOutputPorts === undefined || cartOutputPorts.length === 0) {
                     return;
                 }
-                const response = await createDataProduct(request).unwrap();
-
-                await requestDatasetAccessForDataProduct({
-                    id: response.id,
-                    linkInputPortsToDataProduct: {
-                        input_ports: cartOutputPorts?.map((dataset) => dataset.id),
-                        justification: justification,
+                const response = await createDataProduct({
+                    ...request,
+                    input_ports: {
+                        justification,
+                        output_ports: cartOutputPorts?.map((dataset) => dataset.id),
                     },
                 }).unwrap();
                 dispatch(clearCart());
@@ -75,15 +71,7 @@ export const NewDataProductForm = ({ cartOutputPorts }: Props) => {
                 setSubmitting(false);
             }
         },
-        [
-            requestDatasetAccessForDataProduct,
-            posthog,
-            createDataProduct,
-            navigate,
-            clearStorage,
-            cartOutputPorts,
-            dispatch,
-        ],
+        [posthog, createDataProduct, navigate, clearStorage, cartOutputPorts, dispatch],
     );
     const initialValues = {
         owners: currentUser?.id ? [currentUser?.id] : [],

--- a/frontend/src/store/api/services/generated/dataProductsApi.ts
+++ b/frontend/src/store/api/services/generated/dataProductsApi.ts
@@ -110,12 +110,14 @@ const injectedRtkApi = api.injectEndpoints({
         body: queryArg.linkInputPortsToDataProduct,
       }),
     }),
-    getDataProductEventHistory: build.query<
-      GetDataProductEventHistoryApiResponse,
-      GetDataProductEventHistoryApiArg
+    requestInputPortsForDataProduct: build.mutation<
+      RequestInputPortsForDataProductApiResponse,
+      RequestInputPortsForDataProductApiArg
     >({
       query: (queryArg) => ({
-        url: `/api/v2/data_products/${queryArg}/history`,
+        url: `/api/v2/data_products/${queryArg.id}/input_ports`,
+        method: "POST",
+        body: queryArg.requestInputPortsForDataProductRequest,
       }),
     }),
     getDataProductInputPorts: build.query<
@@ -124,6 +126,14 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({
         url: `/api/v2/data_products/${queryArg}/input_ports`,
+      }),
+    }),
+    getDataProductEventHistory: build.query<
+      GetDataProductEventHistoryApiResponse,
+      GetDataProductEventHistoryApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/v2/data_products/${queryArg}/history`,
       }),
     }),
     getDataProductRolledUpTags: build.query<
@@ -210,12 +220,18 @@ export type LinkInputPortsToDataProductApiArg = {
   id: string;
   linkInputPortsToDataProduct: LinkInputPortsToDataProduct;
 };
-export type GetDataProductEventHistoryApiResponse =
-  /** status 200 Successful Response */ GetEventHistoryResponse;
-export type GetDataProductEventHistoryApiArg = string;
+export type RequestInputPortsForDataProductApiResponse =
+  /** status 200 Successful Response */ RequestInputPortsForDataProductResponse;
+export type RequestInputPortsForDataProductApiArg = {
+  id: string;
+  requestInputPortsForDataProductRequest: RequestInputPortsForDataProductRequest;
+};
 export type GetDataProductInputPortsApiResponse =
   /** status 200 Successful Response */ GetDataProductInputPortsResponse;
 export type GetDataProductInputPortsApiArg = string;
+export type GetDataProductEventHistoryApiResponse =
+  /** status 200 Successful Response */ GetEventHistoryResponse;
+export type GetDataProductEventHistoryApiArg = string;
 export type GetDataProductRolledUpTagsApiResponse =
   /** status 200 Successful Response */ GetDataProductRolledUpTagsResponse;
 export type GetDataProductRolledUpTagsApiArg = string;
@@ -241,6 +257,10 @@ export type ValidationError = {
 export type HttpValidationError = {
   detail?: ValidationError[];
 };
+export type RequestInputPortsForDataProductRequest = {
+  output_ports: string[];
+  justification: string;
+};
 export type DataProductCreate = {
   name: string;
   namespace: string;
@@ -251,6 +271,7 @@ export type DataProductCreate = {
   tag_ids?: string[];
   lifecycle_id: string;
   owners: string[];
+  input_ports?: RequestInputPortsForDataProductRequest | null;
 };
 export type Tag = {
   id: string;
@@ -361,6 +382,29 @@ export type LinkInputPortsToDataProduct = {
   input_ports: string[];
   justification: string;
 };
+export type RequestInputPortsForDataProductResponse = {
+  input_port_links: string[];
+};
+export type OutputPort = {
+  id: string;
+  name: string;
+  namespace: string;
+  description: string;
+  status: OutputPortStatus;
+  access_type: OutputPortAccessType;
+  data_product_id: string;
+  tags: Tag[];
+};
+export type InputPort = {
+  id: string;
+  justification: string;
+  status: DecisionStatus;
+  output_port_id: string;
+  output_port: OutputPort;
+};
+export type GetDataProductInputPortsResponse = {
+  input_ports: InputPort[];
+};
 export type User = {
   id: string;
   email: string;
@@ -378,16 +422,6 @@ export type DataProduct = {
   description: string;
   status: DataProductStatus;
   type: DataProductType;
-};
-export type OutputPort = {
-  id: string;
-  name: string;
-  namespace: string;
-  description: string;
-  status: OutputPortStatus;
-  access_type: OutputPortAccessType;
-  data_product_id: string;
-  tags: Tag[];
 };
 export type AzureBlobTechnicalAssetConfiguration = {
   configuration_type: "AzureBlobTechnicalAssetConfiguration";
@@ -509,16 +543,6 @@ export type GetEventHistoryResponseItem = {
 export type GetEventHistoryResponse = {
   events: GetEventHistoryResponseItem[];
 };
-export type InputPort = {
-  id: string;
-  justification: string;
-  status: DecisionStatus;
-  output_port_id: string;
-  output_port: OutputPort;
-};
-export type GetDataProductInputPortsResponse = {
-  input_ports: InputPort[];
-};
 export type GetDataProductRolledUpTagsResponse = {
   rolled_up_tags: Tag[];
 };
@@ -563,11 +587,10 @@ export enum NodeType {
   DatasetNode = "datasetNode",
   DomainNode = "domainNode",
 }
-export enum EventEntityType {
-  DataProduct = "data_product",
-  OutputPort = "output_port",
-  TechnicalAsset = "technical_asset",
-  User = "user",
+export enum DecisionStatus {
+  Approved = "approved",
+  Pending = "pending",
+  Denied = "denied",
 }
 export enum OutputPortStatus {
   Pending = "pending",
@@ -579,6 +602,12 @@ export enum OutputPortAccessType {
   Restricted = "restricted",
   Private = "private",
   Unrestricted = "unrestricted",
+}
+export enum EventEntityType {
+  DataProduct = "data_product",
+  OutputPort = "output_port",
+  TechnicalAsset = "technical_asset",
+  User = "user",
 }
 export enum TechnicalAssetStatus {
   Pending = "pending",
@@ -592,11 +621,6 @@ export enum TechnicalMapping {
 export enum AccessGranularity {
   Schema = "schema",
   Table = "table",
-}
-export enum DecisionStatus {
-  Approved = "approved",
-  Pending = "pending",
-  Denied = "denied",
 }
 export enum DataProductSettingType {
   Checkbox = "checkbox",
@@ -622,10 +646,11 @@ export const {
   useLazyGetDataProductGraphDataQuery,
   useSetValueForDataProductMutation,
   useLinkInputPortsToDataProductMutation,
-  useGetDataProductEventHistoryQuery,
-  useLazyGetDataProductEventHistoryQuery,
+  useRequestInputPortsForDataProductMutation,
   useGetDataProductInputPortsQuery,
   useLazyGetDataProductInputPortsQuery,
+  useGetDataProductEventHistoryQuery,
+  useLazyGetDataProductEventHistoryQuery,
   useGetDataProductRolledUpTagsQuery,
   useLazyGetDataProductRolledUpTagsQuery,
   useUnlinkInputPortFromDataProductMutation,

--- a/frontend/src/store/api/services/tags/dataProductTags.ts
+++ b/frontend/src/store/api/services/tags/dataProductTags.ts
@@ -12,7 +12,14 @@ export const dataProductTags = {
         providesTags: (response) => (response?.id ? [{ type: TagTypes.DataProduct, id: response?.id }] : []),
     },
     createDataProduct: {
-        invalidatesTags: [{ type: TagTypes.DataProduct, id: STATIC_TAG_ID.LIST }],
+        invalidatesTags: (_, __, arg) => [
+            { type: TagTypes.DataProduct, id: STATIC_TAG_ID.LIST },
+            ...(arg.input_ports?.output_ports?.map((id) => ({
+                type: TagTypes.OutputPort,
+                id,
+            })) ?? []),
+            ...(arg.input_ports?.output_ports?.map((id) => ({ type: TagTypes.History, id })) ?? []),
+        ],
     },
     removeDataProduct: {
         invalidatesTags: (_, __, id) => [
@@ -61,14 +68,14 @@ export const dataProductTags = {
     getDataProductEventHistory: {
         providesTags: (_, __, id) => [{ type: TagTypes.History, id: id }],
     },
-    linkInputPortsToDataProduct: {
+    requestInputPortsForDataProduct: {
         invalidatesTags: (_, __, arg) => [
             { type: TagTypes.DataProduct, id: arg.id },
-            ...arg.linkInputPortsToDataProduct.input_ports.map((id) => ({
+            ...arg.requestInputPortsForDataProductRequest.output_ports.map((id) => ({
                 type: TagTypes.OutputPort,
                 id,
             })),
-            ...arg.linkInputPortsToDataProduct.input_ports.map((id) => ({ type: TagTypes.History, id })),
+            ...arg.requestInputPortsForDataProductRequest.output_ports.map((id) => ({ type: TagTypes.History, id })),
             { type: TagTypes.History, id: arg.id },
             { type: TagTypes.DataProductInputPorts, id: arg.id },
         ],

--- a/frontend/src/tests/pages/cart-explorations/cart.page.test.tsx
+++ b/frontend/src/tests/pages/cart-explorations/cart.page.test.tsx
@@ -45,7 +45,7 @@ describe('Cart', () => {
             mockDataProductOutputPorts(mockDataProducts[0].id, []);
 
             const submitHandler = vi.fn(() => HttpResponse.json({}));
-            server.use(http.post(`*/api/v2/data_products/${mockDataProducts[0].id}/link_input_ports`, submitHandler));
+            server.use(http.post(`*/api/v2/data_products/${mockDataProducts[0].id}/input_ports`, submitHandler));
 
             renderWithProviders(<ExplorationsCart />, {
                 routerProps: { initialEntries: ['/cart'] },
@@ -157,11 +157,7 @@ describe('Cart', () => {
 
             const createdDataProductId = 'new-dp-id';
             const createHandler = vi.fn(() => HttpResponse.json({ id: createdDataProductId }));
-            const linkHandler = vi.fn(() => HttpResponse.json({}));
-            server.use(
-                http.post('*/api/v2/data_products', createHandler),
-                http.post(`*/api/v2/data_products/${createdDataProductId}/link_input_ports`, linkHandler),
-            );
+            server.use(http.post('*/api/v2/data_products', createHandler));
 
             renderWithProviders(<ExplorationsCart />, {
                 routerProps: { initialEntries: ['/cart'] },
@@ -204,7 +200,6 @@ describe('Cart', () => {
             // Assert the create and link APIs were called
             await waitFor(() => {
                 expect(createHandler).toHaveBeenCalled();
-                expect(linkHandler).toHaveBeenCalled();
             });
         });
     }, 20000);

--- a/sdk/sdk/api_client/api/data_products/request_input_ports_for_data_product.py
+++ b/sdk/sdk/api_client/api/data_products/request_input_ports_for_data_product.py
@@ -1,0 +1,197 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.request_input_ports_for_data_product_request import (
+    RequestInputPortsForDataProductRequest,
+)
+from ...models.request_input_ports_for_data_product_response import (
+    RequestInputPortsForDataProductResponse,
+)
+from ...types import Response
+
+
+def _get_kwargs(
+    id: UUID,
+    *,
+    body: RequestInputPortsForDataProductRequest,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/api/v2/data_products/{id}/input_ports".format(
+            id=quote(str(id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | RequestInputPortsForDataProductResponse | None:
+    if response.status_code == 200:
+        response_200 = RequestInputPortsForDataProductResponse.from_dict(
+            response.json()
+        )
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError | RequestInputPortsForDataProductResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: RequestInputPortsForDataProductRequest,
+) -> Response[Any | HTTPValidationError | RequestInputPortsForDataProductResponse]:
+    """Request Input Ports For Data Product
+
+    Args:
+        id (UUID):
+        body (RequestInputPortsForDataProductRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError | RequestInputPortsForDataProductResponse]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: RequestInputPortsForDataProductRequest,
+) -> Any | HTTPValidationError | RequestInputPortsForDataProductResponse | None:
+    """Request Input Ports For Data Product
+
+    Args:
+        id (UUID):
+        body (RequestInputPortsForDataProductRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError | RequestInputPortsForDataProductResponse
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: RequestInputPortsForDataProductRequest,
+) -> Response[Any | HTTPValidationError | RequestInputPortsForDataProductResponse]:
+    """Request Input Ports For Data Product
+
+    Args:
+        id (UUID):
+        body (RequestInputPortsForDataProductRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError | RequestInputPortsForDataProductResponse]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: RequestInputPortsForDataProductRequest,
+) -> Any | HTTPValidationError | RequestInputPortsForDataProductResponse | None:
+    """Request Input Ports For Data Product
+
+    Args:
+        id (UUID):
+        body (RequestInputPortsForDataProductRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError | RequestInputPortsForDataProductResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/sdk/sdk/api_client/models/__init__.py
+++ b/sdk/sdk/api_client/models/__init__.py
@@ -227,6 +227,12 @@ from .render_technical_asset_access_path_response import (
     RenderTechnicalAssetAccessPathResponse,
 )
 from .request_data_product_role_assignment import RequestDataProductRoleAssignment
+from .request_input_ports_for_data_product_request import (
+    RequestInputPortsForDataProductRequest,
+)
+from .request_input_ports_for_data_product_response import (
+    RequestInputPortsForDataProductResponse,
+)
 from .request_input_ports_for_exploration_request import (
     RequestInputPortsForExplorationRequest,
 )
@@ -471,6 +477,8 @@ __all__ = (
     "RenderTechnicalAssetAccessPathRequest",
     "RenderTechnicalAssetAccessPathResponse",
     "RequestDataProductRoleAssignment",
+    "RequestInputPortsForDataProductRequest",
+    "RequestInputPortsForDataProductResponse",
     "RequestInputPortsForExplorationRequest",
     "RequestInputPortsForExplorationResponse",
     "RequestOutputPortRoleAssignment",

--- a/sdk/sdk/api_client/models/data_product_create.py
+++ b/sdk/sdk/api_client/models/data_product_create.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.request_input_ports_for_data_product_request import (
+        RequestInputPortsForDataProductRequest,
+    )
+
 
 T = TypeVar("T", bound="DataProductCreate")
 
@@ -25,6 +31,7 @@ class DataProductCreate:
         owners (list[UUID]):
         about (None | str | Unset):
         tag_ids (list[UUID] | Unset):
+        input_ports (None | RequestInputPortsForDataProductRequest | Unset):
     """
 
     name: str
@@ -36,9 +43,14 @@ class DataProductCreate:
     owners: list[UUID]
     about: None | str | Unset = UNSET
     tag_ids: list[UUID] | Unset = UNSET
+    input_ports: None | RequestInputPortsForDataProductRequest | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.request_input_ports_for_data_product_request import (
+            RequestInputPortsForDataProductRequest,
+        )
+
         name = self.name
 
         namespace = self.namespace
@@ -69,6 +81,14 @@ class DataProductCreate:
                 tag_ids_item = str(tag_ids_item_data)
                 tag_ids.append(tag_ids_item)
 
+        input_ports: dict[str, Any] | None | Unset
+        if isinstance(self.input_ports, Unset):
+            input_ports = UNSET
+        elif isinstance(self.input_ports, RequestInputPortsForDataProductRequest):
+            input_ports = self.input_ports.to_dict()
+        else:
+            input_ports = self.input_ports
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -86,11 +106,17 @@ class DataProductCreate:
             field_dict["about"] = about
         if tag_ids is not UNSET:
             field_dict["tag_ids"] = tag_ids
+        if input_ports is not UNSET:
+            field_dict["input_ports"] = input_ports
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.request_input_ports_for_data_product_request import (
+            RequestInputPortsForDataProductRequest,
+        )
+
         d = dict(src_dict)
         name = d.pop("name")
 
@@ -129,6 +155,27 @@ class DataProductCreate:
 
                 tag_ids.append(tag_ids_item)
 
+        def _parse_input_ports(
+            data: object,
+        ) -> None | RequestInputPortsForDataProductRequest | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                input_ports_type_0 = RequestInputPortsForDataProductRequest.from_dict(
+                    data
+                )
+
+                return input_ports_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | RequestInputPortsForDataProductRequest | Unset, data)
+
+        input_ports = _parse_input_ports(d.pop("input_ports", UNSET))
+
         data_product_create = cls(
             name=name,
             namespace=namespace,
@@ -139,6 +186,7 @@ class DataProductCreate:
             owners=owners,
             about=about,
             tag_ids=tag_ids,
+            input_ports=input_ports,
         )
 
         data_product_create.additional_properties = d

--- a/sdk/sdk/api_client/models/request_input_ports_for_data_product_request.py
+++ b/sdk/sdk/api_client/models/request_input_ports_for_data_product_request.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="RequestInputPortsForDataProductRequest")
+
+
+@_attrs_define
+class RequestInputPortsForDataProductRequest:
+    """
+    Attributes:
+        output_ports (list[UUID]):
+        justification (str):
+    """
+
+    output_ports: list[UUID]
+    justification: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        output_ports = []
+        for output_ports_item_data in self.output_ports:
+            output_ports_item = str(output_ports_item_data)
+            output_ports.append(output_ports_item)
+
+        justification = self.justification
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "output_ports": output_ports,
+                "justification": justification,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        output_ports = []
+        _output_ports = d.pop("output_ports")
+        for output_ports_item_data in _output_ports:
+            output_ports_item = UUID(output_ports_item_data)
+
+            output_ports.append(output_ports_item)
+
+        justification = d.pop("justification")
+
+        request_input_ports_for_data_product_request = cls(
+            output_ports=output_ports,
+            justification=justification,
+        )
+
+        request_input_ports_for_data_product_request.additional_properties = d
+        return request_input_ports_for_data_product_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/sdk/api_client/models/request_input_ports_for_data_product_response.py
+++ b/sdk/sdk/api_client/models/request_input_ports_for_data_product_response.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="RequestInputPortsForDataProductResponse")
+
+
+@_attrs_define
+class RequestInputPortsForDataProductResponse:
+    """
+    Attributes:
+        input_port_links (list[UUID]):
+    """
+
+    input_port_links: list[UUID]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        input_port_links = []
+        for input_port_links_item_data in self.input_port_links:
+            input_port_links_item = str(input_port_links_item_data)
+            input_port_links.append(input_port_links_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "input_port_links": input_port_links,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        input_port_links = []
+        _input_port_links = d.pop("input_port_links")
+        for input_port_links_item_data in _input_port_links:
+            input_port_links_item = UUID(input_port_links_item_data)
+
+            input_port_links.append(input_port_links_item)
+
+        request_input_ports_for_data_product_response = cls(
+            input_port_links=input_port_links,
+        )
+
+        request_input_ports_for_data_product_response.additional_properties = d
+        return request_input_ports_for_data_product_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties


### PR DESCRIPTION
This ensure we don't have to handle the
request failing while the create
data product succeeds.

In support of: #3211

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested
