### PR TITLE
Persist choices in cart

### DIFF
--- a/frontend/src/pages/cart-explorations/cart.page.tsx
+++ b/frontend/src/pages/cart-explorations/cart.page.tsx
@@ -7,8 +7,7 @@ import {
     UnorderedListOutlined,
 } from '@ant-design/icons';
 import { Col, Flex, Row } from 'antd';
-import { parseAsStringEnum, useQueryState } from 'nuqs';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useBreadcrumbs } from '@/components/layout/navbar/breadcrumbs/breadcrumb.context.tsx';
@@ -18,29 +17,35 @@ import { ExistingDataProductForm } from '@/pages/cart-explorations/components/ex
 import { ExistingExplorationForm } from '@/pages/cart-explorations/components/existing-exploration-form.tsx';
 import { NewDataProductForm } from '@/pages/cart-explorations/components/new-data-product-form.tsx';
 import { NewExplorationForm } from '@/pages/cart-explorations/components/new-exploration-form.tsx';
+import { useAppDispatch } from '@/store';
 import { useSearchOutputPortsQuery } from '@/store/api/services/generated/outputPortsSearchApi.ts';
-import { selectCartDatasetIds } from '@/store/features/cart/cart-slice.ts';
+import {
+    DataProductChoiceOptions,
+    ExistingOrNew,
+    selectCartDataProductTypeChoice,
+    selectCartDatasetIds,
+    selectCartExistingOrNewChoice,
+    setCartExplorationChoices,
+} from '@/store/features/cart/cart-slice.ts';
 import { ApplicationPaths } from '@/types/navigation.ts';
