### PR TITLE
Show required by default in all forms

### DIFF
--- a/frontend/src/components/data-outputs/data-output-form/data-output-form.component.tsx
+++ b/frontend/src/components/data-outputs/data-output-form/data-output-form.component.tsx
@@ -144,7 +144,6 @@ export function DataOutputForm({ mode, dataProductId, dataOutputId }: Props) {
             onFinish={onSubmit}
             onFinishFailed={onSubmitFailed}
             autoComplete={'off'}
-            requiredMark={'optional'}
             disabled={isLoading || !canEdit}
             initialValues={initialValues}
         >

--- a/frontend/src/components/data-products/data-output-form/data-output-form.component.tsx
+++ b/frontend/src/components/data-products/data-output-form/data-output-form.component.tsx
@@ -244,7 +244,6 @@ export function DataOutputForm({ mode, formRef, dataProductId, modalCallbackOnSu
             onFinishFailed={onSubmitFailed}
             onValuesChange={onValuesChange}
             autoComplete={'off'}
-            requiredMark={'optional'}
             labelWrap
             disabled={isLoading}
         >

--- a/frontend/src/components/data-products/data-product-form/data-product-form.component.tsx
+++ b/frontend/src/components/data-products/data-product-form/data-product-form.component.tsx
@@ -223,7 +223,6 @@ export function DataProductForm({ mode, dataProductId }: Props) {
                 onFinish={onFinish}
                 onFinishFailed={onFinishFailed}
                 autoComplete={'off'}
-                requiredMark={'optional'}
                 disabled={isLoading || !canSubmit}
                 initialValues={initialValues}
             >

--- a/frontend/src/components/data-products/data-product-settings/data-product-settings.component.tsx
+++ b/frontend/src/components/data-products/data-product-settings/data-product-settings.component.tsx
@@ -241,7 +241,6 @@ export function DataProductSettings({ id, scope, dataProductId }: Props) {
                 onFinish={onSubmit}
                 onFinishFailed={onSubmitFailed}
                 autoComplete={'off'}
-                requiredMark={'optional'}
                 labelWrap
                 labelAlign={'left'}
                 disabled={

--- a/frontend/src/components/datasets/dataset-form/dataset-form.component.tsx
+++ b/frontend/src/components/datasets/dataset-form/dataset-form.component.tsx
@@ -320,7 +320,6 @@ export function DatasetForm({ mode, modalCallbackOnSubmit, formRef, datasetId, d
             onFinish={onFinish}
             onFinishFailed={onFinishFailed}
             autoComplete={'off'}
-            requiredMark={'optional'}
             disabled={isLoading || !canSubmit}
             initialValues={initialValues}
         >

--- a/frontend/src/pages/cart/components/new-data-product-form.tsx
+++ b/frontend/src/pages/cart/components/new-data-product-form.tsx
@@ -81,6 +81,7 @@ export const NewDataProductForm = ({ cartOutputPorts }: Props) => {
             form={form}
             onFinish={onFinish}
             layout={'vertical'}
+            autoComplete={'off'}
             onValuesChange={onValuesChange}
             initialValues={initialValues}
         >

--- a/frontend/src/pages/settings/components/settings-tabs/components/theme-form/theme-form.component.tsx
+++ b/frontend/src/pages/settings/components/settings-tabs/components/theme-form/theme-form.component.tsx
@@ -83,7 +83,6 @@ export function ThemeSettingsForm() {
                 onFinish={onSubmit}
                 onFinishFailed={onSubmitFailed}
                 autoComplete={'off'}
-                requiredMark={'optional'}
                 labelWrap
                 disabled={isLoading || !canEditForm}
                 initialValues={data}


### PR DESCRIPTION
It was confusing that it sometimes shows
up and sometimes doesn't. It's better for
users to always show it that way they know
things are required.

Also removed autocomplete from the exploration
form since it was useless.

In support of: #3211

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested
