### PR TITLE
Fix single behavior

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from fastapi.concurrency import iterate_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.routing import APIRoute
 from fastapi.staticfiles import StaticFiles
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.authorization.service import AuthorizationService
@@ -177,12 +178,27 @@ def use_route_names_as_operation_ids(app: FastAPI) -> None:
 
 use_route_names_as_operation_ids(app)
 
+
+class SPAStaticFiles(StaticFiles):
+    """StaticFiles subclass that falls back to index.html for unknown paths.
+    Which is required for SPAs (single page applications).
+    """
+
+    async def get_response(self, path: str, scope):  # type: ignore[override]
+        try:
+            return await super().get_response(path, scope)
+        except StarletteHTTPException as exc:
+            if exc.status_code == 404:
+                return await super().get_response("index.html", scope)
+            raise
+
+
 if settings.SERVE_FRONTEND:
     _frontend_dir = Path(settings.FRONTEND_DIST_DIR)
     if _frontend_dir.exists():
         app.mount(
             "/",
-            StaticFiles(directory=str(_frontend_dir), html=True),
+            SPAStaticFiles(directory=str(_frontend_dir), html=True),
             name="frontend",
         )
     else:


### PR DESCRIPTION
- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested


Hard refresh did not work, but now does. Basically, the static files plugin should serve the index.html, if the route /studio does not match to a file, but it does not work that way. So added a fix to ensure it does.

Non working:
<img width="634" height="169" alt="image" src="https://github.com/user-attachments/assets/159f6113-fdb4-4b4b-a2f9-67a216c37d94" />

Working:
<img width="804" height="131" alt="image" src="https://github.com/user-attachments/assets/7689f36e-ecfe-452a-a748-fedbc1faeda3" />
