### PR TITLE
Added explorations to graph views

### DIFF
--- a/backend/app/abstract_data_product/graph_utils.py
+++ b/backend/app/abstract_data_product/graph_utils.py
@@ -1,0 +1,34 @@
+from typing import TYPE_CHECKING, cast
+
+from app.abstract_data_product.model import AbstractDataProduct, AbstractDataProductType
+from app.graph.node import Node, NodeData, NodeType
+
+if TYPE_CHECKING:
+    from app.data_products.model import DataProduct
+
+
+def get_graph_data_from_abstract_data_product(
+    id: str, adp: AbstractDataProduct
+) -> Node:
+    icon = None
+    node_type = NodeType.dataProductNode
+    match adp.abstract_data_product_type:
+        case AbstractDataProductType.DATA_PRODUCT:
+            data_product = cast("DataProduct", adp)
+            icon = data_product.type.icon_key
+            node_type = NodeType.dataProductNode
+        case AbstractDataProductType.EXPLORATION:
+            node_type = NodeType.explorationNode
+        case _:
+            raise Exception(
+                f"Unsupported abstract data product type: {adp.abstract_data_product_type}"
+            )
+    return Node(
+        id=id,
+        data=NodeData(
+            id=f"{adp.id}",
+            icon_key=icon,
+            name=adp.name,
+        ),
+        type=node_type,
+    )

--- a/backend/app/data_products/output_ports/service.py
+++ b/backend/app/data_products/output_ports/service.py
@@ -8,6 +8,9 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session, joinedload, raiseload, selectinload, undefer
 from sqlalchemy.sql.base import ExecutableOption
 
+from app.abstract_data_product.graph_utils import (
+    get_graph_data_from_abstract_data_product,
+)
 from app.authorization.role_assignments.enums import DecisionStatus
 from app.authorization.role_assignments.output_port.service import (
     RoleAssignmentService as DatasetRoleAssignmentService,
@@ -93,9 +96,7 @@ class OutputPortService:
         )
 
         if not dataset:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="Dataset not found"
-            )
+            raise self.not_found_exception(id)
 
         if not self.is_visible_to_user(dataset, user):
             raise HTTPException(
@@ -285,9 +286,7 @@ class OutputPortService:
             id, self.db, data_product_id=data_product_id
         )
         if not dataset:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail=f"Dataset {id} not found"
-            )
+            raise self.not_found_exception(id)
 
         result = copy.deepcopy(dataset)
         self.db.delete(dataset)
@@ -362,7 +361,7 @@ class OutputPortService:
         return current_dataset
 
     def get_graph_data(self, id: UUID, data_product_id: UUID, level: int) -> Graph:
-        dataset = self.db.scalar(
+        dataset: DatasetModel | None = self.db.scalar(
             select(DatasetModel)
             .where(DatasetModel.id == id)
             .where(DatasetModel.data_product_id == data_product_id)
@@ -371,6 +370,8 @@ class OutputPortService:
                 selectinload(DatasetModel.data_output_links),
             )
         )
+        if not dataset:
+            raise self.not_found_exception(id)
         nodes = [
             Node(
                 id=id,
@@ -380,20 +381,15 @@ class OutputPortService:
                     name=dataset.name,
                     link_to_id=dataset.data_product_id,
                 ),
-                type=NodeType.datasetNode,
+                type=NodeType.outputPortNode,
             )
         ]
         edges = []
         for downstream_products in dataset.data_product_links:
             nodes.append(
-                Node(
-                    id=downstream_products.consuming_abstract_data_product_id,
-                    data=NodeData(
-                        id=downstream_products.consuming_abstract_data_product_id,
-                        name=downstream_products.consuming_abstract_data_product.name,
-                        icon_key=downstream_products.consuming_abstract_data_product.type.icon_key,
-                    ),
-                    type=NodeType.dataProductNode,
+                get_graph_data_from_abstract_data_product(
+                    str(downstream_products.consuming_abstract_data_product_id),
+                    downstream_products.consuming_abstract_data_product,
                 )
             )
             edges.append(
@@ -416,7 +412,7 @@ class OutputPortService:
                         name=data_output.name,
                         link_to_id=data_output.owner_id,
                     ),
-                    type=NodeType.dataOutputNode,
+                    type=NodeType.technicalAssetNode,
                 )
             )
             edges.append(
@@ -532,8 +528,11 @@ class OutputPortService:
             )
         )
         if not dataset:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Output port {output_port_id} not found",
-            )
+            raise self.not_found_exception(output_port_id)
         return dataset.data_product_links
+
+    def not_found_exception(self, output_port_id: UUID) -> HTTPException:
+        return HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Output port {output_port_id} not found",
+        )

--- a/backend/app/data_products/service.py
+++ b/backend/app/data_products/service.py
@@ -7,6 +7,9 @@ from fastapi import HTTPException, status
 from sqlalchemy import asc, select
 from sqlalchemy.orm import Session, joinedload, selectinload, undefer
 
+from app.abstract_data_product.graph_utils import (
+    get_graph_data_from_abstract_data_product,
+)
 from app.abstract_data_product.service import AbstractDataProductService
 from app.authorization.role_assignments.enums import DecisionStatus
 from app.authorization.roles.schema import Prototype
@@ -309,7 +312,7 @@ class DataProductService(AbstractDataProductService):
                         name=upstream_datasets.dataset.name,
                         link_to_id=upstream_datasets.dataset.data_product_id,
                     ),
-                    type=NodeType.datasetNode,
+                    type=NodeType.outputPortNode,
                 )
             )
             edges.append(
@@ -331,7 +334,7 @@ class DataProductService(AbstractDataProductService):
                         name=data_output.name,
                         link_to_id=data_output.owner_id,
                     ),
-                    type=NodeType.dataOutputNode,
+                    type=NodeType.technicalAssetNode,
                 )
             )
             edges.append(
@@ -352,7 +355,7 @@ class DataProductService(AbstractDataProductService):
                                 name=downstream_datasets.dataset.name,
                                 link_to_id=downstream_datasets.dataset.data_product_id,
                             ),
-                            type=NodeType.datasetNode,
+                            type=NodeType.outputPortNode,
                         )
                     )
                     edges.append(
@@ -368,16 +371,11 @@ class DataProductService(AbstractDataProductService):
                         for (
                             downstream_dps
                         ) in downstream_datasets.dataset.data_product_links:
-                            icon = downstream_dps.consuming_abstract_data_product.type.icon_key
+                            node_id = f"{downstream_dps.id}_3"
                             nodes.append(
-                                Node(
-                                    id=f"{downstream_dps.id}_3",
-                                    data=NodeData(
-                                        id=f"{downstream_dps.consuming_abstract_data_product_id}",
-                                        icon_key=icon,
-                                        name=downstream_dps.consuming_abstract_data_product.name,
-                                    ),
-                                    type=NodeType.dataProductNode,
+                                get_graph_data_from_abstract_data_product(
+                                    node_id,
+                                    downstream_dps.consuming_abstract_data_product,
                                 )
                             )
                             edges.append(
@@ -386,7 +384,7 @@ class DataProductService(AbstractDataProductService):
                                         f"{downstream_dps.id}-"
                                         f"{downstream_datasets.dataset.id}-3"
                                     ),
-                                    target=f"{downstream_dps.id}_3",
+                                    target=node_id,
                                     source=f"{downstream_datasets.dataset.id}_2",
                                     animated=downstream_dps.status
                                     == DecisionStatus.APPROVED,
@@ -404,7 +402,7 @@ class DataProductService(AbstractDataProductService):
                             name=downstream_dataset.name,
                             link_to_id=downstream_dataset.data_product_id,
                         ),
-                        type=NodeType.datasetNode,
+                        type=NodeType.outputPortNode,
                     )
                 )
                 edges.append(

--- a/backend/app/graph/node.py
+++ b/backend/app/graph/node.py
@@ -17,8 +17,9 @@ class NodeData(BaseModel):
 
 class NodeType(str, Enum):
     dataProductNode = "dataProductNode"
-    dataOutputNode = "dataOutputNode"
-    datasetNode = "datasetNode"
+    explorationNode = "explorationNode"
+    technicalAssetNode = "technicalAssetNode"
+    outputPortNode = "outputPortNode"
     domainNode = "domainNode"
 
 

--- a/backend/app/graph/service.py
+++ b/backend/app/graph/service.py
@@ -100,7 +100,7 @@ class GraphService:
                             domain_id=dataset["domain_id"],
                             description=dataset["description"],
                         ),
-                        type=NodeType.datasetNode,
+                        type=NodeType.outputPortNode,
                     )
                     for dataset in datasets
                 ]

--- a/backend/tests/app/data_products/output_ports/test_router.py
+++ b/backend/tests/app/data_products/output_ports/test_router.py
@@ -19,6 +19,7 @@ from tests.factories import (
     DatasetFactory,
     DatasetRoleAssignmentFactory,
     DomainFactory,
+    ExplorationFactory,
     GlobalRoleAssignmentFactory,
     InputPortFactory,
     RoleFactory,
@@ -48,7 +49,7 @@ def dataset_payload():
     }
 
 
