### PR TITLE
Data product reconciler

### DIFF
--- a/backend/app/core/webhooks/events.py
+++ b/backend/app/core/webhooks/events.py
@@ -31,23 +31,23 @@ class V2Event(BaseModel):
         raise NotImplementedError
 
 
-class ExplorationPayload(BaseModel):
+class ExplorationEventPayload(BaseModel):
     id: UUID
 
 
-class ExplorationCreatedEvent(V2Event, ExplorationPayload):
+class ExplorationCreatedEvent(V2Event, ExplorationEventPayload):
     @classmethod
     def event_type(cls) -> str:
         return "exploration.created"
 
 
-class ExplorationUpdatedEvent(V2Event, ExplorationPayload):
+class ExplorationUpdatedEvent(V2Event, ExplorationEventPayload):
     @classmethod
     def event_type(cls) -> str:
         return "exploration.updated"
 
 
-class ExplorationDeletedEvent(V2Event, ExplorationPayload):
+class ExplorationDeletedEvent(V2Event, ExplorationEventPayload):
     @classmethod
     def event_type(cls) -> str:
         return "exploration.deleted"
@@ -75,3 +75,25 @@ class InputPortDeletedEvent(V2Event, InputPortPayload):
     @classmethod
     def event_type(cls) -> str:
         return "input_port.deleted"
+
+
+class DataProductEventPayload(BaseModel):
+    id: UUID
+
+
+class DataProductCreatedEvent(V2Event, DataProductEventPayload):
+    @classmethod
+    def event_type(cls) -> str:
+        return "data_product.created"
+
+
+class DataProductUpdatedEvent(V2Event, DataProductEventPayload):
+    @classmethod
+    def event_type(cls) -> str:
+        return "data_product.updated"
+
+
+class DataProductDeletedEvent(V2Event, DataProductEventPayload):
+    @classmethod
+    def event_type(cls) -> str:
+        return "data_product.deleted"

--- a/backend/app/data_products/model.py
+++ b/backend/app/data_products/model.py
@@ -12,8 +12,15 @@ from app.authorization.role_assignments.data_product.model import (
 from app.authorization.role_assignments.enums import DecisionStatus
 from app.configuration.data_product_types.model import DataProductType
 from app.configuration.tags.model import Tag, tag_data_product_table
+from app.core.webhooks.events import (
+    DataProductCreatedEvent,
+    DataProductDeletedEvent,
+    DataProductEventPayload,
+    DataProductUpdatedEvent,
+)
 from app.data_products.technical_assets.model import TechnicalAsset
 from app.database.database import ensure_exists
+from app.database.event_mixin import EventTrackedMixin
 
 if TYPE_CHECKING:
     from app.configuration.data_product_lifecycles.model import DataProductLifecycle
@@ -23,7 +30,13 @@ if TYPE_CHECKING:
     )
 
 
-class DataProduct(AbstractDataProduct):
+class DataProduct(
+    AbstractDataProduct,
+    EventTrackedMixin,
+    create_event=DataProductCreatedEvent,
+    update_event=DataProductUpdatedEvent,
+    delete_event=DataProductDeletedEvent,
+):
     __tablename__ = "data_products"
 
     id: Mapped[UUID] = mapped_column(
@@ -89,6 +102,11 @@ class DataProduct(AbstractDataProduct):
     __mapper_args__ = {
         "polymorphic_identity": AbstractDataProductType.DATA_PRODUCT,
     }
+
+    def to_event(self) -> DataProductEventPayload:
+        return DataProductEventPayload(
+            id=self.id,
+        )
 
 
 def ensure_data_product_exists(

--- a/backend/app/database/event_mixin.py
+++ b/backend/app/database/event_mixin.py
@@ -1,6 +1,5 @@
 from pydantic import BaseModel
 from sqlalchemy import event as sql_event
-from sqlalchemy import inspect
 
 
 class EventTrackedMixin:

--- a/backend/app/explorations/model.py
+++ b/backend/app/explorations/model.py
@@ -9,7 +9,7 @@ from app.abstract_data_product.type import AbstractDataProductType
 from app.core.webhooks.events import (
     ExplorationCreatedEvent,
     ExplorationDeletedEvent,
-    ExplorationPayload,
+    ExplorationEventPayload,
     ExplorationUpdatedEvent,
 )
 from app.database.database import ensure_exists
@@ -37,8 +37,8 @@ class Exploration(
     owner_id: Mapped[UUID] = mapped_column("owner_id", ForeignKey("users.id"))
     owner: Mapped["User"] = relationship("User", foreign_keys=[owner_id], lazy="raise")
 
-    def to_event(self) -> ExplorationPayload:
-        return ExplorationPayload(
+    def to_event(self) -> ExplorationEventPayload:
+        return ExplorationEventPayload(
             id=self.id,
         )
 

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -7381,6 +7381,15 @@
                   },
                   {
                     "$ref": "#/components/schemas/CloudEvent_InputPortDeletedEvent"
+                  },
+                  {
+                    "$ref": "#/components/schemas/CloudEvent_DataProductCreatedEvent"
+                  },
+                  {
+                    "$ref": "#/components/schemas/CloudEvent_DataProductUpdatedEvent"
+                  },
+                  {
+                    "$ref": "#/components/schemas/CloudEvent_DataProductDeletedEvent"
                   }
                 ],
                 "title": "Body",
@@ -7392,7 +7401,10 @@
                     "exploration.deleted": "#/components/schemas/CloudEvent_ExplorationDeletedEvent",
                     "input_port.created": "#/components/schemas/CloudEvent_InputPortCreatedEvent",
                     "input_port.updated": "#/components/schemas/CloudEvent_InputPortUpdatedEvent",
-                    "input_port.deleted": "#/components/schemas/CloudEvent_InputPortDeletedEvent"
+                    "input_port.deleted": "#/components/schemas/CloudEvent_InputPortDeletedEvent",
+                    "data_product.created": "#/components/schemas/CloudEvent_DataProductCreatedEvent",
+                    "data_product.updated": "#/components/schemas/CloudEvent_DataProductUpdatedEvent",
+                    "data_product.deleted": "#/components/schemas/CloudEvent_DataProductDeletedEvent"
                   }
                 }
               }
@@ -7794,6 +7806,138 @@
           "can_become_admin"
         ],
         "title": "CanBecomeAdminUpdate"
+      },
+      "CloudEvent_DataProductCreatedEvent": {
+        "properties": {
+          "specversion": {
+            "type": "string",
+            "title": "Specversion",
+            "description": "The CloudEvents specification version.",
+            "default": "1.0"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "A unique UUID identifier for this specific event instance."
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "description": "Identifies the context in which an event happened.",
+            "default": "data-product-portal"
+          },
+          "type": {
+            "type": "string",
+            "const": "data_product.created",
+            "title": "Type",
+            "description": "The unique type string belonging to this event.",
+            "default": "data_product.created"
+          },
+          "time": {
+            "type": "string",
+            "title": "Time",
+            "description": "Timestamp of when the event occurred in ISO 8601 UTC format."
+          },
+          "data": {
+            "$ref": "#/components/schemas/DataProductCreatedEvent",
+            "description": "The specific data payload corresponding to this event type."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "time",
+          "data"
+        ],
+        "title": "CloudEvent_DataProductCreatedEvent"
+      },
+      "CloudEvent_DataProductDeletedEvent": {
+        "properties": {
+          "specversion": {
+            "type": "string",
+            "title": "Specversion",
+            "description": "The CloudEvents specification version.",
+            "default": "1.0"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "A unique UUID identifier for this specific event instance."
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "description": "Identifies the context in which an event happened.",
+            "default": "data-product-portal"
+          },
+          "type": {
+            "type": "string",
+            "const": "data_product.deleted",
+            "title": "Type",
+            "description": "The unique type string belonging to this event.",
+            "default": "data_product.deleted"
+          },
+          "time": {
+            "type": "string",
+            "title": "Time",
+            "description": "Timestamp of when the event occurred in ISO 8601 UTC format."
+          },
+          "data": {
+            "$ref": "#/components/schemas/DataProductDeletedEvent",
+            "description": "The specific data payload corresponding to this event type."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "time",
+          "data"
+        ],
+        "title": "CloudEvent_DataProductDeletedEvent"
+      },
+      "CloudEvent_DataProductUpdatedEvent": {
+        "properties": {
+          "specversion": {
+            "type": "string",
+            "title": "Specversion",
+            "description": "The CloudEvents specification version.",
+            "default": "1.0"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "A unique UUID identifier for this specific event instance."
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "description": "Identifies the context in which an event happened.",
+            "default": "data-product-portal"
+          },
+          "type": {
+            "type": "string",
+            "const": "data_product.updated",
+            "title": "Type",
+            "description": "The unique type string belonging to this event.",
+            "default": "data_product.updated"
+          },
+          "time": {
+            "type": "string",
+            "title": "Time",
+            "description": "Timestamp of when the event occurred in ISO 8601 UTC format."
+          },
+          "data": {
+            "$ref": "#/components/schemas/DataProductUpdatedEvent",
+            "description": "The specific data payload corresponding to this event type."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "time",
+          "data"
+        ],
+        "title": "CloudEvent_DataProductUpdatedEvent"
       },
       "CloudEvent_ExplorationCreatedEvent": {
         "properties": {
@@ -8714,6 +8858,34 @@
         ],
         "title": "DataProductCreate"
       },
+      "DataProductCreatedEvent": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "DataProductCreatedEvent"
+      },
+      "DataProductDeletedEvent": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "DataProductDeletedEvent"
+      },
       "DataProductIconKey": {
         "type": "string",
         "enum": [
@@ -9617,6 +9789,20 @@
           "lifecycle_id"
         ],
         "title": "DataProductUpdate"
+      },
+      "DataProductUpdatedEvent": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "DataProductUpdatedEvent"
       },
       "DataProductUsageUpdate": {
         "properties": {

--- a/sdk/example/provisioner.py
+++ b/sdk/example/provisioner.py
@@ -1,11 +1,12 @@
 """A worked example provisioner built on the SDK reconcile loop.
 
-This shows how to turn exploration webhook events into an operator-style control
-loop. The :class:`ExplorationProvisioner` is a level-based reconciler: on every event
-it (re-)fetches the current state of the exploration from the portal and converges an
-external resource towards it. Here the "external resource" is a directory on disk
-containing a small manifest, which stands in for whatever real infrastructure a
-provisioner would manage (an S3 prefix, a database schema, a Terraform workspace, ...).
+This shows how to turn portal webhook events into an operator-style control loop.
+The :class:`ExplorationProvisioner` is an implementation of such a reconciler.
+On every event it (re-)fetches the current state of the
+resource from the portal and converge an external resource towards it. Here the
+"external resource" is a directory on disk containing a small manifest, which stands
+in for whatever real infrastructure a provisioner would manage (an S3 prefix, a
+database schema, a Terraform workspace, ...).
 
 Run it with::
 
@@ -40,6 +41,7 @@ from sdk import (
     ReconcileEventHandler,
     ReconcileManager,
     Reconciler,
+    ResourceType,
 )
 from sdk.api_client.api.explorations import get_exploration, get_explorations
 from sdk.api_client.models import (
@@ -143,8 +145,10 @@ class ExplorationProvisioner(Reconciler):
 async def lifespan(app: FastAPI):
     client = _build_client()
     manager = ReconcileManager(
-        ExplorationProvisioner(client),
-        default_delay=30.0,  # debounce: wait 30s before picking an exploration up
+        {
+            ResourceType.EXPLORATION: ExplorationProvisioner(client),
+        },
+        default_delay=30.0,  # debounce: wait 30s before picking a resource up
         num_workers=4,
     )
     manager.start()
@@ -162,7 +166,6 @@ app = FastAPI(lifespan=lifespan)
 
 @app.post("/webhook")
 async def webhook(request: Request) -> dict[str, Any]:
-    """Receive portal CloudEvents and enqueue a reconcile for the exploration."""
     return await request.app.state.handler.dispatch_routing(request)
 
 

--- a/sdk/example/tests/test_provisioner.py
+++ b/sdk/example/tests/test_provisioner.py
@@ -6,12 +6,10 @@ import pytest
 
 from example import provisioner as prov_module
 from example.provisioner import ExplorationProvisioner
-from sdk import Client, ReconcileManager
+from sdk import Client
 from sdk.api_client.models import (
     Domain,
-    Exploration,
     GetExplorationResponse,
-    GetExplorationsResponse,
     User,
 )
 from sdk.api_client.models.abstract_data_product_status import AbstractDataProductStatus
@@ -147,28 +145,3 @@ async def test_reconcile_deprovision_when_already_absent(
 
     assert result is None
     assert not (tmp_path / str(eid)).exists()
-
-
-async def test_reconcile_runs_via_manager(
-    tmp_path: Path, fake_client, patch_get_exploration
-):
-    eid = uuid.uuid4()
-    patch_get_exploration(eid, _fake_exploration(eid))
-    provisioner = ExplorationProvisioner(client=fake_client, workspace=tmp_path)
-    manager = ReconcileManager(provisioner, default_delay=0.0, num_workers=2)
-    manager.start()
-
-    # Multiple events for the same exploration should coalesce into a single manifest.
-    await manager.enqueue(eid)
-    await manager.enqueue(eid)
-
-    manifest = tmp_path / str(eid) / "manifest.json"
-    import asyncio
-
-    for _ in range(200):
-        if manifest.exists():
-            break
-        await asyncio.sleep(0.01)
-    await manager.stop()
-
-    assert manifest.exists()

--- a/sdk/sdk/__init__.py
+++ b/sdk/sdk/__init__.py
@@ -6,6 +6,7 @@ from sdk.provisioner.reconcile_manager import (
     ReconcileEventHandler,
     ReconcileManager,
     Reconciler,
+    ResourceType,
 )
 
 __all__ = [
@@ -15,4 +16,5 @@ __all__ = [
     "Reconciler",
     "ReconcileEventHandler",
     "ReconcileManager",
+    "ResourceType",
 ]

--- a/sdk/sdk/api_client/models/__init__.py
+++ b/sdk/sdk/api_client/models/__init__.py
@@ -27,6 +27,9 @@ from .azure_environment_platform_configuration import (
 from .become_admin import BecomeAdmin
 from .bitol_contract_request import BitolContractRequest
 from .can_become_admin_update import CanBecomeAdminUpdate
+from .cloud_event_data_product_created_event import CloudEventDataProductCreatedEvent
+from .cloud_event_data_product_deleted_event import CloudEventDataProductDeletedEvent
+from .cloud_event_data_product_updated_event import CloudEventDataProductUpdatedEvent
 from .cloud_event_exploration_created_event import CloudEventExplorationCreatedEvent
 from .cloud_event_exploration_deleted_event import CloudEventExplorationDeletedEvent
 from .cloud_event_exploration_updated_event import CloudEventExplorationUpdatedEvent
@@ -56,6 +59,8 @@ from .data_output_update import DataOutputUpdate
 from .data_product import DataProduct
 from .data_product_about_update import DataProductAboutUpdate
 from .data_product_create import DataProductCreate
+from .data_product_created_event import DataProductCreatedEvent
+from .data_product_deleted_event import DataProductDeletedEvent
 from .data_product_icon_key import DataProductIconKey
 from .data_product_life_cycle import DataProductLifeCycle
 from .data_product_life_cycle_create import DataProductLifeCycleCreate
@@ -83,6 +88,7 @@ from .data_product_type_update import DataProductTypeUpdate
 from .data_product_types_get import DataProductTypesGet
 from .data_product_types_get_item import DataProductTypesGetItem
 from .data_product_update import DataProductUpdate
+from .data_product_updated_event import DataProductUpdatedEvent
 from .data_product_usage_update import DataProductUsageUpdate
 from .data_quality_status import DataQualityStatus
 from .data_quality_technical_asset import DataQualityTechnicalAsset
@@ -339,6 +345,9 @@ __all__ = (
     "BecomeAdmin",
     "BitolContractRequest",
     "CanBecomeAdminUpdate",
+    "CloudEventDataProductCreatedEvent",
+    "CloudEventDataProductDeletedEvent",
+    "CloudEventDataProductUpdatedEvent",
     "CloudEventExplorationCreatedEvent",
     "CloudEventExplorationDeletedEvent",
     "CloudEventExplorationUpdatedEvent",
@@ -370,6 +379,8 @@ __all__ = (
     "DataProduct",
     "DataProductAboutUpdate",
     "DataProductCreate",
+    "DataProductCreatedEvent",
+    "DataProductDeletedEvent",
     "DataProductIconKey",
     "DataProductLifeCycle",
     "DataProductLifeCycleCreate",
@@ -395,6 +406,7 @@ __all__ = (
     "DataProductTypesGetItem",
     "DataProductTypeUpdate",
     "DataProductUpdate",
+    "DataProductUpdatedEvent",
     "DataProductUsageUpdate",
     "DataQualityStatus",
     "DataQualityTechnicalAsset",

--- a/sdk/sdk/api_client/models/cloud_event_data_product_created_event.py
+++ b/sdk/sdk/api_client/models/cloud_event_data_product_created_event.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.data_product_created_event import DataProductCreatedEvent
+
+
+T = TypeVar("T", bound="CloudEventDataProductCreatedEvent")
+
+
+@_attrs_define
+class CloudEventDataProductCreatedEvent:
+    """
+    Attributes:
+        id (str): A unique UUID identifier for this specific event instance.
+        time (str): Timestamp of when the event occurred in ISO 8601 UTC format.
+        data (DataProductCreatedEvent):
+        specversion (str | Unset): The CloudEvents specification version. Default: '1.0'.
+        source (str | Unset): Identifies the context in which an event happened. Default: 'data-product-portal'.
+        type_ (Literal['data_product.created'] | Unset): The unique type string belonging to this event. Default:
+            'data_product.created'.
+    """
+
+    id: str
+    time: str
+    data: DataProductCreatedEvent
+    specversion: str | Unset = "1.0"
+    source: str | Unset = "data-product-portal"
+    type_: Literal["data_product.created"] | Unset = "data_product.created"
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        time = self.time
+
+        data = self.data.to_dict()
+
+        specversion = self.specversion
+
+        source = self.source
+
+        type_ = self.type_
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "time": time,
+                "data": data,
+            }
+        )
+        if specversion is not UNSET:
+            field_dict["specversion"] = specversion
+        if source is not UNSET:
+            field_dict["source"] = source
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.data_product_created_event import DataProductCreatedEvent
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        time = d.pop("time")
+
+        data = DataProductCreatedEvent.from_dict(d.pop("data"))
+
+        specversion = d.pop("specversion", UNSET)
+
+        source = d.pop("source", UNSET)
+
+        type_ = cast(Literal["data_product.created"] | Unset, d.pop("type", UNSET))
+        if type_ != "data_product.created" and not isinstance(type_, Unset):
+            raise ValueError(
+                f"type must match const 'data_product.created', got '{type_}'"
+            )
+
+        cloud_event_data_product_created_event = cls(
+            id=id,
+            time=time,
+            data=data,
+            specversion=specversion,
+            source=source,
+            type_=type_,
+        )
+
+        cloud_event_data_product_created_event.additional_properties = d
+        return cloud_event_data_product_created_event
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/sdk/api_client/models/cloud_event_data_product_deleted_event.py
+++ b/sdk/sdk/api_client/models/cloud_event_data_product_deleted_event.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.data_product_deleted_event import DataProductDeletedEvent
+
+
+T = TypeVar("T", bound="CloudEventDataProductDeletedEvent")
+
+
+@_attrs_define
+class CloudEventDataProductDeletedEvent:
+    """
+    Attributes:
+        id (str): A unique UUID identifier for this specific event instance.
+        time (str): Timestamp of when the event occurred in ISO 8601 UTC format.
+        data (DataProductDeletedEvent):
+        specversion (str | Unset): The CloudEvents specification version. Default: '1.0'.
+        source (str | Unset): Identifies the context in which an event happened. Default: 'data-product-portal'.
+        type_ (Literal['data_product.deleted'] | Unset): The unique type string belonging to this event. Default:
+            'data_product.deleted'.
+    """
+
+    id: str
+    time: str
+    data: DataProductDeletedEvent
+    specversion: str | Unset = "1.0"
+    source: str | Unset = "data-product-portal"
+    type_: Literal["data_product.deleted"] | Unset = "data_product.deleted"
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        time = self.time
+
+        data = self.data.to_dict()
+
+        specversion = self.specversion
+
+        source = self.source
+
+        type_ = self.type_
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "time": time,
+                "data": data,
+            }
+        )
+        if specversion is not UNSET:
+            field_dict["specversion"] = specversion
+        if source is not UNSET:
+            field_dict["source"] = source
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.data_product_deleted_event import DataProductDeletedEvent
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        time = d.pop("time")
+
+        data = DataProductDeletedEvent.from_dict(d.pop("data"))
+
+        specversion = d.pop("specversion", UNSET)
+
+        source = d.pop("source", UNSET)
+
+        type_ = cast(Literal["data_product.deleted"] | Unset, d.pop("type", UNSET))
+        if type_ != "data_product.deleted" and not isinstance(type_, Unset):
+            raise ValueError(
+                f"type must match const 'data_product.deleted', got '{type_}'"
+            )
+
+        cloud_event_data_product_deleted_event = cls(
+            id=id,
+            time=time,
+            data=data,
+            specversion=specversion,
+            source=source,
+            type_=type_,
+        )
+
+        cloud_event_data_product_deleted_event.additional_properties = d
+        return cloud_event_data_product_deleted_event
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/sdk/api_client/models/cloud_event_data_product_updated_event.py
+++ b/sdk/sdk/api_client/models/cloud_event_data_product_updated_event.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.data_product_updated_event import DataProductUpdatedEvent
+
+
+T = TypeVar("T", bound="CloudEventDataProductUpdatedEvent")
+
+
+@_attrs_define
+class CloudEventDataProductUpdatedEvent:
+    """
+    Attributes:
+        id (str): A unique UUID identifier for this specific event instance.
+        time (str): Timestamp of when the event occurred in ISO 8601 UTC format.
+        data (DataProductUpdatedEvent):
+        specversion (str | Unset): The CloudEvents specification version. Default: '1.0'.
+        source (str | Unset): Identifies the context in which an event happened. Default: 'data-product-portal'.
+        type_ (Literal['data_product.updated'] | Unset): The unique type string belonging to this event. Default:
+            'data_product.updated'.
+    """
+
+    id: str
+    time: str
+    data: DataProductUpdatedEvent
+    specversion: str | Unset = "1.0"
+    source: str | Unset = "data-product-portal"
+    type_: Literal["data_product.updated"] | Unset = "data_product.updated"
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        time = self.time
+
+        data = self.data.to_dict()
+
+        specversion = self.specversion
+
+        source = self.source
+
+        type_ = self.type_
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "time": time,
+                "data": data,
+            }
+        )
+        if specversion is not UNSET:
+            field_dict["specversion"] = specversion
+        if source is not UNSET:
+            field_dict["source"] = source
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.data_product_updated_event import DataProductUpdatedEvent
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        time = d.pop("time")
+
+        data = DataProductUpdatedEvent.from_dict(d.pop("data"))
+
+        specversion = d.pop("specversion", UNSET)
+
+        source = d.pop("source", UNSET)
+
+        type_ = cast(Literal["data_product.updated"] | Unset, d.pop("type", UNSET))
+        if type_ != "data_product.updated" and not isinstance(type_, Unset):
+            raise ValueError(
+                f"type must match const 'data_product.updated', got '{type_}'"
+            )
+
+        cloud_event_data_product_updated_event = cls(
+            id=id,
+            time=time,
+            data=data,
+            specversion=specversion,
+            source=source,
+            type_=type_,
+        )
+
+        cloud_event_data_product_updated_event.additional_properties = d
+        return cloud_event_data_product_updated_event
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/sdk/api_client/models/data_product_created_event.py
+++ b/sdk/sdk/api_client/models/data_product_created_event.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="DataProductCreatedEvent")
+
+
+@_attrs_define
+class DataProductCreatedEvent:
+    """
+    Attributes:
+        id (UUID):
+    """
+
+    id: UUID
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        data_product_created_event = cls(
+            id=id,
+        )
+
+        data_product_created_event.additional_properties = d
+        return data_product_created_event
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/sdk/api_client/models/data_product_deleted_event.py
+++ b/sdk/sdk/api_client/models/data_product_deleted_event.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="DataProductDeletedEvent")
+
+
+@_attrs_define
+class DataProductDeletedEvent:
+    """
+    Attributes:
+        id (UUID):
+    """
+
+    id: UUID
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        data_product_deleted_event = cls(
+            id=id,
+        )
+
+        data_product_deleted_event.additional_properties = d
+        return data_product_deleted_event
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/sdk/api_client/models/data_product_updated_event.py
+++ b/sdk/sdk/api_client/models/data_product_updated_event.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="DataProductUpdatedEvent")
+
+
+@_attrs_define
+class DataProductUpdatedEvent:
+    """
+    Attributes:
+        id (UUID):
+    """
+
+    id: UUID
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        data_product_updated_event = cls(
+            id=id,
+        )
+
+        data_product_updated_event.additional_properties = d
+        return data_product_updated_event
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/sdk/sdk/provisioner/event_handler.py
+++ b/sdk/sdk/provisioner/event_handler.py
@@ -5,12 +5,18 @@ from typing import Any
 from fastapi import HTTPException, Request
 
 from sdk.api_client.models import (
+    CloudEventDataProductCreatedEvent,
+    CloudEventDataProductDeletedEvent,
+    CloudEventDataProductUpdatedEvent,
     CloudEventExplorationCreatedEvent,
     CloudEventExplorationDeletedEvent,
     CloudEventExplorationUpdatedEvent,
     CloudEventInputPortCreatedEvent,
     CloudEventInputPortDeletedEvent,
     CloudEventInputPortUpdatedEvent,
+    DataProductCreatedEvent,
+    DataProductDeletedEvent,
+    DataProductUpdatedEvent,
     ExplorationCreatedEvent,
     ExplorationDeletedEvent,
     ExplorationUpdatedEvent,
@@ -49,6 +55,12 @@ class AbstractEventHandler(ABC):
         elif event_type == "exploration.deleted":
             parsed_event = CloudEventExplorationDeletedEvent.from_dict(payload)
             return await self.on_exploration_deleted(parsed_event.data)
+        elif event_type == "data_product.deleted":
+            parsed_event = CloudEventDataProductDeletedEvent.from_dict(payload)
+            return await self.on_data_product_deleted(parsed_event.data)
+        elif event_type == "data_product.created":
+            parsed_event = CloudEventDataProductCreatedEvent.from_dict(payload)
+            return await self.on_data_product_created(parsed_event.data)
         elif event_type == "input_port.deleted":
             parsed_event = CloudEventInputPortDeletedEvent.from_dict(payload)
             return await self.on_input_port_deleted(parsed_event.data)
@@ -58,6 +70,9 @@ class AbstractEventHandler(ABC):
         elif event_type == "exploration.updated":
             parsed_event = CloudEventExplorationUpdatedEvent.from_dict(payload)
             return await self.on_exploration_updated(parsed_event.data)
+        elif event_type == "data_product.updated":
+            parsed_event = CloudEventDataProductUpdatedEvent.from_dict(payload)
+            return await self.on_data_product_updated(parsed_event.data)
         else:
             # Standard practice is to accept unhandled hooks with a 202/success to avoid webhook retries
             return {
@@ -81,6 +96,16 @@ class AbstractEventHandler(ABC):
         pass
 
     @abstractmethod
+    async def on_data_product_deleted(self, data: DataProductDeletedEvent) -> Any:
+        """Handler for the parsed payload of 'data_product.deleted'"""
+        pass
+
+    @abstractmethod
+    async def on_data_product_created(self, data: DataProductCreatedEvent) -> Any:
+        """Handler for the parsed payload of 'data_product.created'"""
+        pass
+
+    @abstractmethod
     async def on_input_port_deleted(self, data: InputPortDeletedEvent) -> Any:
         """Handler for the parsed payload of 'input_port.deleted'"""
         pass
@@ -93,6 +118,11 @@ class AbstractEventHandler(ABC):
     @abstractmethod
     async def on_exploration_updated(self, data: ExplorationUpdatedEvent) -> Any:
         """Handler for the parsed payload of 'exploration.updated'"""
+        pass
+
+    @abstractmethod
+    async def on_data_product_updated(self, data: DataProductUpdatedEvent) -> Any:
+        """Handler for the parsed payload of 'data_product.updated'"""
         pass
 
 
@@ -111,6 +141,12 @@ class EmptyEventHandler(AbstractEventHandler):
     async def on_exploration_deleted(self, data: ExplorationDeletedEvent) -> Any:
         pass
 
+    async def on_data_product_deleted(self, data: DataProductDeletedEvent) -> Any:
+        pass
+
+    async def on_data_product_created(self, data: DataProductCreatedEvent) -> Any:
+        pass
+
     async def on_input_port_deleted(self, data: InputPortDeletedEvent) -> Any:
         pass
 
@@ -118,4 +154,7 @@ class EmptyEventHandler(AbstractEventHandler):
         pass
 
     async def on_exploration_updated(self, data: ExplorationUpdatedEvent) -> Any:
+        pass
+
+    async def on_data_product_updated(self, data: DataProductUpdatedEvent) -> Any:
         pass

--- a/sdk/sdk/provisioner/reconcile_manager.py
+++ b/sdk/sdk/provisioner/reconcile_manager.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import asyncio
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
-from typing import Any
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from enum import Enum
 from uuid import UUID
 
 from sdk.api_client.models import (
     AbstractDataProductType,
+    DataProductCreatedEvent,
+    DataProductDeletedEvent,
+    DataProductUpdatedEvent,
     ExplorationCreatedEvent,
     ExplorationDeletedEvent,
     ExplorationUpdatedEvent,
@@ -28,17 +32,32 @@ logger = logging.getLogger(__name__)
 INITIAL_SYNC_MAX_BACKOFF: float = 60.0
 
 
-class Reconciler(ABC):
-    """Level-based reconciler.
+class ResourceType(str, Enum):
+    """The kinds of portal objects a reconciler can be registered for."""
 
-    Implementations receive only the exploration id and are expected to re-fetch
-    the current state of the exploration themselves, making reconciliation
-    idempotent and resilient to coalesced events.
+    EXPLORATION = "exploration"
+    DATA_PRODUCT = "data_product"
+
+
+@dataclass(frozen=True)
+class ReconcileKey:
+    """A queue key identifying one instance of a resource to reconcile."""
+
+    resource_type: ResourceType
+    id: UUID
+
+
+class Reconciler(ABC):
+    """Level-based reconciler for a single resource type.
+
+    Implementations receive only the resource id and are expected to re-fetch the
+    current state of the resource themselves, making reconciliation idempotent and
+    resilient to coalesced events.
     """
 
     @abstractmethod
-    async def reconcile(self, exploration_id: UUID):
-        """Reconcile the exploration identified by ``exploration_id``.
+    async def reconcile(self, resource_id: UUID):
+        """Reconcile the resource identified by ``resource_id``.
 
         Return ``None`` on success. When an exception is raised, we will retry.
         """
@@ -57,24 +76,28 @@ class Reconciler(ABC):
 
 
 class ReconcileManager:
-    """Drives a :class:`Reconciler` from a :class:`DelayingDeduplicatingQueue`.
+    """Drives one or more :class:`Reconciler` from a shared work queue.
 
-    Runs a pool of worker tasks that each loop ``get -> reconcile -> done``. A given
-    exploration id is never reconciled by two workers concurrently (guaranteed by the
-    queue's in-flight tracking). Failures and explicit requeues are retried with
-    exponential backoff.
+    Reconcilers are registered per :class:`ResourceType`. Runs a pool of worker tasks
+    that each loop ``get -> dispatch -> done``; every queued key carries its resource
+    type, so the manager hands it to the matching reconciler. A given key is never
+    reconciled by two workers concurrently (guaranteed by the queue's in-flight
+    tracking). Failures and explicit requeues are retried with exponential backoff.
     """
 
     def __init__(
         self,
-        reconciler: Reconciler,
+        reconcilers: Mapping[ResourceType, Reconciler] | None = None,
         *,
         default_delay: float = DEFAULT_DELAY,
         num_workers: int = 1,
-        rate_limiter: RateLimiter | None = None,
+        rate_limiter: RateLimiter[ReconcileKey] | None = None,
     ) -> None:
-        self._reconciler = reconciler
-        self._queue = DelayingDeduplicatingQueue(default_delay=default_delay)
+        self._reconcilers: dict[ResourceType, Reconciler] = dict(reconcilers or {})
+        self._queue: DelayingDeduplicatingQueue[ReconcileKey] = (
+            DelayingDeduplicatingQueue[ReconcileKey](default_delay=default_delay)
+        )
+
         self._rate_limiter = rate_limiter if rate_limiter else RateLimiter()
         self._workers: list[asyncio.Task[None]] = []
         self._initial_sync_task: asyncio.Task[None] | None = None
@@ -83,11 +106,15 @@ class ReconcileManager:
         self._num_workers = num_workers
 
     @property
-    def queue(self) -> DelayingDeduplicatingQueue:
+    def queue(self) -> DelayingDeduplicatingQueue[ReconcileKey]:
         return self._queue
 
-    async def enqueue(self, exploration_id: UUID) -> None:
-        await self._queue.add(exploration_id)
+    def has_reconciler(self, resource_type: ResourceType) -> bool:
+        """Return whether a reconciler is registered for ``resource_type``."""
+        return resource_type in self._reconcilers
+
+    async def enqueue(self, resource_type: ResourceType, resource_id: UUID) -> None:
+        await self._queue.add(ReconcileKey(resource_type, resource_id))
 
     def start(self) -> None:
         """This methods starts the reconciler and makes it active"""
@@ -114,18 +141,25 @@ class ReconcileManager:
     async def _initial_sync(self) -> None:
         """Enqueue a reconcile for every existing resource when the manager starts.
 
-        Retries listing with exponential backoff, giving up after
-        ``initial_sync_max_attempts`` consecutive failures so a permanently broken
-        listing (e.g. misconfigured auth) doesn't retry forever.
+        Each registered reconciler is listed in turn; listing is retried with
+        exponential backoff so a transiently broken listing (e.g. the portal being
+        briefly unavailable) doesn't drop the startup resync.
         """
+        for resource_type, reconciler in self._reconcilers.items():
+            await self._initial_sync_one(resource_type, reconciler)
+
+    async def _initial_sync_one(
+        self, resource_type: ResourceType, reconciler: Reconciler
+    ) -> None:
         attempt = 0
         while True:
             try:
-                ids = await self._reconciler.list_ids()
+                ids = await reconciler.list_ids()
             except Exception:
                 delay = min(2.0 ** (attempt - 1), INITIAL_SYNC_MAX_BACKOFF)
                 logger.exception(
-                    "Initial sync listing failed (attempt %d), retrying in %.1fs",
+                    "Initial sync listing for %s failed (attempt %d), retrying in %.1fs",
+                    resource_type.value,
                     attempt,
                     delay,
                 )
@@ -135,9 +169,11 @@ class ReconcileManager:
 
             count = 0
             for resource_id in ids:
-                await self._queue.add(resource_id, delay=0)
+                await self._queue.add(ReconcileKey(resource_type, resource_id), delay=0)
                 count += 1
-            logger.info("Initial sync enqueued %d resource(s)", count)
+            logger.info(
+                "Initial sync enqueued %d %s resource(s)", count, resource_type.value
+            )
             return
 
     async def _worker_loop(self) -> None:
@@ -150,28 +186,35 @@ class ReconcileManager:
             finally:
                 await self._queue.done(key)
 
-    async def _process(self, key: UUID) -> None:
+    async def _process(self, key: ReconcileKey) -> None:
+        reconciler = self._reconcilers.get(key.resource_type)
+        if reconciler is None:
+            return
         try:
-            await self._reconciler.reconcile(key)
+            await reconciler.reconcile(key.id)
         except Exception:
-            logger.exception("Reconcile failed for exploration %s", key)
+            logger.exception(
+                "Reconcile failed for %s %s", key.resource_type.value, key.id
+            )
             await self._requeue_with_backoff(key)
             return
 
         self._rate_limiter.forget(key)
 
-    async def _requeue_with_backoff(self, key: UUID) -> None:
+    async def _requeue_with_backoff(self, key: ReconcileKey) -> None:
         delay = self._rate_limiter.when(key)
         await self._queue.add_after(key, delay)
 
 
 class ReconcileEventHandler(AbstractEventHandler):
-    """Webhook handler that enqueues a reconcile for each exploration event.
+    """Webhook handler that enqueues a reconcile for each supported portal event.
 
-    Subclasses the generated :class:`~sdk.event_handler.AbstractEventHandler` and wires
-    every ``exploration.created`` / ``exploration.updated`` / ``exploration.deleted``
-    event to a :class:`ReconcileManager`, returning a fast "queued" acknowledgement so
-    the webhook responds immediately while reconciliation happens asynchronously.
+    Subclasses the generated :class:`~sdk.event_handler.AbstractEventHandler` and
+    wires every ``created`` / ``updated`` / ``deleted`` event to a
+    :class:`ReconcileManager`, routing each event to its :class:`ResourceType`. It
+    returns a fast "queued" acknowledgement so the webhook responds immediately while
+    reconciliation happens asynchronously. Events for a resource type without a
+    registered reconciler are acknowledged as "ignored".
     """
 
     def __init__(self, manager: ReconcileManager) -> None:
@@ -181,41 +224,63 @@ class ReconcileEventHandler(AbstractEventHandler):
     def manager(self) -> ReconcileManager:
         return self._manager
 
-    async def _enqueue(self, exploration_id: UUID) -> dict[str, Any]:
-        await self._manager.enqueue(exploration_id)
-        return {"status": "queued", "exploration_id": str(exploration_id)}
+    async def _enqueue(self, resource_type: ResourceType, resource_id: UUID):
+        if not self._manager.has_reconciler(resource_type):
+            logger.debug(f"No reconciler registered for '{resource_type.value}'")
+            return
+        await self._manager.enqueue(resource_type, resource_id)
 
-    async def on_exploration_created(
-        self, data: ExplorationCreatedEvent
-    ) -> dict[str, Any]:
-        return await self._enqueue(data.id)
+    async def on_exploration_created(self, data: ExplorationCreatedEvent):
+        await self._enqueue(ResourceType.EXPLORATION, data.id)
 
-    async def on_exploration_updated(self, data: ExplorationUpdatedEvent) -> Any:
-        return await self._enqueue(data.id)
+    async def on_exploration_updated(self, data: ExplorationUpdatedEvent):
+        await self._enqueue(ResourceType.EXPLORATION, data.id)
 
-    async def on_exploration_deleted(self, data: ExplorationDeletedEvent) -> Any:
-        return await self._enqueue(data.id)
+    async def on_exploration_deleted(self, data: ExplorationDeletedEvent):
+        return await self._enqueue(ResourceType.EXPLORATION, data.id)
 
-    async def on_input_port_updated(self, data: InputPortUpdatedEvent) -> Any:
-        if (
-            data.consuming_abstract_data_product_type
-            == AbstractDataProductType.EXPLORATIONS
-        ):
-            return await self._enqueue(data.consuming_abstract_data_product_id)
+    async def on_data_product_created(self, data: DataProductCreatedEvent):
+        await self._enqueue(ResourceType.DATA_PRODUCT, data.id)
+
+    async def on_data_product_updated(self, data: DataProductUpdatedEvent):
+        await self._enqueue(ResourceType.DATA_PRODUCT, data.id)
+
+    async def on_data_product_deleted(self, data: DataProductDeletedEvent):
+        await self._enqueue(ResourceType.DATA_PRODUCT, data.id)
+
+    async def on_input_port_updated(self, data: InputPortUpdatedEvent):
+        match data.consuming_abstract_data_product_type:
+            case AbstractDataProductType.EXPLORATIONS:
+                return await self._enqueue(
+                    ResourceType.EXPLORATION, data.consuming_abstract_data_product_id
+                )
+            case AbstractDataProductType.DATA_PRODUCTS:
+                return await self._enqueue(
+                    ResourceType.DATA_PRODUCT, data.consuming_abstract_data_product_id
+                )
         return None
 
-    async def on_input_port_created(self, data: InputPortCreatedEvent) -> Any:
-        if (
-            data.consuming_abstract_data_product_type
-            == AbstractDataProductType.EXPLORATIONS
-        ):
-            return await self._enqueue(data.consuming_abstract_data_product_id)
+    async def on_input_port_created(self, data: InputPortCreatedEvent):
+        match data.consuming_abstract_data_product_type:
+            case AbstractDataProductType.EXPLORATIONS:
+                return await self._enqueue(
+                    ResourceType.EXPLORATION, data.consuming_abstract_data_product_id
+                )
+            case AbstractDataProductType.DATA_PRODUCTS:
+                return await self._enqueue(
+                    ResourceType.DATA_PRODUCT, data.consuming_abstract_data_product_id
+                )
         return None
 
-    async def on_input_port_deleted(self, data: InputPortDeletedEvent) -> Any:
-        if (
-            data.consuming_abstract_data_product_type
-            == AbstractDataProductType.EXPLORATIONS
-        ):
-            return await self._enqueue(data.consuming_abstract_data_product_id)
+    async def on_input_port_deleted(self, data: InputPortDeletedEvent):
+        match data.consuming_abstract_data_product_type:
+            case AbstractDataProductType.EXPLORATIONS:
+                return await self._enqueue(
+                    ResourceType.EXPLORATION, data.consuming_abstract_data_product_id
+                )
+            case AbstractDataProductType.DATA_PRODUCTS:
+                return await self._enqueue(
+                    ResourceType.DATA_PRODUCT, data.consuming_abstract_data_product_id
+                )
+
         return None

--- a/sdk/sdk/provisioner/reconcile_queue.py
+++ b/sdk/sdk/provisioner/reconcile_queue.py
@@ -1,39 +1,20 @@
-"""Kubernetes-operator-style reconcile primitives for exploration events.
-
-This module provides a small, dependency-free (pure asyncio) toolkit for building
-operator-like reconcile loops on top of the generated webhook event handler:
-
-- :class:`DelayingDeduplicatingQueue` -- a work queue keyed by exploration id that
-  coalesces duplicate enqueues, applies a debounce delay before a key becomes
-  eligible for processing, and guarantees a key is only handed to one worker at a
-  time. A key re-enqueued while it is being processed is reconciled exactly once
-  more afterwards (no lost events).
-- :class:`RateLimiter` -- exponential backoff used to requeue keys after a failed
-  or explicitly retried reconcile.
-- :class:`Reconciler` -- abstract, level-based reconciler: it receives only the
-  exploration id and is expected to re-fetch current state itself.
-- :class:`ReconcileManager` -- runs a pool of workers that pull keys off the queue
-  and invoke the reconciler, requeuing with backoff on failure.
-- :class:`ReconcileEventHandler` -- a ready-to-use subclass of the generated
-  ``AbstractEventHandler`` that enqueues the exploration id on every created,
-  updated or deleted webhook.
-"""
-
 from __future__ import annotations
 
 import asyncio
 import logging
 import time
-from dataclasses import dataclass, field
-from uuid import UUID
+from collections.abc import Hashable
+from typing import Generic, TypeVar
 
 logger = logging.getLogger(__name__)
 
 # Default debounce applied before an enqueued key becomes eligible for processing.
 DEFAULT_DELAY: float = 15.0
 
+KeyT = TypeVar("KeyT", bound=Hashable)
 
-class RateLimiter:
+
+class RateLimiter(Generic[KeyT]):
     """Per-key exponential backoff helper.
 
     Each failed attempt for a key increases the delay returned by :meth:`when`,
@@ -56,32 +37,32 @@ class RateLimiter:
             raise ValueError("max_delay must be >= 10")
         self._max_delay = max_delay
         self._factor = factor
-        self._failures: dict[UUID, int] = {}
+        self._failures: dict[KeyT, int] = {}
 
-    def when(self, key: UUID) -> float:
+    def when(self, key: KeyT) -> float:
         """Record a failure for ``key`` and return the delay before the next retry."""
         failures = self._failures.get(key, 0)
         self._failures[key] = failures + 1
         delay = self._base_delay * (self._factor**failures)
         return min(delay, self._max_delay)
 
-    def failures(self, key: UUID) -> int:
+    def failures(self, key: KeyT) -> int:
         """Return how many consecutive failures have been recorded for ``key``."""
         return self._failures.get(key, 0)
 
-    def forget(self, key: UUID) -> None:
+    def forget(self, key: KeyT) -> None:
         """Reset the backoff state for ``key`` (call on success)."""
         self._failures.pop(key, None)
 
 
-class DelayingDeduplicatingQueue:
-    """An asyncio work queue keyed by :class:`~uuid.UUID`.
+class DelayingDeduplicatingQueue(Generic[KeyT]):
+    """An asyncio work queue keyed by an arbitrary hashable key.
 
     Semantics mirror a Kubernetes ``client-go`` delaying + deduplicating workqueue:
 
     - **Deduplication / coalescing**: adding a key that is already waiting is a
       no-op beyond (optionally) shortening its ready time. Two events for the same
-      exploration therefore result in a single reconcile.
+      key therefore result in a single reconcile.
     - **Delay**: ``add`` schedules the key to become eligible after ``delay`` seconds.
     - **Single in-flight per key**: :meth:`get` marks a key as "processing"; it will
       not be returned again until :meth:`done` is called for it. If the key is added
@@ -92,11 +73,11 @@ class DelayingDeduplicatingQueue:
     def __init__(self, default_delay: float = DEFAULT_DELAY) -> None:
         self._default_delay = default_delay
         # key -> time at which the key becomes eligible for processing.
-        self._waiting: dict[UUID, float] = {}
+        self._waiting: dict[KeyT, float] = {}
         # keys currently handed out to a worker (in flight).
-        self._processing: set[UUID] = set()
+        self._processing: set[KeyT] = set()
         # keys re-added while in flight; re-queued on done().
-        self._dirty: set[UUID] = set()
+        self._dirty: set[KeyT] = set()
         self._cond = asyncio.Condition()
         self._shutdown = False
 
@@ -104,7 +85,7 @@ class DelayingDeduplicatingQueue:
     def default_delay(self) -> float:
         return self._default_delay
 
-    async def add(self, key: UUID, delay: float | None = None) -> None:
+    async def add(self, key: KeyT, delay: float | None = None) -> None:
         """Enqueue ``key`` to be processed after ``delay`` seconds (debounced)."""
         if delay is None:
             delay = self._default_delay
@@ -122,11 +103,11 @@ class DelayingDeduplicatingQueue:
                 self._waiting[key] = ready_at
             self._cond.notify_all()
 
-    async def add_after(self, key: UUID, delay: float) -> None:
+    async def add_after(self, key: KeyT, delay: float) -> None:
         """Explicit delayed add; alias for :meth:`add` used by retry/backoff paths."""
         await self.add(key, delay)
 
-    async def get(self) -> UUID | None:
+    async def get(self) -> KeyT | None:
         """Block until a waiting key is eligible and return it (marked in flight).
 
         Returns ``None`` once the queue has been shut down and drained.
@@ -137,7 +118,7 @@ class DelayingDeduplicatingQueue:
                     return None
 
                 now = time.monotonic()
-                ready_key: UUID | None = None
+                ready_key: KeyT | None = None
                 next_ready: float | None = None
                 for candidate, ready_at in self._waiting.items():
                     if ready_at <= now:
@@ -165,7 +146,7 @@ class DelayingDeduplicatingQueue:
                 else:
                     await self._cond.wait()
 
-    async def done(self, key: UUID) -> None:
+    async def done(self, key: KeyT) -> None:
         """Mark an in-flight ``key`` as finished.
 
         If the key was re-added while in flight it is immediately re-queued.
@@ -185,5 +166,5 @@ class DelayingDeduplicatingQueue:
             self._cond.notify_all()
 
     def qsize(self) -> int:
-        """Number of keys currently waiting (not counting in-flight keys)."""
-        return len(self._waiting)
+        """Number of keys currently waiting or in flight."""
+        return len(self._waiting) + len(self._processing)

--- a/sdk/tests/provisioner/test_reconcile_manager.py
+++ b/sdk/tests/provisioner/test_reconcile_manager.py
@@ -11,9 +11,9 @@ from sdk.provisioner.reconcile_manager import (
     ReconcileEventHandler,
     ReconcileManager,
     Reconciler,
+    ResourceType,
 )
 from sdk.provisioner.reconcile_queue import (
-    DelayingDeduplicatingQueue,
     RateLimiter,
 )
 
@@ -39,23 +39,32 @@ class RecordingReconciler(Reconciler):
             raise RuntimeError("list boom")
         return list(self.ids_to_list)
 
-    async def reconcile(self, exploration_id: uuid.UUID):
+    async def reconcile(self, resource_id: uuid.UUID):
         async with self._lock:
-            self.calls.append(exploration_id)
-            if exploration_id in self.in_flight:
+            self.calls.append(resource_id)
+            if resource_id in self.in_flight:
                 self.max_concurrent_same_key = max(self.max_concurrent_same_key, 2)
-            self.in_flight.add(exploration_id)
+            self.in_flight.add(resource_id)
         try:
             if self.delay:
                 await asyncio.sleep(self.delay)
-            remaining = self.fail_times.get(exploration_id, 0)
+            remaining = self.fail_times.get(resource_id, 0)
             if remaining > 0:
-                self.fail_times[exploration_id] = remaining - 1
+                self.fail_times[resource_id] = remaining - 1
                 raise RuntimeError("boom")
             return None
         finally:
             async with self._lock:
-                self.in_flight.discard(exploration_id)
+                self.in_flight.discard(resource_id)
+
+
+def _manager(reconciler: Reconciler, **kwargs) -> ReconcileManager:
+    """Build a manager with ``reconciler`` registered for the exploration type."""
+    return ReconcileManager({ResourceType.EXPLORATION: reconciler}, **kwargs)
+
+
+async def _enqueue(manager: ReconcileManager, key: uuid.UUID) -> None:
+    await manager.enqueue(ResourceType.EXPLORATION, key)
 
 
 async def _drain(reconciler: RecordingReconciler, expected: int, timeout: float = 2.0):
@@ -69,13 +78,13 @@ async def _drain(reconciler: RecordingReconciler, expected: int, timeout: float 
 
 async def test_coalesces_duplicate_events():
     reconciler = RecordingReconciler()
-    manager = ReconcileManager(reconciler, num_workers=2, default_delay=0.1)
+    manager = _manager(reconciler, num_workers=2, default_delay=0.1)
     manager.start()
     key = uuid.uuid4()
 
-    await manager.enqueue(key)
-    await manager.enqueue(key)
-    await manager.enqueue(key)
+    await _enqueue(manager, key)
+    await _enqueue(manager, key)
+    await _enqueue(manager, key)
 
     await _drain(reconciler, expected=1)
     await asyncio.sleep(0.2)
@@ -86,11 +95,11 @@ async def test_coalesces_duplicate_events():
 
 async def test_debounce_delay_applies():
     reconciler = RecordingReconciler()
-    manager = ReconcileManager(reconciler, default_delay=0.3)
+    manager = _manager(reconciler, default_delay=0.3)
     manager.start()
     key = uuid.uuid4()
 
-    await manager.enqueue(key)
+    await _enqueue(manager, key)
     await asyncio.sleep(0.1)
     assert reconciler.calls == []  # not yet eligible
 
@@ -102,16 +111,16 @@ async def test_debounce_delay_applies():
 async def test_re_dirty_during_processing_reconciles_once_more():
     reconciler = RecordingReconciler()
     reconciler.delay = 0.2
-    manager = ReconcileManager(reconciler, default_delay=0.2)
+    manager = _manager(reconciler, default_delay=0.2)
     manager.start()
     key = uuid.uuid4()
 
-    await manager.enqueue(key)
+    await _enqueue(manager, key)
     # Wait until the reconcile is in flight, then enqueue again twice.
     while key not in reconciler.in_flight:
         await asyncio.sleep(0.005)
-    await manager.enqueue(key)
-    await manager.enqueue(key)
+    await _enqueue(manager, key)
+    await _enqueue(manager, key)
 
     await _drain(reconciler, expected=2)
     await asyncio.sleep(0.1)
@@ -123,14 +132,14 @@ async def test_re_dirty_during_processing_reconciles_once_more():
 async def test_same_key_never_processed_concurrently():
     reconciler = RecordingReconciler()
     reconciler.delay = 0.15
-    manager = ReconcileManager(reconciler, default_delay=0.0, num_workers=4)
+    manager = _manager(reconciler, default_delay=0.0, num_workers=4)
     manager.start()
     key = uuid.uuid4()
 
-    await manager.enqueue(key)
+    await _enqueue(manager, key)
     while key not in reconciler.in_flight:
         await asyncio.sleep(0.005)
-    await manager.enqueue(key)
+    await _enqueue(manager, key)
 
     await _drain(reconciler, expected=2)
     await asyncio.sleep(0.1)
@@ -142,14 +151,14 @@ async def test_same_key_never_processed_concurrently():
 async def test_different_keys_processed_in_parallel():
     reconciler = RecordingReconciler()
     reconciler.delay = 0.2
-    manager = ReconcileManager(reconciler, default_delay=0.0, num_workers=2)
+    manager = _manager(reconciler, default_delay=0.0, num_workers=2)
     manager.start()
     k1, k2 = uuid.uuid4(), uuid.uuid4()
 
     loop = asyncio.get_running_loop()
     start = loop.time()
-    await manager.enqueue(k1)
-    await manager.enqueue(k2)
+    await _enqueue(manager, k1)
+    await _enqueue(manager, k2)
     await _drain(reconciler, expected=2)
     elapsed = loop.time() - start
     await manager.stop()
@@ -163,7 +172,7 @@ async def test_initial_sync_enqueues_all_listed_ids():
     reconciler = RecordingReconciler()
     ids = [uuid.uuid4() for _ in range(3)]
     reconciler.ids_to_list = ids
-    manager = ReconcileManager(reconciler, default_delay=0.0, num_workers=2)
+    manager = _manager(reconciler, default_delay=0.0, num_workers=2)
     manager.start()
 
     await _drain(reconciler, expected=len(ids))
@@ -176,7 +185,7 @@ async def test_initial_sync_enqueues_all_listed_ids():
 
 async def test_no_initial_sync_without_listed_ids():
     reconciler = RecordingReconciler()
-    manager = ReconcileManager(reconciler, default_delay=0.0, num_workers=1)
+    manager = _manager(reconciler, default_delay=0.0, num_workers=1)
     manager.start()
 
     await asyncio.sleep(0.1)
@@ -191,7 +200,7 @@ async def test_initial_sync_retries_listing_then_succeeds():
     reconciler.ids_to_list = ids
     reconciler.list_ids_fail_times = 1
     # Use base_delay so the backoff (2**0 = 1s capped by max_delay) stays short.
-    manager = ReconcileManager(reconciler, default_delay=0.0, num_workers=1)
+    manager = _manager(reconciler, default_delay=0.0, num_workers=1)
     # Shrink the backoff by monkeypatching the cap is overkill; instead rely on the
     # first retry delay being 2**0 = 1.0s, so allow enough time below.
     manager.start()
@@ -209,18 +218,68 @@ async def test_failure_requeues_with_backoff_then_succeeds():
     key = uuid.uuid4()
     reconciler.fail_times[key] = 2
     rate_limiter = RateLimiter(base_delay=0.05, max_delay=10, factor=2.0)
-    manager = ReconcileManager(
+    manager = _manager(
         reconciler, default_delay=0.0, rate_limiter=rate_limiter, num_workers=1
     )
     manager.start()
 
-    await manager.enqueue(key)
+    await _enqueue(manager, key)
     await _drain(reconciler, expected=3, timeout=3.0)
     await asyncio.sleep(0.1)
     await manager.stop()
 
     assert reconciler.calls.count(key) == 3
-    assert rate_limiter.failures(key) == 0  # forgotten after success
+
+
+async def test_manager_dispatches_to_correct_reconciler():
+    exploration = RecordingReconciler()
+    data_product = RecordingReconciler()
+    manager = ReconcileManager(
+        {
+            ResourceType.EXPLORATION: exploration,
+            ResourceType.DATA_PRODUCT: data_product,
+        },
+        default_delay=0.0,
+        num_workers=2,
+    )
+    manager.start()
+
+    exp_id = uuid.uuid4()
+    dp_id = uuid.uuid4()
+    await manager.enqueue(ResourceType.EXPLORATION, exp_id)
+    await manager.enqueue(ResourceType.DATA_PRODUCT, dp_id)
+
+    await _drain(exploration, expected=1)
+    await _drain(data_product, expected=1)
+    await manager.stop()
+
+    assert exploration.calls == [exp_id]
+    assert data_product.calls == [dp_id]
+
+
+async def test_same_id_different_types_do_not_collide():
+    exploration = RecordingReconciler()
+    data_product = RecordingReconciler()
+    manager = ReconcileManager(
+        {
+            ResourceType.EXPLORATION: exploration,
+            ResourceType.DATA_PRODUCT: data_product,
+        },
+        default_delay=0.0,
+        num_workers=2,
+    )
+    manager.start()
+
+    shared_id = uuid.uuid4()
+    await manager.enqueue(ResourceType.EXPLORATION, shared_id)
+    await manager.enqueue(ResourceType.DATA_PRODUCT, shared_id)
+
+    await _drain(exploration, expected=1)
+    await _drain(data_product, expected=1)
+    await manager.stop()
+
+    assert exploration.calls == [shared_id]
+    assert data_product.calls == [shared_id]
 
 
 def _build_request(envelope: dict[str, Any]) -> Request:
@@ -242,47 +301,78 @@ def _build_request(envelope: dict[str, Any]) -> Request:
     )
 
 
-def _payload(exploration_id: uuid.UUID) -> dict[str, Any]:
+def _envelope(event_type: str, resource_id: uuid.UUID) -> dict[str, Any]:
     return {
-        "id": str(exploration_id),
-        "name": "exp",
-        "namespace": "ns",
-        "description": None,
-        "domain_id": str(uuid.uuid4()),
-        "owner_id": str(uuid.uuid4()),
-    }
-
-
-@pytest.mark.parametrize(
-    "event_type",
-    [
-        ("exploration.created"),
-        ("exploration.updated"),
-        ("exploration.deleted"),
-    ],
-)
-async def test_event_handler_enqueues_exploration_id(event_type):
-    reconciler = RecordingReconciler()
-    manager = ReconcileManager(reconciler, default_delay=0.0, num_workers=1)
-    manager.start()
-    handler = ReconcileEventHandler(manager)
-    exploration_id = uuid.uuid4()
-
-    envelope = {
         "specversion": "1.0",
         "id": str(uuid.uuid4()),
         "source": "data-product-portal",
         "type": event_type,
         "time": "2026-06-17T00:00:00Z",
         "data": {
-            "id": str(exploration_id),
+            "id": str(resource_id),
         },
     }
 
-    result = await handler.dispatch_routing(_build_request(envelope))
-    assert result["status"] == "queued"
-    assert result["exploration_id"] == str(exploration_id)
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        "exploration.created",
+        "exploration.updated",
+        "exploration.deleted",
+    ],
+)
+async def test_event_handler_enqueues_exploration(event_type):
+    reconciler = RecordingReconciler()
+    manager = _manager(reconciler, default_delay=0.0, num_workers=1)
+    manager.start()
+    handler = ReconcileEventHandler(manager)
+    exploration_id = uuid.uuid4()
+
+    await handler.dispatch_routing(
+        _build_request(_envelope(event_type, exploration_id))
+    )
 
     await _drain(reconciler, expected=1)
     await manager.stop()
     assert reconciler.calls == [exploration_id]
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        "data_product.created",
+        "data_product.updated",
+        "data_product.deleted",
+    ],
+)
+async def test_event_handler_enqueues_data_product(event_type):
+    reconciler = RecordingReconciler()
+    manager = ReconcileManager(
+        {ResourceType.DATA_PRODUCT: reconciler}, default_delay=0.0, num_workers=1
+    )
+    manager.start()
+    handler = ReconcileEventHandler(manager)
+    data_product_id = uuid.uuid4()
+
+    await handler.dispatch_routing(
+        _build_request(_envelope(event_type, data_product_id))
+    )
+
+    await _drain(reconciler, expected=1)
+    await manager.stop()
+    assert reconciler.calls == [data_product_id]
+
+
+async def test_event_handler_ignores_unregistered_resource_type():
+    # Only an exploration reconciler is registered; data product events are ignored.
+    reconciler = RecordingReconciler()
+    manager = _manager(reconciler, default_delay=0.0, num_workers=1)
+    manager.start()
+    handler = ReconcileEventHandler(manager)
+
+    await handler.dispatch_routing(
+        _build_request(_envelope("data_product.created", uuid.uuid4()))
+    )
+    assert manager.queue.qsize() == 0
+    await manager.stop()


### PR DESCRIPTION
Added support for data product reconciler,
in a future PR we will add events for:
- output port
- technical asset
- ...

That trigger updates on the data product

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested.
