### PR TITLE
Empty cart page

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -324,7 +324,6 @@
     "Global role assignment successfully reset": "Global role assignment successfully reset",
     "Global role successfully assigned": "Global role successfully assigned",
     "Go to checkout": "Go to checkout",
-    "Go to the marketplace to add items to your cart": "Go to the marketplace to add items to your cart",
     "Grant Access": "Grant Access",
     "Heading {{value}}": "Heading {{value}}",
     "Hide sidebar": "Hide sidebar",
@@ -715,6 +714,7 @@
     "You have finished the tour!": "You have finished the tour!",
     "You need to be authenticated to access the Data Product Portal": "You need to be authenticated to access the $t(Data Product Portal)",
     "You will get notified when access is granted or denied": "You will get notified when access is granted or denied",
+    "Your cart is currently empty. Explore the marketplace to add items.": "Your cart is currently empty. Explore the marketplace to add items.",
     "Your Exploration has been created.": "Your Exploration has been created.",
     "Your first Data Product!": "Your first $t(Data Product)!",
     "Your requests have successfully been created.": "Your requests have successfully been created."

--- a/frontend/src/pages/cart-explorations/cart.page.tsx
+++ b/frontend/src/pages/cart-explorations/cart.page.tsx
@@ -6,10 +6,11 @@ import {
     ShoppingCartOutlined,
     UnorderedListOutlined,
 } from '@ant-design/icons';
-import { Col, Flex, Row } from 'antd';
+import { Button, Col, Empty, Flex, Row, Typography } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
+import { Link } from 'react-router';
 import { useBreadcrumbs } from '@/components/layout/navbar/breadcrumbs/breadcrumb.context.tsx';
 import { CardSelection } from '@/pages/cart-explorations/components/card-selection.tsx';
 import { CartOverview } from '@/pages/cart-explorations/components/cart-overview.component.tsx';
@@ -112,6 +113,21 @@ function ExplorationsCart() {
         }
         return null;
     }, [dataProductTypeChoice, existingOrNewChoice, cartOutputPorts]);
+    if (cartDatasetIds?.length === 0) {
+        return (
+            <Empty
+                description={
+                    <Typography.Text>
+                        {t('Your cart is currently empty. Explore the marketplace to add items.')}
+                    </Typography.Text>
+                }
+            >
+                <Link to={ApplicationPaths.Marketplace}>
+                    <Button type="primary">{t('Marketplace')}</Button>
+                </Link>
+            </Empty>
+        );
+    }
     return (
         <Row gutter={16}>
             <Col span={16}>

--- a/frontend/src/pages/cart-explorations/components/cart-overview.component.tsx
+++ b/frontend/src/pages/cart-explorations/components/cart-overview.component.tsx
@@ -1,5 +1,5 @@
 import { DeleteOutlined, WarningTwoTone } from '@ant-design/icons';
-import { Button, Card, Collapse, Descriptions, Empty, Skeleton, Space, Tag, Tooltip, Typography, theme } from 'antd';
+import { Button, Card, Collapse, Descriptions, Skeleton, Space, Tag, Tooltip, Typography, theme } from 'antd';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
@@ -7,7 +7,7 @@ import { useCartOverlapCheck } from '@/pages/cart-explorations/hooks/use-cart-ov
 import { useAppDispatch } from '@/store';
 import type { SearchOutputPortsResponseItem } from '@/store/api/services/generated/outputPortsSearchApi.ts';
 import { removeDatasetFromCart } from '@/store/features/cart/cart-slice.ts';
-import { ApplicationPaths, createDataProductIdPath } from '@/types/navigation.ts';
+import { createDataProductIdPath } from '@/types/navigation.ts';
 import { useGetDataProductOwners } from '@/utils/data-product-user-role.helper.ts';
 
 type CartOverviewItemProps = {
@@ -127,16 +127,6 @@ export const CartOverview = ({
         <Card title={<Typography.Title level={3}>{t('Cart summary')}</Typography.Title>}>
             {loading ? (
                 <Skeleton active />
-            ) : cartOutputPorts?.length === 0 ? (
-                <Empty
-                    description={
-                        <Typography.Text>{t('Go to the marketplace to add items to your cart')}</Typography.Text>
-                    }
-                >
-                    <Link to={ApplicationPaths.Marketplace}>
-                        <Button type="primary">{t('Marketplace')}</Button>
-                    </Link>
-                </Empty>
             ) : (
                 <Collapse
                     accordion

--- a/frontend/src/tests/pages/cart-explorations/cart.page.test.tsx
+++ b/frontend/src/tests/pages/cart-explorations/cart.page.test.tsx
@@ -37,6 +37,16 @@ describe('Cart', () => {
         const existingChoice = await screen.findByText('Select an existing Exploration');
         await userEvent.click(existingChoice);
     };
+    describe('Empty cart page', () => {
+        it('Should show a message to direct to the Marketplace', async () => {
+            renderWithProviders(<ExplorationsCart />, {
+                routerProps: { initialEntries: ['/cart'] },
+                currentUser: mockUsers[0],
+            });
+
+            await screen.findByText(/Your cart is currently empty/);
+        });
+    });
     describe('Cart should support existing data products', () => {
         const selectExistingDataProducts = async () => {
             const existingChoice = await screen.findByText('Select an existing Data Product');


### PR DESCRIPTION
Improved empty cart page

in support of: #3211

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested

<img width="2554" height="1355" alt="Screenshot 2026-04-28 at 14 43 49" src="https://github.com/user-attachments/assets/1edc6100-ac3c-4512-94a9-01c7ac8d97ce" />

