### PR TITLE
Simplify exploration creation

### DIFF
--- a/backend/app/data_products/service.py
+++ b/backend/app/data_products/service.py
@@ -21,10 +21,6 @@ from app.configuration.tags.model import Tag as TagModel
 from app.configuration.tags.model import ensure_tag_exists
 from app.configuration.tags.schema import Tag
 from app.core.aws.get_url import _get_data_product_role_arn
-from app.core.namespace.validation import (
-    NamespaceValidator,
-    TechnicalAssetNamespaceValidator,
-)
 from app.data_products.model import DataProduct as DataProductModel
 from app.data_products.model import ensure_data_product_exists
 from app.data_products.output_port_technical_assets_link.model import (
@@ -59,8 +55,6 @@ from app.users.schema import User
 class DataProductService(AbstractDataProductService):
     def __init__(self, db: Session):
         super().__init__(db)
-        self.namespace_validator = NamespaceValidator(DataProductModel)
-        self.technical_asset_namespace_validator = TechnicalAssetNamespaceValidator()
 
     def get_data_product_settings(
         self, data_product_id: UUID

--- a/backend/app/explorations/schema_request.py
+++ b/backend/app/explorations/schema_request.py
@@ -11,7 +11,7 @@ class RequestInputPortsForExplorationRequest(ORMModel):
 
 class CreateExplorationRequest(ORMModel):
     name: str
-    namespace: str
+    namespace: Optional[str] = None
     description: str
     domain_id: UUID
 

--- a/backend/app/explorations/service.py
+++ b/backend/app/explorations/service.py
@@ -7,7 +7,6 @@ from sqlalchemy.orm import Session, joinedload
 from starlette import status
 
 from app.abstract_data_product.service import AbstractDataProductService
-from app.core.namespace.validation import NamespaceValidator
 from app.resource_names.service import ResourceNameService, ResourceNameValidityType
 from app.users.model import User
 
@@ -19,13 +18,17 @@ from .schema_request import CreateExplorationRequest
 class ExplorationService(AbstractDataProductService):
     def __init__(self, db: Session):
         super().__init__(db)
-        self.namespace_validator = NamespaceValidator(ExplorationModel)
 
     def create_exploration(
         self,
         exploration: CreateExplorationRequest,
         authenticated_user: User,
     ) -> ExplorationModel:
+        resource_name_validator = ResourceNameService(model=ExplorationModel)
+        if not exploration.namespace:
+            exploration.namespace = resource_name_validator.resource_name_suggestion(
+                exploration.name
+            ).resource_name
         if (
             validity := ResourceNameService(model=ExplorationModel)
             .validate_resource_name(exploration.namespace, self.db)

--- a/backend/tests/app/explorations/test_router.py
+++ b/backend/tests/app/explorations/test_router.py
@@ -42,6 +42,28 @@ class TestExplorationRouter:
         )
         assert response.status_code == 200, response.text
 
+    def test_create_exploration_resource_name_automatically_filled_in(self, client):
+        d = DomainFactory()
+        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        role = RoleFactory(
+            scope=Scope.GLOBAL,
+            permissions=[Action.GLOBAL__CREATE_EXPLORATION],
+        )
+        GlobalRoleAssignmentFactory(
+            user_id=user.id,
+            role_id=role.id,
+        )
+
+        response = client.post(
+            ROUTE,
+            json={
+                "name": str(uuid.uuid4()),
+                "domain_id": str(d.id),
+                "description": faker.Faker().text(),
+            },
+        )
+        assert response.status_code == 200, response.text
+
     def test_create_exploration_invalid_namespace(self, client):
         d = DomainFactory()
         namespace = str(uuid.uuid4())

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -7473,7 +7473,14 @@
             "title": "Name"
           },
           "namespace": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Namespace"
           },
           "description": {
@@ -7499,7 +7506,6 @@
         "type": "object",
         "required": [
           "name",
-          "namespace",
           "description",
           "domain_id"
         ],

--- a/frontend/src/pages/cart/components/new-exploration-form.tsx
+++ b/frontend/src/pages/cart/components/new-exploration-form.tsx
@@ -1,15 +1,11 @@
 import { usePostHog } from '@posthog/react';
 import { Button, Flex, Form, type FormProps, Input, Select } from 'antd';
 import { useForm } from 'antd/es/form/Form';
-import TextArea from 'antd/es/input/TextArea';
 import { t } from 'i18next';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router';
-import { useDebouncedCallback } from 'use-debounce';
 import styles from '@/components/data-products/data-product-form/data-product-form.module.scss';
-import { ResourceNameFormItem } from '@/components/resource-name/resource-name-form-item.tsx';
-import { MAX_DESCRIPTION_INPUT_LENGTH } from '@/constants/form.constants.ts';
 import { PosthogEvents } from '@/constants/posthog.constants.ts';
 import { useFormPersist } from '@/hooks/use-form-persist.tsx';
 import { JustificationFormItem } from '@/pages/cart/components/form-item-justification.tsx';
@@ -20,12 +16,6 @@ import { useGetDomainsQuery } from '@/store/api/services/generated/configuration
 import type { DataProductCreate } from '@/store/api/services/generated/dataProductsApi.ts';
 import { useCreateExplorationMutation } from '@/store/api/services/generated/explorationsApi.ts';
 import type { SearchOutputPortsResponseItem } from '@/store/api/services/generated/outputPortsSearchApi.ts';
-import {
-    ResourceNameModel,
-    useLazySanitizeResourceNameQuery,
-    useLazyValidateResourceNameQuery,
-    useResourceNameConstraintsQuery,
-} from '@/store/api/services/generated/resourceNamesApi.ts';
 import { clearCart } from '@/store/features/cart/cart-slice.ts';
 import { dispatchMessage } from '@/store/features/feedback/utils/dispatch-feedback.ts';
 import { createExplorationIdPath } from '@/types/navigation.ts';
@@ -37,8 +27,6 @@ type Props = {
 
 type CreateExplorationRequestForm = {
     name: string;
-    namespace: string;
-    description: string;
     domain_id: string;
     justification: string;
 };
@@ -56,30 +44,6 @@ export const NewExplorationForm = ({ cartOutputPorts }: Props) => {
         form,
         'cart-new-exploration-form',
     );
-    const dataProductNameValue = Form.useWatch('name', form);
-    const [canEditResourceName, setCanEditResourceName] = useState<boolean>(false);
-    const [sanitizeResourceName, { data: sanitizedResourceName, isSuccess: sanitizedResourceNameSuccess }] =
-        useLazySanitizeResourceNameQuery();
-    const fetchResourceNameDebounced = useDebouncedCallback((name: string) => sanitizeResourceName(name), 500);
-    useEffect(() => {
-        if (!canEditResourceName) {
-            form.setFields([
-                {
-                    name: 'namespace',
-                    validating: true,
-                    errors: [],
-                },
-            ]);
-            fetchResourceNameDebounced(dataProductNameValue ?? '');
-        }
-    }, [form, canEditResourceName, dataProductNameValue, fetchResourceNameDebounced]);
-
-    useEffect(() => {
-        if (!canEditResourceName && sanitizedResourceNameSuccess && sanitizedResourceName) {
-            form.setFieldValue('namespace', sanitizedResourceName.resource_name);
-            form.validateFields(['namespace']);
-        }
-    }, [form, canEditResourceName, sanitizedResourceName, sanitizedResourceNameSuccess]);
 
     const onFinish: FormProps<CreateExplorationRequestForm>['onFinish'] = useCallback(
         async (values: CreateExplorationRequestForm) => {
@@ -90,6 +54,7 @@ export const NewExplorationForm = ({ cartOutputPorts }: Props) => {
                 }
                 const { justification, ...request } = values;
                 const response = await createExploration({
+                    description: justification,
                     input_ports: {
                         output_ports: cartOutputPorts?.map((dataset) => dataset.id),
                         justification,
@@ -112,16 +77,6 @@ export const NewExplorationForm = ({ cartOutputPorts }: Props) => {
     const initialValues = {
         owners: currentUser?.id ? [currentUser?.id] : [],
     };
-    const [validateResourceName, { isFetching: validatingResourceName }] = useLazyValidateResourceNameQuery();
-    const { data: constraints, isFetching: loadingResourceNameConstraints } = useResourceNameConstraintsQuery();
-    const resourceNameValidationCallback = useCallback(
-        (resourceName: string) =>
-            validateResourceName({
-                resourceName: resourceName,
-                model: ResourceNameModel.Exploration,
-            }).unwrap(),
-        [validateResourceName],
-    );
     return (
         <Form<CreateExplorationRequestForm>
             form={form}
@@ -143,16 +98,6 @@ export const NewExplorationForm = ({ cartOutputPorts }: Props) => {
             >
                 <Input />
             </Form.Item>
-            <ResourceNameFormItem
-                form={form}
-                tooltip={t('The namespace of the Data Product')}
-                max_length={constraints?.max_length}
-                editToggleDisabled={false}
-                canEditResourceName={canEditResourceName}
-                toggleCanEditResourceName={() => setCanEditResourceName((prev) => !prev)}
-                validationRequired
-                validateResourceName={resourceNameValidationCallback}
-            />
             <Form.Item<CreateExplorationRequestForm>
                 name={'domain_id'}
                 label={t('Domain')}
@@ -170,25 +115,6 @@ export const NewExplorationForm = ({ cartOutputPorts }: Props) => {
                     allowClear
                 />
             </Form.Item>
-            <Form.Item<CreateExplorationRequestForm>
-                name={'description'}
-                label={t('Description')}
-                tooltip={t('A description for the Data Product')}
-                rules={[
-                    {
-                        required: true,
-                        message: t('Please provide a description for the Data Product'),
-                    },
-                    {
-                        max: MAX_DESCRIPTION_INPUT_LENGTH,
-                        message: t('Description must be less than {{length}} characters', {
-                            length: MAX_DESCRIPTION_INPUT_LENGTH,
-                        }),
-                    },
-                ]}
-            >
-                <TextArea rows={4} count={{ show: true, max: MAX_DESCRIPTION_INPUT_LENGTH }} />
-            </Form.Item>
             <JustificationFormItem />
             <Form.Item>
                 <Flex justify="end">
@@ -197,7 +123,7 @@ export const NewExplorationForm = ({ cartOutputPorts }: Props) => {
                         type="primary"
                         htmlType={'submit'}
                         loading={isCreatingExploration}
-                        disabled={isFetchingDomains || validatingResourceName || loadingResourceNameConstraints}
+                        disabled={isFetchingDomains}
                     >
                         {t('Create')}
                     </Button>

--- a/frontend/src/store/api/services/generated/explorationsApi.ts
+++ b/frontend/src/store/api/services/generated/explorationsApi.ts
@@ -106,7 +106,7 @@ export type RequestInputPortsForExplorationRequest = {
 };
 export type CreateExplorationRequestWithInputPorts = {
   name: string;
-  namespace: string;
+  namespace?: string | null;
   description: string;
   domain_id: string;
   input_ports?: RequestInputPortsForExplorationRequest | null;

--- a/frontend/src/tests/pages/cart/cart.page.test.tsx
+++ b/frontend/src/tests/pages/cart/cart.page.test.tsx
@@ -234,9 +234,6 @@ describe('Cart', () => {
 
             mockOutputPortsSearch();
             mockUsersHttp(mockUsers);
-            mockGetResourceNamesConstraints();
-            mockResourceNamesSanitize();
-            mockResourceNamesValidate();
             mockGetDomains();
 
             const createHandler = vi.fn(() => HttpResponse.json({ id: 'id-1' }));
@@ -258,9 +255,6 @@ describe('Cart', () => {
             await userEvent.click(domainSelect);
             const domainOption = await screen.findByText('Finance');
             await userEvent.click(domainOption);
-
-            const descriptionTextArea = screen.getByRole('textbox', { name: /description/i });
-            await userEvent.type(descriptionTextArea, 'A detailed description of the exploration.');
 
             const justificationTextArea = await screen.findByPlaceholderText(
                 'Explain why you need access to these Output Ports',

--- a/sdk/sdk/api_client/models/create_exploration_request_with_input_ports.py
+++ b/sdk/sdk/api_client/models/create_exploration_request_with_input_ports.py
@@ -23,16 +23,16 @@ class CreateExplorationRequestWithInputPorts:
     """
     Attributes:
         name (str):
-        namespace (str):
         description (str):
         domain_id (UUID):
+        namespace (None | str | Unset):
         input_ports (None | RequestInputPortsForExplorationRequest | Unset):
     """
 
     name: str
-    namespace: str
     description: str
     domain_id: UUID
+    namespace: None | str | Unset = UNSET
     input_ports: None | RequestInputPortsForExplorationRequest | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -43,11 +43,15 @@ class CreateExplorationRequestWithInputPorts:
 
         name = self.name
 
-        namespace = self.namespace
-
         description = self.description
 
         domain_id = str(self.domain_id)
+
+        namespace: None | str | Unset
+        if isinstance(self.namespace, Unset):
+            namespace = UNSET
+        else:
+            namespace = self.namespace
 
         input_ports: dict[str, Any] | None | Unset
         if isinstance(self.input_ports, Unset):
@@ -62,11 +66,12 @@ class CreateExplorationRequestWithInputPorts:
         field_dict.update(
             {
                 "name": name,
-                "namespace": namespace,
                 "description": description,
                 "domain_id": domain_id,
             }
         )
+        if namespace is not UNSET:
+            field_dict["namespace"] = namespace
         if input_ports is not UNSET:
             field_dict["input_ports"] = input_ports
 
@@ -81,11 +86,18 @@ class CreateExplorationRequestWithInputPorts:
         d = dict(src_dict)
         name = d.pop("name")
 
-        namespace = d.pop("namespace")
-
         description = d.pop("description")
 
         domain_id = UUID(d.pop("domain_id"))
+
+        def _parse_namespace(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        namespace = _parse_namespace(d.pop("namespace", UNSET))
 
         def _parse_input_ports(
             data: object,
@@ -110,9 +122,9 @@ class CreateExplorationRequestWithInputPorts:
 
         create_exploration_request_with_input_ports = cls(
             name=name,
-            namespace=namespace,
             description=description,
             domain_id=domain_id,
+            namespace=namespace,
             input_ports=input_ports,
         )
 


### PR DESCRIPTION
Reduced the form to minimal setup currently
required.
So description is copied from justification
and namespace is automatically generated.

In support of: #3211

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested

<img width="2549" height="1268" alt="Screenshot 2026-04-28 at 15 12 15" src="https://github.com/user-attachments/assets/fb2f9b92-a34a-49da-896e-db04a75b0aa8" />
