### PR TITLE
Added some extra posthog events

### DIFF
--- a/frontend/src/constants/posthog.constants.ts
+++ b/frontend/src/constants/posthog.constants.ts
@@ -29,12 +29,17 @@ export enum PosthogEvents {
     DATA_PRODUCT_TOUR_FINISHED = 'data_product_tour_finished',
     DATA_PRODUCT_TOUR_CLOSED = 'data_product_tour_closed',
 
-    CART_CHECKOUT_COMPLETED = 'cart_checkout_completed',
+    CART_DATA_PRODUCT_OR_EXPLORATION_CHOICE = 'cart_data_product_or_exploration_choice',
+    CART_EXISTING_OR_NEW_CHOICE = 'cart_existing_or_new_choice',
+
     CART_CHECKOUT_COMPLETED_EXISTING_DATA_PRODUCT = 'cart_checkout_completed_existing_data_product',
     CART_CHECKOUT_COMPLETED_NEW_DATA_PRODUCT = 'cart_checkout_completed_new_data_product',
     CART_CHECKOUT_COMPLETED_EXISTING_EXPLORATION = 'cart_checkout_completed_existing_exploration',
     CART_CHECKOUT_COMPLETED_NEW_EXPLORATION = 'cart_checkout_completed_new_exploration',
-    CART_CREATE_DATA_PRODUCT = 'cart_create_data_product',
+
+    OUTPUT_PORT_TAB = 'output_port_tab',
+    OUTPUT_PORT_DATA_MODEL_TABLE = 'output_port_data_model_table',
+    OUTPUT_PORT_DATA_MODEL_LOADED = 'output_port_data_model_loaded',
 
     ADMIN_PRIVILEGES_GRANTED = 'admin_privileges_granted',
     ADMIN_PRIVILEGES_REVOKED = 'admin_privileges_revoked',

--- a/frontend/src/hooks/use-tab-param.tsx
+++ b/frontend/src/hooks/use-tab-param.tsx
@@ -5,14 +5,15 @@ export type Props = {
     defaultValue: string;
     acceptedValues?: string[];
 };
-export function useTabParam(defaultValue: string, acceptedValues?: string[]) {
+export function useTabParam(defaultValue: string, acceptedValues?: string[], capturePosthog?: (value: string) => void) {
     const [searchParams, setSearchParams] = useSearchParams();
 
     const onTabChange = useCallback(
         (key: string) => {
+            capturePosthog?.(key);
             setSearchParams({ tab: key });
         },
-        [setSearchParams],
+        [setSearchParams, capturePosthog],
     );
 
     const resolveTab = useCallback(() => {

--- a/frontend/src/pages/cart/cart.page.tsx
+++ b/frontend/src/pages/cart/cart.page.tsx
@@ -1,5 +1,6 @@
 import { PlusOutlined, ShopOutlined, ShoppingCartOutlined, UnorderedListOutlined } from '@ant-design/icons';
 import { Button, Col, Empty, Flex, Row, Typography } from 'antd';
+import posthog from 'posthog-js';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -7,6 +8,7 @@ import { Link } from 'react-router';
 import ExplorationBorderIcon from '@/assets/icons/border-icons/exploration-border-icon.svg?react';
 import { CustomSvgIconLoader } from '@/components/icons/custom-svg-icon-loader/custom-svg-icon-loader.component.tsx';
 import { useBreadcrumbs } from '@/components/layout/navbar/breadcrumbs/breadcrumb.context.tsx';
+import { PosthogEvents } from '@/constants/posthog.constants.ts';
 import { CardSelection } from '@/pages/cart/components/card-selection.tsx';
 import { CartOverview } from '@/pages/cart/components/cart-overview.component.tsx';
 import { ExistingDataProductForm } from '@/pages/cart/components/existing-data-product-form.tsx';
@@ -34,12 +36,14 @@ function ExplorationsCart() {
 
     const setDataProductTypeChoice = useCallback(
         (choice: DataProductChoiceOptions | null) => {
+            posthog.capture(PosthogEvents.CART_DATA_PRODUCT_OR_EXPLORATION_CHOICE, { choice });
             dispatch(setCartExplorationChoices({ dataProductTypeChoice: choice, existingOrNewChoice: null }));
         },
         [dispatch],
     );
     const setExistingOrNewChoice = useCallback(
         (choice: ExistingOrNew | null) => {
+            posthog.capture(PosthogEvents.CART_EXISTING_OR_NEW_CHOICE, { choice });
             dispatch(setCartExplorationChoices({ dataProductTypeChoice, existingOrNewChoice: choice }));
         },
         [dispatch, dataProductTypeChoice],

--- a/frontend/src/pages/dataset/components/dataset-tabs/data-model-tab/data-model-tab.tsx
+++ b/frontend/src/pages/dataset/components/dataset-tabs/data-model-tab/data-model-tab.tsx
@@ -1,9 +1,11 @@
+import { usePostHog } from '@posthog/react';
 import { Card, Space, Table, Tag, Typography } from 'antd';
 import type { TFunction } from 'i18next';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EmptyList } from '@/components/empty/empty-list/empty-list.component';
 import { LoadingSpinner } from '@/components/loading/loading-spinner/loading-spinner';
+import { PosthogEvents } from '@/constants/posthog.constants.ts';
 import type { SchemaPropertyResponse } from '@/store/api/services/generated/dataProductsOutputPortsApi.ts';
 import { useGetOutputPortSchemaQuery } from '@/store/api/services/generated/dataProductsOutputPortsApi.ts';
 import styles from './data-model-tab.module.scss';
@@ -78,10 +80,19 @@ function getPropertyColumns(t: TFunction) {
 
 export function DataModelTab({ datasetId, dataProductId }: Props) {
     const { t } = useTranslation();
+    const posthog = usePostHog();
     const { data, isLoading } = useGetOutputPortSchemaQuery({ id: datasetId, dataProductId });
     const schemaObjects = data?.schema_objects ?? [];
 
     const [activeTab, setActiveTab] = useState<string | undefined>(undefined);
+
+    useEffect(() => {
+        if (!isLoading && data !== undefined) {
+            posthog.capture(PosthogEvents.OUTPUT_PORT_DATA_MODEL_LOADED, {
+                data_model_defined: data?.schema_objects?.length !== 0,
+            });
+        }
+    }, [isLoading, data, posthog]);
 
     if (isLoading) {
         return <LoadingSpinner />;
@@ -130,7 +141,14 @@ export function DataModelTab({ datasetId, dataProductId }: Props) {
     };
 
     return (
-        <Card size="small" tabList={tabList} onTabChange={setActiveTab}>
+        <Card
+            size="small"
+            tabList={tabList}
+            onTabChange={(key: string) => {
+                posthog.capture(PosthogEvents.OUTPUT_PORT_DATA_MODEL_TABLE, { tab: key });
+                setActiveTab(key);
+            }}
+        >
             {renderSchema(activeTab)}
         </Card>
     );

--- a/frontend/src/pages/dataset/components/dataset-tabs/dataset-tabs.tsx
+++ b/frontend/src/pages/dataset/components/dataset-tabs/dataset-tabs.tsx
@@ -47,7 +47,9 @@ export function DatasetTabs({ datasetId, dataProductId, isLoading }: Props) {
     const posthog = usePostHog();
     const { data: { events: datasetHistoryData = [] } = {}, isLoading: isFetchingDatasetHistory } =
         useGetOutputPortsEventHistoryQuery({ id: datasetId, dataProductId }, { skip: !datasetId });
-    const { activeTab, onTabChange } = useTabParam(TabKeys.About, Object.values(TabKeys));
+    const { activeTab, onTabChange } = useTabParam(TabKeys.About, Object.values(TabKeys), (tab) =>
+        posthog.capture(PosthogEvents.OUTPUT_PORT_TAB, { tab }),
+    );
 
     useEffect(() => {
         posthog.capture(PosthogEvents.MARKETPLACE_DATASET_TAB_CLICKED, {


### PR DESCRIPTION
We now capture output port tab clicks.
And if the data model is defined, allows
us to see how this is used.

And we capture cart choices.
This enables us to see if people get stuck.

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested.
