### PR TITLE
Fix log file path to /var/log/data-product-portal.log

### DIFF
--- a/backend/app/core/logging/logger.py
+++ b/backend/app/core/logging/logger.py
@@ -13,11 +13,11 @@ LOG_CONFIG_PATH = os.path.join(
 )
 
 
-def get_logger(name: str, prefix: str = "local"):
+def get_logger(name: str, filename: str = "data-product-portal.log"):
     with open(LOG_CONFIG_PATH) as log_config_file:
         dict_config = json.load(log_config_file)
         dict_config["handlers"]["fileHandler"]["filename"] = os.path.join(
-            settings.LOGGING_DIRECTORY, prefix
+            settings.LOGGING_DIRECTORY, filename
         )
 
         if not os.path.exists(settings.LOGGING_DIRECTORY):

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -99,7 +99,7 @@ class LoggerConfig(BaseSettings):
 
     LOG_LEVEL: LogLevel = LogLevel.INFO
     LOG_CONFIG_FILE: str = "log_config.json"
-    LOGGING_DIRECTORY: str = "/var/logs"
+    LOGGING_DIRECTORY: str = "/var/log"
     SCARF_NO_ANALYTICS: bool = False
     DO_NOT_TRACK: bool = False
     SANDBOX: bool = False

--- a/helm/templates/configmap_cw.yaml
+++ b/helm/templates/configmap_cw.yaml
@@ -11,7 +11,7 @@ data:
         "logs_collected": {
             "files": {
                 "collect_list": [{
-                    "file_path": "/var/logs/local",
+                    "file_path": "/var/log/data-product-portal.log",
                     "log_group_name": "data-product-portal/cwagent"
                 }
                 ]

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -170,7 +170,7 @@ volumes:
 
 volumeMounts:
   - name: varlog
-    mountPath: /var/logs
+    mountPath: /var/log
   - name: sampledata
     mountPath: /sampledata
   - name: tmpdir


### PR DESCRIPTION
The logger was writing to `/var/logs/local` , pretty confusing path imo.
Also  `/var/logs` (with trailing `s`) is non-standard. 
PR switches to `/var/log/data-product-portal.log`.

- [ ] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [ ] When updating the UI please provide screenshots or videos to the reviewers.
- [ ] Updated sample data so the new feature can be easily tested
