### PR TITLE
fix: add .unwrap() to RTK Query mutations to properly catch API errors

### DIFF
--- a/frontend/src/pages/settings/components/settings-tabs/components/data-product-lifecycles-table/data-product-lifecycles-table.component.tsx
+++ b/frontend/src/pages/settings/components/settings-tabs/components/data-product-lifecycles-table/data-product-lifecycles-table.component.tsx
@@ -39,7 +39,7 @@ export function DataProductLifecyclesTable() {
     const handleRemove = useCallback(
         async (lifeCycle: DataProductLifeCyclesGetItem) => {
             try {
-                await onRemoveDataProductLifecycle(lifeCycle.id);
+                await onRemoveDataProductLifecycle(lifeCycle.id).unwrap();
                 dispatchMessage({ content: t('Lifecycle removed successfully'), type: 'success' });
             } catch (_) {
                 dispatchMessage({ content: t('Could not remove lifecycle'), type: 'error' });

--- a/frontend/src/pages/settings/components/settings-tabs/components/data-product-lifecycles-table/new-data-product-lifecycles-modal.component.tsx
+++ b/frontend/src/pages/settings/components/settings-tabs/components/data-product-lifecycles-table/new-data-product-lifecycles-modal.component.tsx
@@ -49,7 +49,7 @@ export const CreateLifecycleModal: React.FC<CreateLifecycleModalProps> = ({ isOp
     const handleFinish = async (lifeCycle: DataProductLifeCycle) => {
         try {
             if (mode === 'create') {
-                await createDataProductLifecycle(lifeCycle);
+                await createDataProductLifecycle(lifeCycle).unwrap();
             } else {
                 await editDataProductLifecycle({
                     id: lifeCycle.id,
@@ -59,7 +59,7 @@ export const CreateLifecycleModal: React.FC<CreateLifecycleModalProps> = ({ isOp
                         color: lifeCycle.color,
                         is_default: lifeCycle.is_default,
                     },
-                });
+                }).unwrap();
             }
             dispatchMessage({ content: variableText.successMessage, type: 'success' });
             form.resetFields();

--- a/frontend/src/pages/settings/components/settings-tabs/components/data-product-settings-table/data-product-settings-table.component.tsx
+++ b/frontend/src/pages/settings/components/settings-tabs/components/data-product-settings-table/data-product-settings-table.component.tsx
@@ -48,7 +48,7 @@ export function DataProductSettingsTable({ scope }: Props) {
     const handleRemove = useCallback(
         async (setting: DataProductSettingsGetItem) => {
             try {
-                await onRemoveDataProductSetting(setting.id);
+                await onRemoveDataProductSetting(setting.id).unwrap();
                 dispatchMessage({ content: t('Data Product lifecycle removed successfully'), type: 'success' });
             } catch (_) {
                 dispatchMessage({ content: t('Could not remove Data Product lifecycle'), type: 'error' });

--- a/frontend/src/pages/settings/components/settings-tabs/components/data-product-type-table/data-product-type-form-modal.component.tsx
+++ b/frontend/src/pages/settings/components/settings-tabs/components/data-product-type-table/data-product-type-form-modal.component.tsx
@@ -53,14 +53,14 @@ export function CreateDataProductTypeModal({ isOpen, onClose, mode, initial }: P
     const handleFinish = async (values: DataProductTypeCreate) => {
         try {
             if (mode === 'create') {
-                await createDataProductType(values);
+                await createDataProductType(values).unwrap();
             } else {
                 await editDataProductType({
                     id: initial?.id as string,
                     dataProductTypeUpdate: {
                         ...values,
                     },
-                });
+                }).unwrap();
             }
 
             dispatchMessage({ content: variableText.successMessage, type: 'success' });

--- a/frontend/src/pages/settings/components/settings-tabs/components/data-product-type-table/data-product-type-migrate-modal.component.tsx
+++ b/frontend/src/pages/settings/components/settings-tabs/components/data-product-type-table/data-product-type-migrate-modal.component.tsx
@@ -29,8 +29,8 @@ export function CreateDataProductTypeMigrateModal({ isOpen, onClose, migrateFrom
 
     const handleFinish = async (values: DataProductTypeMigrateFormValues) => {
         try {
-            await migrateDataProductType({ fromId: migrateFrom?.id, toId: values.toId });
-            await onRemoveDataProductType(migrateFrom?.id);
+            await migrateDataProductType({ fromId: migrateFrom?.id, toId: values.toId }).unwrap();
+            await onRemoveDataProductType(migrateFrom?.id).unwrap();
             dispatchMessage({ content: t('Type migrated and deleted successfully'), type: 'success' });
             form.resetFields();
             onClose();

--- a/frontend/src/pages/settings/components/settings-tabs/components/data-product-type-table/data-product-type-table.component.tsx
+++ b/frontend/src/pages/settings/components/settings-tabs/components/data-product-type-table/data-product-type-table.component.tsx
@@ -46,7 +46,7 @@ export function DataProductTypeTable() {
                 setMigrateFrom(type);
                 handleOpenMigrate();
             } else {
-                await onRemoveDataProductType(type.id);
+                await onRemoveDataProductType(type.id).unwrap();
                 dispatchMessage({ content: t('Type removed successfully'), type: 'success' });
             }
         } catch (_error) {

--- a/frontend/src/pages/settings/components/settings-tabs/components/domain-table/domain-form-modal.component.tsx
+++ b/frontend/src/pages/settings/components/settings-tabs/components/domain-table/domain-form-modal.component.tsx
@@ -47,14 +47,14 @@ export function CreateDomainModal({ isOpen, onClose, mode, initial }: Props) {
     const handleFinish = async (values: DomainCreate) => {
         try {
             if (mode === 'create') {
-                await createDomain(values);
+                await createDomain(values).unwrap();
             } else {
                 await editDomain({
                     id: initial?.id as string,
                     domainUpdate: {
                         ...values,
                     },
-                });
+                }).unwrap();
             }
 
             dispatchMessage({ content: variableText.successMessage, type: 'success' });

--- a/frontend/src/pages/settings/components/settings-tabs/components/domain-table/domain-migrate-modal.component.tsx
+++ b/frontend/src/pages/settings/components/settings-tabs/components/domain-table/domain-migrate-modal.component.tsx
@@ -29,8 +29,8 @@ export function CreateDomainMigrateModal({ isOpen, onClose, migrateFrom }: Props
 
     const handleFinish = async (values: DomainMigrateFormValues) => {
         try {
-            await migrateDomain({ fromId: migrateFrom.id, toId: values.toId });
-            await onRemoveDomain(migrateFrom.id);
+            await migrateDomain({ fromId: migrateFrom.id, toId: values.toId }).unwrap();
+            await onRemoveDomain(migrateFrom.id).unwrap();
             dispatchMessage({ content: t('Domain migrated and deleted successfully'), type: 'success' });
             form.resetFields();
             onClose();

--- a/frontend/src/pages/settings/components/settings-tabs/components/domain-table/domain-table.component.tsx
+++ b/frontend/src/pages/settings/components/settings-tabs/components/domain-table/domain-table.component.tsx
@@ -46,7 +46,7 @@ export function DomainTable() {
                 setMigrateFrom(domain);
                 handleOpenMigrate();
             } else {
-                await onRemoveDomain(domain.id);
+                await onRemoveDomain(domain.id).unwrap();
                 dispatchMessage({ content: t('Domain removed successfully'), type: 'success' });
             }
         } catch (_error) {

--- a/frontend/src/pages/settings/components/settings-tabs/components/tags-table/tags-form-modal.component.tsx
+++ b/frontend/src/pages/settings/components/settings-tabs/components/tags-table/tags-form-modal.component.tsx
@@ -43,9 +43,9 @@ export function CreateTagsModal({ isOpen, onClose, mode, initial }: Props) {
     const handleFinish = async (values: TagContract) => {
         try {
             if (mode === 'create') {
-                await createTag(values);
+                await createTag(values).unwrap();
             } else {
-                await editTag({ id: initial?.id ?? '', tagUpdate: { ...values } });
+                await editTag({ id: initial?.id ?? '', tagUpdate: { ...values } }).unwrap();
             }
 
             dispatchMessage({ content: variableText.successMessage, type: 'success' });


### PR DESCRIPTION
Closes #2468
Cool repo! I added .unwrap() to all RTK Query mutation calls in the settings components that were missing it. Without .unwrap(), failed API calls (e.g. 500 errors) were not properly thrown as errors, causing success messages to be shown even when operations failed. This fix ensures errors are properly caught and the correct error message is displayed to the user.
Hope this helps!