-class TestDatasetsRouter:
+class TestOutputPortRouter:
     invalid_id = "00000000-0000-0000-0000-000000000000"
 
     def test_create_dataset(self, dataset_payload, client):
@@ -445,7 +446,7 @@ class TestDatasetsRouter:
         response = self.get_output_port(client, ds.id, ds.data_product.id)
         assert response.json()["status"] == "pending"
 
-    def test_get_graph_data(self, client):
+    def test_get_output_port_graph_data(self, client):
         dp = DataProductFactory()
         ds = DatasetFactory(data_product=dp)
         response = client.get(f"{ENDPOINT.format(dp.id)}/{ds.id}/graph")
@@ -461,7 +462,7 @@ class TestDatasetsRouter:
         ]
         nodes = response.json()["nodes"]
         dp_node = [node for node in nodes if node["type"] == "dataProductNode"][0]
-        ds_node = [node for node in nodes if node["type"] == "datasetNode"][0]
+        ds_node = [node for node in nodes if node["type"] == "outputPortNode"][0]
         assert dp_node == {
             "data": {
                 "id": f"{str(dp.id)}",
@@ -488,8 +489,20 @@ class TestDatasetsRouter:
             },
             "id": str(ds.id),
             "isMain": True,
-            "type": "datasetNode",
+            "type": "outputPortNode",
         }
+
+    def test_get_output_port_graph_data_exploration(self, client):
+        ds = DatasetFactory()
+        exp = ExplorationFactory()
+        InputPortFactory(
+            dataset=ds,
+            consuming_abstract_data_product=exp,
+        )
+        response = client.get(
+            f"{ENDPOINT.format(ds.data_product.id)}/{ds.id}/graph", params={"level": 3}
+        )
+        assert response.status_code == 200, response.text
 
     def test_dataset_set_custom_setting_no_role(self, client):
         ds = DatasetFactory()

--- a/backend/tests/app/data_products/technical_assets/test_router.py
+++ b/backend/tests/app/data_products/technical_assets/test_router.py
@@ -332,7 +332,7 @@ class TestTechnicalAssetsRouter:
             }
         ]
         for node in response.json()["nodes"]:
-            if node["type"] == "dataOutputNode":
+            if node["type"] == "technicalAssetNode":
                 assert node == {
                     "data": {
                         "icon_key": "S3TechnicalAssetConfiguration",
@@ -345,7 +345,7 @@ class TestTechnicalAssetsRouter:
                     },
                     "id": str(data_output.id),
                     "isMain": True,
-                    "type": "dataOutputNode",
+                    "type": "technicalAssetNode",
                 }
             else:
                 assert node == {

--- a/backend/tests/app/data_products/test_router.py
+++ b/backend/tests/app/data_products/test_router.py
@@ -21,6 +21,7 @@ from tests.factories import (
     DomainFactory,
     EnvironmentFactory,
     EnvPlatformConfigFactory,
+    ExplorationFactory,
     GlobalRoleAssignmentFactory,
     InputPortFactory,
     LifecycleFactory,
@@ -410,6 +411,20 @@ class TestDataProductsRouter:
         InputPortFactory(
             dataset=dataset,
             consuming_abstract_data_product=downstream_dataset.data_product,
+        )
+        response = client.get(f"{ENDPOINT}/{data_product.id}/graph")
+        assert len(response.json()["edges"]) == 3
+        assert len(response.json()["nodes"]) == 4
+
+    def test_get_data_product_graph_data_exploration_included(self, client):
+        data_product = DataProductFactory()
+        dataset = DatasetFactory(data_product=data_product)
+        ta = TechnicalAssetFactory(owner=data_product)
+        DataOutputDatasetAssociationFactory(data_output=ta, dataset=dataset)
+        exp = ExplorationFactory()
+        InputPortFactory(
+            dataset=dataset,
+            consuming_abstract_data_product=exp,
         )
         response = client.get(f"{ENDPOINT}/{data_product.id}/graph")
         assert len(response.json()["edges"]) == 3

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -11109,8 +11109,9 @@
         "type": "string",
         "enum": [
           "dataProductNode",
-          "dataOutputNode",
-          "datasetNode",
+          "explorationNode",
+          "technicalAssetNode",
+          "outputPortNode",
           "domainNode"
         ],
         "title": "NodeType"

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -680,6 +680,7 @@
     "Value must be a number": "Value must be a number",
     "View Data Product": "View $t(Data Product)",
     "View details": "View details",
+    "View Exploration": "View Exploration",
     "View Output Port": "View $t(Output Port)",
     "View requests": "View requests",
     "View Technical Asset": "View $t(Technical Asset)",

--- a/frontend/src/components/charts/custom-nodes/exploration-node/exploration-node.tsx
+++ b/frontend/src/components/charts/custom-nodes/exploration-node/exploration-node.tsx
@@ -1,10 +1,9 @@
 import type { Node, NodeProps, Position } from '@xyflow/react';
 import type { ReactNode } from 'react';
-
-import outputPortBorderIcon from '@/assets/icons/border-icons/output-port-border-icon.svg?react';
+import explorationBorderIcon from '@/assets/icons/border-icons/exploration-border-icon.svg?react';
 import { BaseNode } from '@/components/charts/custom-nodes/base-node/base-node.tsx';
 
-type DatasetNodeProps = Node<{
+type ExplorationNodeProps = Node<{
     id: string;
     name: string;
     isMainNode?: boolean;
@@ -13,11 +12,12 @@ type DatasetNodeProps = Node<{
     sourceHandlePosition?: Position;
     isActive?: boolean;
     domain?: string;
+    description?: string;
     centeredHandles?: boolean;
-    onClick: () => void;
+    onClick?: () => void;
 }>;
 
-export function DatasetNode({
+export function ExplorationNode({
     data: {
         name,
         id,
@@ -27,24 +27,26 @@ export function DatasetNode({
         sourceHandlePosition,
         isActive,
         domain,
+        description,
         centeredHandles,
         onClick,
     },
     ...props
-}: NodeProps<DatasetNodeProps>) {
+}: NodeProps<ExplorationNodeProps>) {
     return (
         <BaseNode
             data={{
-                isMainNode,
                 name,
                 id,
-                icon: outputPortBorderIcon,
+                isMainNode,
+                icon: explorationBorderIcon,
                 borderType: 'square',
                 nodeToolbarActions,
-                targetHandlePosition,
                 sourceHandlePosition,
+                targetHandlePosition,
                 isActive,
                 domain,
+                description,
                 centeredHandles,
                 onClick,
             }}

--- a/frontend/src/components/charts/custom-nodes/output-port-node/output-port-node.tsx
+++ b/frontend/src/components/charts/custom-nodes/output-port-node/output-port-node.tsx
@@ -1,11 +1,10 @@
 import type { Node, NodeProps, Position } from '@xyflow/react';
 import type { ReactNode } from 'react';
 
+import outputPortBorderIcon from '@/assets/icons/border-icons/output-port-border-icon.svg?react';
 import { BaseNode } from '@/components/charts/custom-nodes/base-node/base-node.tsx';
-import type { UiElementMetadataResponse } from '@/store/api/services/generated/pluginsApi';
-import { getDataOutputIcon } from '@/utils/data-output-type.helper';
 
-type DataOutputNodeProps = Node<{
+type DatasetNodeProps = Node<{
     id: string;
     name: string;
     isMainNode?: boolean;
@@ -13,14 +12,12 @@ type DataOutputNodeProps = Node<{
     targetHandlePosition?: Position;
     sourceHandlePosition?: Position;
     isActive?: boolean;
-    icon_key: string;
     domain?: string;
     centeredHandles?: boolean;
-    onClick?: () => void;
-    plugins?: UiElementMetadataResponse[];
+    onClick: () => void;
 }>;
 
-export function DataOutputNode({
+export function OutputPortNode({
     data: {
         name,
         id,
@@ -28,22 +25,20 @@ export function DataOutputNode({
         nodeToolbarActions,
         targetHandlePosition,
         sourceHandlePosition,
-        icon_key,
         isActive,
         domain,
         centeredHandles,
         onClick,
-        plugins,
     },
     ...props
-}: NodeProps<DataOutputNodeProps>) {
+}: NodeProps<DatasetNodeProps>) {
     return (
         <BaseNode
             data={{
                 isMainNode,
                 name,
                 id,
-                icon: getDataOutputIcon(icon_key, plugins),
+                icon: outputPortBorderIcon,
                 borderType: 'square',
                 nodeToolbarActions,
                 targetHandlePosition,

--- a/frontend/src/components/charts/custom-nodes/technical-asset-node/technical-asset-node.tsx
+++ b/frontend/src/components/charts/custom-nodes/technical-asset-node/technical-asset-node.tsx
@@ -1,0 +1,59 @@
+import type { Node, NodeProps, Position } from '@xyflow/react';
+import type { ReactNode } from 'react';
+
+import { BaseNode } from '@/components/charts/custom-nodes/base-node/base-node.tsx';
+import type { UiElementMetadataResponse } from '@/store/api/services/generated/pluginsApi';
+import { getDataOutputIcon } from '@/utils/data-output-type.helper';
+
+type DataOutputNodeProps = Node<{
+    id: string;
+    name: string;
+    isMainNode?: boolean;
+    nodeToolbarActions?: ReactNode;
+    targetHandlePosition?: Position;
+    sourceHandlePosition?: Position;
+    isActive?: boolean;
+    icon_key: string;
+    domain?: string;
+    centeredHandles?: boolean;
+    onClick?: () => void;
+    plugins?: UiElementMetadataResponse[];
+}>;
+
+export function TechnicalAssetNode({
+    data: {
+        name,
+        id,
+        isMainNode,
+        nodeToolbarActions,
+        targetHandlePosition,
+        sourceHandlePosition,
+        icon_key,
+        isActive,
+        domain,
+        centeredHandles,
+        onClick,
+        plugins,
+    },
+    ...props
+}: NodeProps<DataOutputNodeProps>) {
+    return (
+        <BaseNode
+            data={{
+                isMainNode,
+                name,
+                id,
+                icon: getDataOutputIcon(icon_key, plugins),
+                borderType: 'square',
+                nodeToolbarActions,
+                targetHandlePosition,
+                sourceHandlePosition,
+                isActive,
+                domain,
+                centeredHandles,
+                onClick,
+            }}
+            {...props}
+        />
+    );
+}

--- a/frontend/src/components/charts/node-editor/node-types.ts
+++ b/frontend/src/components/charts/node-editor/node-types.ts
@@ -3,16 +3,11 @@ import type { EdgeTypes, NodeTypes } from '@xyflow/react';
 import { DefaultEdge } from '@/components/charts/custom-edges/default-edge';
 import { StraightEdge } from '@/components/charts/custom-edges/straight-edge';
 import { DataProductNode } from '@/components/charts/custom-nodes/data-product-node/data-product-node.tsx';
-import { DataOutputNode } from '@/components/charts/custom-nodes/dataoutput-node/dataoutput-node';
-import { DatasetNode } from '@/components/charts/custom-nodes/dataset-node/dataset-node.tsx';
 import { DomainNode } from '@/components/charts/custom-nodes/domain-node/domain-node.tsx';
-
-export enum CustomNodeTypes {
-    DataProductNode = 'dataProductNode',
-    DatasetNode = 'datasetNode',
-    DataOutputNode = 'dataOutputNode',
-    DomainNode = 'domainNode',
-}
+import { ExplorationNode } from '@/components/charts/custom-nodes/exploration-node/exploration-node.tsx';
+import { OutputPortNode } from '@/components/charts/custom-nodes/output-port-node/output-port-node.tsx';
+import { NodeType } from '@/store/api/services/generated/graphApi.ts';
+import { TechnicalAssetNode } from '../custom-nodes/technical-asset-node/technical-asset-node';
 
 export enum CustomEdgeTypes {
     DefaultEdge = 'defaultEdge',
@@ -20,10 +15,11 @@ export enum CustomEdgeTypes {
 }
 
 export const nodeTypes: NodeTypes = {
-    [CustomNodeTypes.DataProductNode]: DataProductNode,
-    [CustomNodeTypes.DatasetNode]: DatasetNode,
-    [CustomNodeTypes.DataOutputNode]: DataOutputNode,
-    [CustomNodeTypes.DomainNode]: DomainNode,
+    [NodeType.DataProductNode]: DataProductNode,
+    [NodeType.OutputPortNode]: OutputPortNode,
+    [NodeType.TechnicalAssetNode]: TechnicalAssetNode,
+    [NodeType.DomainNode]: DomainNode,
+    [NodeType.ExplorationNode]: ExplorationNode,
 };
 
 export const edgeTypes: EdgeTypes = {

--- a/frontend/src/components/explorer/common.tsx
+++ b/frontend/src/components/explorer/common.tsx
@@ -11,6 +11,7 @@ import { TabKeys as DatasetTabKeys } from '@/pages/dataset/components/dataset-ta
 import {
     createDataOutputIdPath,
     createDataProductIdPath,
+    createExplorationIdPath,
     createMarketplaceOutputPortPath,
 } from '@/types/navigation.ts';
 
@@ -21,6 +22,15 @@ function LinkToDataProductNode({ id }: { id: string }) {
     return (
         <Link to={createDataProductIdPath(id, DataProductTabKeys.Explorer)} className={styles.link}>
             <Button type="default">{t('View Data Product')}</Button>
+        </Link>
+    );
+}
+
+function LinkToExplorationNode({ id }: { id: string }) {
+    const { t } = useTranslation();
+    return (
+        <Link to={createExplorationIdPath(id)} className={styles.link}>
+            <Button type="default">{t('View Exploration')}</Button>
         </Link>
     );
 }
@@ -43,4 +53,4 @@ function LinkToDataOutputNode({ id, product_id }: { id: string; product_id: stri
     );
 }
 
-export { LinkToDataOutputNode, LinkToDataProductNode, LinkToDatasetNode };
+export { LinkToDataOutputNode, LinkToDataProductNode, LinkToDatasetNode, LinkToExplorationNode };

--- a/frontend/src/components/explorer/internal-explorer.tsx
+++ b/frontend/src/components/explorer/internal-explorer.tsx
@@ -16,7 +16,7 @@ import { useGetTechnicalAssetGraphDataQuery } from '@/store/api/services/generat
 import { type UiElementMetadataResponse, useGetPluginsQuery } from '@/store/api/services/generated/pluginsApi.ts';
 import { dispatchMessage } from '@/store/features/feedback/utils/dispatch-feedback.ts';
 import { parseRegularNode } from '@/utils/node-parser.helper.ts';
-import { LinkToDataOutputNode, LinkToDataProductNode, LinkToDatasetNode } from './common.tsx';
+import { LinkToDataOutputNode, LinkToDataProductNode, LinkToDatasetNode, LinkToExplorationNode } from './common.tsx';
 import styles from './explorer.module.scss';
 import { useNodeEditor } from './use-node-editor.tsx';
 import { parseEdges } from './utils.tsx';
@@ -33,7 +33,7 @@ function parseNodes(nodes: GraphNode[], t: TFunction, plugins: UiElementMetadata
         .map((node) => {
             let extra_attributes = {};
             switch (node.type) {
-                case NodeType.DataOutputNode:
+                case NodeType.TechnicalAssetNode:
                     extra_attributes = {
                         nodeToolbarActions: node.isMain ? (
                             ''
@@ -47,7 +47,7 @@ function parseNodes(nodes: GraphNode[], t: TFunction, plugins: UiElementMetadata
                         plugins: plugins,
                     };
                     break;
-                case NodeType.DatasetNode:
+                case NodeType.OutputPortNode:
                     extra_attributes = {
                         nodeToolbarActions: node.isMain ? (
                             ''
@@ -62,6 +62,13 @@ function parseNodes(nodes: GraphNode[], t: TFunction, plugins: UiElementMetadata
                     extra_attributes = {
                         targetHandlePosition: Position.Left,
                         nodeToolbarActions: node.isMain ? '' : <LinkToDataProductNode id={node.data.id} />,
+                        description: node.data.description,
+                    };
+                    break;
+                case NodeType.ExplorationNode:
+                    extra_attributes = {
+                        targetHandlePosition: Position.Left,
+                        nodeToolbarActions: node.isMain ? '' : <LinkToExplorationNode id={node.data.id} />,
                         description: node.data.description,
                     };
                     break;

--- a/frontend/src/components/global-explorer/internal-explorer.tsx
+++ b/frontend/src/components/global-explorer/internal-explorer.tsx
@@ -5,11 +5,16 @@ import { type Edge, type Node, Position, ReactFlowProvider, useReactFlow } from 
 import { Flex, theme } from 'antd';
 import { type MouseEvent, useCallback, useEffect, useState } from 'react';
 import { defaultFitViewOptions, NodeEditor } from '@/components/charts/node-editor/node-editor.tsx';
-import { CustomEdgeTypes, CustomNodeTypes } from '@/components/charts/node-editor/node-types.ts';
+import { CustomEdgeTypes } from '@/components/charts/node-editor/node-types.ts';
 import type { Node as GraphNode } from '@/store/api/services/generated/graphApi.ts';
 import { NodeType, useGetGraphDataQuery } from '@/store/api/services/generated/graphApi.ts';
 import { parseRegularNode } from '@/utils/node-parser.helper';
-import { LinkToDataOutputNode, LinkToDataProductNode, LinkToDatasetNode } from '../explorer/common';
+import {
+    LinkToDataOutputNode,
+    LinkToDataProductNode,
+    LinkToDatasetNode,
+    LinkToExplorationNode,
+} from '../explorer/common';
 import styles from '../explorer/explorer.module.scss';
 import { parseEdges } from '../explorer/utils';
 import { Sidebar, type SidebarFilters } from './sidebar/sidebar';
@@ -42,7 +47,7 @@ function parseFullNodes(nodes: GraphNode[], setNodeId: (id: string) => void, dom
             domainNodes.push({
                 id: domainId,
                 position: { x: 0, y: 0 },
-                type: CustomNodeTypes.DomainNode,
+                type: NodeType.DomainNode,
                 draggable: true,
                 deletable: false,
                 data: {
@@ -67,7 +72,13 @@ function parseFullNodes(nodes: GraphNode[], setNodeId: (id: string) => void, dom
                         targetHandlePosition: Position.Left,
                     };
                     break;
-                case NodeType.DatasetNode:
+                case NodeType.ExplorationNode:
+                    extra_attributes = {
+                        nodeToolbarActions: node.isMain ? null : <LinkToExplorationNode id={node.data.id} />,
+                        targetHandlePosition: Position.Left,
+                    };
+                    break;
+                case NodeType.OutputPortNode:
                     extra_attributes = {
                         nodeToolbarActions: node.isMain ? (
                             ''
@@ -78,7 +89,7 @@ function parseFullNodes(nodes: GraphNode[], setNodeId: (id: string) => void, dom
                         targetHandleId: 'left_t',
                     };
                     break;
-                case NodeType.DataOutputNode:
+                case NodeType.TechnicalAssetNode:
                     extra_attributes = {
                         nodeToolbarActions: node.isMain ? (
                             ''
@@ -123,7 +134,7 @@ function applyHighlighting(nodes: Node[], edges: Edge[], selectedId: string | nu
     });
 
     // Domain nodes should stay visible if any of their children are connected
-    const domainNodeIds = new Set(nodes.filter((n) => n.type === CustomNodeTypes.DomainNode).map((n) => n.id));
+    const domainNodeIds = new Set(nodes.filter((n) => n.type === NodeType.DomainNode).map((n) => n.id));
     const activeDomainIds = new Set(
         nodes.filter((n) => n.parentId && connectedNodeIds.has(n.id)).map((n) => n.parentId as string),
     );

--- a/frontend/src/components/global-explorer/sidebar/sidebar.tsx
+++ b/frontend/src/components/global-explorer/sidebar/sidebar.tsx
@@ -3,8 +3,8 @@ import { Flex, Segmented, Select, Switch } from 'antd';
 import { type MouseEvent, useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { GetDataProductResponse } from '@/store/api/services/generated/dataProductsApi.ts';
+import { NodeType } from '@/store/api/services/generated/graphApi.ts';
 import { defaultFitViewOptions } from '../../charts/node-editor/node-editor';
-import { CustomNodeTypes } from '../../charts/node-editor/node-types';
 import { NodeContext } from './node-context';
 import styles from './sidebar.module.scss';
 
@@ -66,10 +66,11 @@ export function Sidebar({ nodes, sidebarFilters, onFilterChange, nodeId, nodeCli
 
     const groupedNodes = useMemo(() => {
         const groups = {
-            Domains: nodes.filter((node) => node.type === CustomNodeTypes.DomainNode),
-            'Data Products': nodes.filter((node) => node.type === CustomNodeTypes.DataProductNode),
-            'Output Ports': nodes.filter((node) => node.type === CustomNodeTypes.DatasetNode),
-            'Technical Assets': nodes.filter((node) => node.type === CustomNodeTypes.DataOutputNode),
+            Domains: nodes.filter((node) => node.type === NodeType.DomainNode),
+            'Data Products': nodes.filter((node) => node.type === NodeType.DataProductNode),
+            'Output Ports': nodes.filter((node) => node.type === NodeType.OutputPortNode),
+            'Technical Assets': nodes.filter((node) => node.type === NodeType.TechnicalAssetNode),
+            Explorations: nodes.filter((node) => node.type === NodeType.ExplorationNode),
         };
 
         // Sort each group by name
@@ -91,6 +92,8 @@ export function Sidebar({ nodes, sidebarFilters, onFilterChange, nodeId, nodeCli
                     return t('Output Ports');
                 case 'Technical Assets':
                     return t('Technical Assets');
+                case 'Explorations':
+                    return t('Explorations');
                 default:
                     return t('Undefined group');
             }

--- a/frontend/src/components/global-explorer/use-node-editor.tsx
+++ b/frontend/src/components/global-explorer/use-node-editor.tsx
@@ -2,7 +2,7 @@ import type { Connection, Edge, Node, OnConnect } from '@xyflow/react';
 import { addEdge, useEdgesState, useNodesState } from '@xyflow/react';
 import ELK from 'elkjs';
 import { useCallback } from 'react';
-import { CustomNodeTypes } from '@/components/charts/node-editor/node-types';
+import { NodeType } from '@/store/api/services/generated/graphApi.ts';
 
 // gets node width and height from base-node.module.scss
 const getNodeDimensions = () => {
@@ -127,7 +127,7 @@ async function applyElkLayout(nodes: Node[], edges: Edge[], advancedLayout: bool
     const parentNodes = nodes.filter((node) => !node.parentId);
     const childNodes = nodes.filter((node) => node.parentId);
     const graphChildren = parentNodes.map((parentNode) => {
-        if (parentNode.type === CustomNodeTypes.DomainNode) {
+        if (parentNode.type === NodeType.DomainNode) {
             // If this is a domain node, include its children
             const children = childNodes
                 .filter((child) => child.parentId === parentNode.id)
@@ -176,7 +176,7 @@ async function applyElkLayout(nodes: Node[], edges: Edge[], advancedLayout: bool
         const node = nodes.find((n) => n.id === layoutNode.id);
         if (!node) return; // happens for children of domain nodes (not top level)
 
-        if (node.type === CustomNodeTypes.DomainNode) {
+        if (node.type === NodeType.DomainNode) {
             // domain node itself
             elkedNodes.push({
                 ...node,

--- a/frontend/src/store/api/services/generated/dataProductsApi.ts
+++ b/frontend/src/store/api/services/generated/dataProductsApi.ts
@@ -583,8 +583,9 @@ export enum DataProductIconKey {
 }
 export enum NodeType {
   DataProductNode = "dataProductNode",
-  DataOutputNode = "dataOutputNode",
-  DatasetNode = "datasetNode",
+  ExplorationNode = "explorationNode",
+  TechnicalAssetNode = "technicalAssetNode",
+  OutputPortNode = "outputPortNode",
   DomainNode = "domainNode",
 }
 export enum DecisionStatus {

--- a/frontend/src/store/api/services/generated/dataProductsOutputPortsApi.ts
+++ b/frontend/src/store/api/services/generated/dataProductsOutputPortsApi.ts
@@ -717,8 +717,9 @@ export enum DataProductIconKey {
 }
 export enum NodeType {
   DataProductNode = "dataProductNode",
-  DataOutputNode = "dataOutputNode",
-  DatasetNode = "datasetNode",
+  ExplorationNode = "explorationNode",
+  TechnicalAssetNode = "technicalAssetNode",
+  OutputPortNode = "outputPortNode",
   DomainNode = "domainNode",
 }
 export const {

--- a/frontend/src/store/api/services/generated/dataProductsTechnicalAssetsApi.ts
+++ b/frontend/src/store/api/services/generated/dataProductsTechnicalAssetsApi.ts
@@ -606,8 +606,9 @@ export enum EventEntityType {
 }
 export enum NodeType {
   DataProductNode = "dataProductNode",
-  DataOutputNode = "dataOutputNode",
-  DatasetNode = "datasetNode",
+  ExplorationNode = "explorationNode",
+  TechnicalAssetNode = "technicalAssetNode",
+  OutputPortNode = "outputPortNode",
   DomainNode = "domainNode",
 }
 export const {

--- a/frontend/src/store/api/services/generated/graphApi.ts
+++ b/frontend/src/store/api/services/generated/graphApi.ts
@@ -59,8 +59,9 @@ export type HttpValidationError = {
 };
 export enum NodeType {
   DataProductNode = "dataProductNode",
-  DataOutputNode = "dataOutputNode",
-  DatasetNode = "datasetNode",
+  ExplorationNode = "explorationNode",
+  TechnicalAssetNode = "technicalAssetNode",
+  OutputPortNode = "outputPortNode",
   DomainNode = "domainNode",
 }
 export const { useGetGraphDataQuery, useLazyGetGraphDataQuery } =

--- a/sdk/sdk/api_client/models/node_type.py
+++ b/sdk/sdk/api_client/models/node_type.py
@@ -2,10 +2,11 @@ from enum import Enum
 
 
 class NodeType(str, Enum):
-    DATAOUTPUTNODE = "dataOutputNode"
     DATAPRODUCTNODE = "dataProductNode"
-    DATASETNODE = "datasetNode"
     DOMAINNODE = "domainNode"
+    EXPLORATIONNODE = "explorationNode"
+    OUTPUTPORTNODE = "outputPortNode"
+    TECHNICALASSETNODE = "technicalAssetNode"
 
     def __str__(self) -> str:
         return str(self.value)


### PR DESCRIPTION
They are only added to the small views
in a data product or output port.
Not in the explorer view

In support of: #3211

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested


Output port graph
<img width="1721" height="995" alt="image" src="https://github.com/user-attachments/assets/0d66c820-2600-417d-90c4-1595ebfc2f9c" />

Data product graph:
<img width="1725" height="992" alt="image" src="https://github.com/user-attachments/assets/04434b2b-a8f3-4326-ab33-44f38611138f" />

Technical asset graph:
<img width="1720" height="992" alt="image" src="https://github.com/user-attachments/assets/20ecb49b-a354-452d-b4d1-c129b9c53378" />