-
-export enum DataProductChoiceOptions {
-    exploration = 'EXPLORATION',
-    data_product = 'DATA_PRODUCT',
-}
-
-export enum ExistingOrNew {
-    existing = 'EXISTING',
-    new = 'new',
-}
 
 function ExplorationsCart() {
     const { t } = useTranslation();
-    const [dataProductTypeChoice, setDataProductTypeChoice] = useQueryState(
-        'data-product-type-choice',
-        parseAsStringEnum<DataProductChoiceOptions>(Object.values(DataProductChoiceOptions)),
+    const dispatch = useAppDispatch();
+    const dataProductTypeChoice = useSelector(selectCartDataProductTypeChoice);
+    const existingOrNewChoice = useSelector(selectCartExistingOrNewChoice);
+
+    const setDataProductTypeChoice = useCallback(
+        (choice: DataProductChoiceOptions | null) => {
+            dispatch(setCartExplorationChoices({ dataProductTypeChoice: choice, existingOrNewChoice: null }));
+        },
+        [dispatch],
     );
-    const [existingOrNewChoice, setExistingOrNewChoice] = useQueryState(
-        'existing-or-new',
-        parseAsStringEnum<ExistingOrNew>(Object.values(ExistingOrNew)),
+    const setExistingOrNewChoice = useCallback(
+        (choice: ExistingOrNew | null) => {
+            dispatch(setCartExplorationChoices({ dataProductTypeChoice, existingOrNewChoice: choice }));
+        },
+        [dispatch, dataProductTypeChoice],
     );
     const [selectedDataProductId, setSelectedDataProductId] = useState<string | undefined>(undefined);
     const [selectedExplorationId, setSelectedExplorationId] = useState<string | undefined>(undefined);

--- a/frontend/src/store/features/cart/cart-slice.ts
+++ b/frontend/src/store/features/cart/cart-slice.ts
@@ -1,11 +1,24 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 
+export enum DataProductChoiceOptions {
+    exploration = 'EXPLORATION',
+    data_product = 'DATA_PRODUCT',
+}
+
+export enum ExistingOrNew {
+    existing = 'EXISTING',
+    new = 'new',
+}
+
 export type CartState = {
     DatasetIds: string[];
+    dataProductTypeChoice: DataProductChoiceOptions | null;
+    existingOrNewChoice: ExistingOrNew | null;
 };
 
 const DATASET_IDS_KEY = 'CartDatasetIds';
+const EXPLORATION_CHOICES_KEY = 'CartExplorationChoices';
 
 const saveDatasetIds = (datasetIds: string[]): void => {
     localStorage.setItem(DATASET_IDS_KEY, JSON.stringify(datasetIds));
@@ -25,9 +38,33 @@ const clearDatasetIds = (): void => {
     localStorage.removeItem(DATASET_IDS_KEY);
 };
 
+const saveExplorationChoices = (dataProductTypeChoice: string | null, existingOrNewChoice: string | null): void => {
+    localStorage.setItem(EXPLORATION_CHOICES_KEY, JSON.stringify({ dataProductTypeChoice, existingOrNewChoice }));
+};
+
+const loadExplorationChoices = (): { dataProductTypeChoice: string | null; existingOrNewChoice: string | null } => {
+    try {
+        const stored = localStorage.getItem(EXPLORATION_CHOICES_KEY);
+        return stored ? JSON.parse(stored) : { dataProductTypeChoice: null, existingOrNewChoice: null };
+    } catch {
+        return { dataProductTypeChoice: null, existingOrNewChoice: null };
+    }
+};
+
+const clearExplorationChoicesStorage = (): void => {
+    localStorage.removeItem(EXPLORATION_CHOICES_KEY);
+};
+
+const { dataProductTypeChoice: initialDataProductTypeChoice, existingOrNewChoice: initialExistingOrNewChoice } =
+    loadExplorationChoices();
+
 const cartSlice = createSlice({
     name: 'cart',
-    initialState: { DatasetIds: loadDatasetIds() } as CartState,
+    initialState: {
+        DatasetIds: loadDatasetIds(),
+        dataProductTypeChoice: initialDataProductTypeChoice,
+        existingOrNewChoice: initialExistingOrNewChoice,
+    } as CartState,
     reducers: {
         addDatasetToCart: (
             state,
@@ -57,16 +94,35 @@ const cartSlice = createSlice({
         },
         clearCart: (state) => {
             clearDatasetIds();
+            clearExplorationChoicesStorage();
             state.DatasetIds = [];
+            state.dataProductTypeChoice = null;
+            state.existingOrNewChoice = null;
+        },
+        setCartExplorationChoices: (
+            state,
+            {
+                payload: { dataProductTypeChoice, existingOrNewChoice },
+            }: PayloadAction<{
+                dataProductTypeChoice: DataProductChoiceOptions | null;
+                existingOrNewChoice: ExistingOrNew | null;
+            }>,
+        ) => {
+            state.dataProductTypeChoice = dataProductTypeChoice;
+            state.existingOrNewChoice = existingOrNewChoice;
+            saveExplorationChoices(dataProductTypeChoice, existingOrNewChoice);
         },
     },
     selectors: {
         selectCartDatasetIds: (state) => state.DatasetIds,
+        selectCartDataProductTypeChoice: (state) => state.dataProductTypeChoice,
+        selectCartExistingOrNewChoice: (state) => state.existingOrNewChoice,
     },
 });
 
-export const { addDatasetToCart, removeDatasetFromCart, clearCart } = cartSlice.actions;
+export const { addDatasetToCart, removeDatasetFromCart, clearCart, setCartExplorationChoices } = cartSlice.actions;
 
 export default cartSlice.reducer;
 
-export const { selectCartDatasetIds } = cartSlice.selectors;
+export const { selectCartDatasetIds, selectCartDataProductTypeChoice, selectCartExistingOrNewChoice } =
+    cartSlice.selectors;

--- a/frontend/src/tests/pages/cart-explorations/cart.page.test.tsx
+++ b/frontend/src/tests/pages/cart-explorations/cart.page.test.tsx
@@ -1,5 +1,6 @@
 import { HttpResponse, http } from 'msw';
-import { describe, expect, it, vi } from 'vitest';
+import { Link, Route, Routes } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import ExplorationsCart from '@/pages/cart-explorations/cart.page.tsx';
 import { allowAllAuth } from '@/tests/mocks/auth.ts';
 import { mockDataProductLifecycles } from '@/tests/mocks/configurationDataProductLifecycles.ts';
@@ -19,6 +20,10 @@ import { mockGetTags } from '@/tests/mocks/tags.ts';
 import { mockUsers, mockUsersHttp } from '@/tests/mocks/users.ts';
 import { renderWithProviders, screen, userEvent, waitFor } from '@/tests/test-utils.tsx';
 
+afterEach(() => {
+    localStorage.clear();
+});
+
 describe('Cart', () => {
     const selectDataProducts = async () => {
         const dataProductChoice = await screen.findByText('I want to build Data Products');
@@ -27,6 +32,10 @@ describe('Cart', () => {
     const selectExplorations = async () => {
         const explorationsChoice = await screen.findByText('I want to explore this data');
         await userEvent.click(explorationsChoice);
+    };
+    const selectExistingExplorations = async () => {
+        const existingChoice = await screen.findByText('Select an existing Exploration');
+        await userEvent.click(existingChoice);
     };
     describe('Cart should support existing data products', () => {
         const selectExistingDataProducts = async () => {
@@ -266,10 +275,6 @@ describe('Cart', () => {
     }, 15000);
 
     describe('Cart should support existing explorations', () => {
-        const selectExistingExplorations = async () => {
-            const existingChoice = await screen.findByText('Select an existing Exploration');
-            await userEvent.click(existingChoice);
-        };
         it('should allow users to select an existing exploration', async () => {
             allowAllAuth();
 
@@ -334,6 +339,51 @@ describe('Cart', () => {
                 expect(
                     screen.getByText(/Output Ports in the cart, for which the selected Exploration already has access/),
                 ).toBeTruthy();
+            });
+        });
+    });
+
+    describe('Cart should persist selection choices across navigation', () => {
+        it('should restore the exploration and existing/new selection when navigating away and back', async () => {
+            allowAllAuth();
+
+            const cartOutputPortId = 'op-1';
+            mockOutputPortsSearch();
+            mockExplorationsHttp();
+            mockExplorationInputPorts(mockExplorations[0].id, []);
+
+            const CartWithRoutes = () => (
+                <Routes>
+                    <Route
+                        path="/cart"
+                        element={
+                            <>
+                                <ExplorationsCart />
+                                <Link to="/other">Go away</Link>
+                            </>
+                        }
+                    />
+                    <Route path="/other" element={<Link to="/cart">Back to cart</Link>} />
+                </Routes>
+            );
+
+            renderWithProviders(<CartWithRoutes />, {
+                routerProps: { initialEntries: ['/cart'] },
+                preloadedState: { cart: { DatasetIds: [cartOutputPortId] } },
+                currentUser: mockUsers[0],
+            });
+
+            await selectExplorations();
+            await selectExistingExplorations();
+
+            // Navigate away and back
+            await userEvent.click(screen.getByText('Go away'));
+            await screen.findByText('Back to cart');
+            await userEvent.click(screen.getByText('Back to cart'));
+
+            await waitFor(() => {
+                expect(screen.getByText('Select an existing Exploration')).toBeTruthy();
+                expect(screen.getByText('I want to explore this data')).toBeTruthy();
             });
         });
     });


### PR DESCRIPTION
This ensure that when the user navigates away
we remember what they selected.

In support of: #3211

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested
