### PR TITLE
fix: exclude the requester from approver email recipients (#3265)

### DIFF
--- a/backend/app/abstract_data_product/service.py
+++ b/backend/app/abstract_data_product/service.py
@@ -198,14 +198,18 @@ class AbstractDataProductService:
                     dataset_link.dataset_id,
                     Action.OUTPUT_PORT__APPROVE_DATAPRODUCT_ACCESS_REQUEST,
                 )
-                background_tasks.add_task(
-                    email.send_dataset_link_email(
-                        dataset_link.consuming_abstract_data_product,
-                        dataset_link.dataset,
-                        requester=deepcopy(actor),
-                        approvers=[deepcopy(approver) for approver in approvers],
+                other_approvers = [a for a in approvers if a != actor]
+                if other_approvers:
+                    background_tasks.add_task(
+                        email.send_dataset_link_email(
+                            dataset_link.consuming_abstract_data_product,
+                            dataset_link.dataset,
+                            requester=deepcopy(actor),
+                            approvers=[
+                                deepcopy(approver) for approver in other_approvers
+                            ],
+                        )
                     )
-                )
 
     def add_finalizer(self, id: UUID, finalizer: str) -> AbstractDataProduct:
         """Add a finalizer to the abstract data product.

--- a/backend/app/authorization/role_assignments/data_product/router.py
+++ b/backend/app/authorization/role_assignments/data_product/router.py
@@ -147,12 +147,14 @@ def request_data_product_role_assignment(
         data_product_id=role_assignment.data_product_id,
         action=Action.DATA_PRODUCT__APPROVE_USER_REQUEST,
     )
-    background_tasks.add_task(
-        email.send_role_assignment_request_email,
-        deepcopy(role_assignment.user),
-        deepcopy(role_assignment.data_product),
-        [deepcopy(approver) for approver in approvers],
-    )
+    other_approvers = [a for a in approvers if a != user]
+    if other_approvers:
+        background_tasks.add_task(
+            email.send_role_assignment_request_email,
+            deepcopy(role_assignment.user),
+            deepcopy(role_assignment.data_product),
+            [deepcopy(approver) for approver in other_approvers],
+        )
     return role_assignment
 
 

--- a/backend/app/data_products/output_port_technical_assets_link/router.py
+++ b/backend/app/data_products/output_port_technical_assets_link/router.py
@@ -177,13 +177,14 @@ def link_output_port_to_technical_asset(
         dataset_link.dataset_id,
         Action.OUTPUT_PORT__APPROVE_TECHNICAL_ASSET_LINK_REQUEST,
     )
-    if authenticated_user not in approvers:
+    other_approvers = [a for a in approvers if a != authenticated_user]
+    if other_approvers:
         background_tasks.add_task(
             email.send_link_dataset_email(
                 dataset_link.dataset,
                 dataset_link.data_output,
                 requester=deepcopy(authenticated_user),
-                approvers=[deepcopy(approver) for approver in approvers],
+                approvers=[deepcopy(approver) for approver in other_approvers],
             )
         )
     return LinkTechnicalAssetsToOutputPortResponse(link_id=dataset_link.id)

--- a/backend/tests/app/abstract_data_product/test_service.py
+++ b/backend/tests/app/abstract_data_product/test_service.py
@@ -1,0 +1,91 @@
+from unittest.mock import MagicMock, patch
+
+from app.abstract_data_product.service import AbstractDataProductService
+from app.authorization.role_assignments.enums import DecisionStatus
+from app.authorization.roles.schema import Scope
+from app.core.authz import Action
+from app.data_products.output_ports.enums import OutputPortAccessType
+from tests import test_session
+from tests.factories import (
+    DataProductFactory,
+    DatasetFactory,
+    DatasetRoleAssignmentFactory,
+    InputPortFactory,
+    RoleFactory,
+    UserFactory,
+)
+
+
+class TestAbstractDataProductService:
+    @patch("app.abstract_data_product.service.email.send_dataset_link_email")
+    def test_input_port_request_email_not_sent_when_requester_is_only_approver(
+        self, mock_send_email
+    ):
+        actor = UserFactory()
+        output_port = DatasetFactory(access_type=OutputPortAccessType.RESTRICTED)
+        input_port = InputPortFactory(
+            consuming_abstract_data_product=DataProductFactory(),
+            dataset=output_port,
+            requested_by=actor,
+            status=DecisionStatus.PENDING,
+        )
+        approver_role = RoleFactory(
+            scope=Scope.DATASET,
+            permissions=[Action.OUTPUT_PORT__APPROVE_DATAPRODUCT_ACCESS_REQUEST],
+        )
+        DatasetRoleAssignmentFactory(
+            dataset=output_port,
+            role_id=approver_role.id,
+            user_id=actor.id,
+        )
+        background_tasks = MagicMock()
+
+        AbstractDataProductService(
+            test_session
+        ).send_input_port_requested_emails_to_output_port_owners(
+            [input_port],
+            background_tasks,
+            actor,
+        )
+
+        mock_send_email.assert_not_called()
+        background_tasks.add_task.assert_not_called()
+
+    @patch("app.abstract_data_product.service.email.send_dataset_link_email")
+    def test_input_port_request_email_excludes_requester_from_approvers(
+        self, mock_send_email
+    ):
+        actor = UserFactory()
+        other_approver = UserFactory()
+        output_port = DatasetFactory(access_type=OutputPortAccessType.RESTRICTED)
+        input_port = InputPortFactory(
+            consuming_abstract_data_product=DataProductFactory(),
+            dataset=output_port,
+            requested_by=actor,
+            status=DecisionStatus.PENDING,
+        )
+        approver_role = RoleFactory(
+            scope=Scope.DATASET,
+            permissions=[Action.OUTPUT_PORT__APPROVE_DATAPRODUCT_ACCESS_REQUEST],
+        )
+        for user in [actor, other_approver]:
+            DatasetRoleAssignmentFactory(
+                dataset=output_port,
+                role_id=approver_role.id,
+                user_id=user.id,
+            )
+        background_tasks = MagicMock()
+
+        AbstractDataProductService(
+            test_session
+        ).send_input_port_requested_emails_to_output_port_owners(
+            [input_port],
+            background_tasks,
+            actor,
+        )
+
+        mock_send_email.assert_called_once()
+        approvers = mock_send_email.call_args.kwargs["approvers"]
+        assert {approver.id for approver in approvers} == {other_approver.id}
+        assert actor.id not in {approver.id for approver in approvers}
+        background_tasks.add_task.assert_called_once_with(mock_send_email.return_value)

--- a/backend/tests/app/authorization/role_assignments/data_product/test_router.py
+++ b/backend/tests/app/authorization/role_assignments/data_product/test_router.py
@@ -155,6 +155,85 @@ class TestDataProductRoleAssignmentsRouter:
         self.test_request_assignment(client)
         assert_event_in_queue("data_product_role_assignment.event", mock_webhook)
 
+    @patch(
+        "app.authorization.role_assignments.data_product.router.email.send_role_assignment_request_email"
+    )
+    def test_request_assignment_email_not_sent_when_requester_is_only_approver(
+        self, mock_send_email, client: TestClient
+    ):
+        data_product: DataProduct = DataProductFactory()
+        requester = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        request_role = RoleFactory(
+            scope=Scope.GLOBAL,
+            permissions=[Action.GLOBAL__REQUEST_DATAPRODUCT_ACCESS],
+        )
+        GlobalRoleAssignmentFactory(user_id=requester.id, role_id=request_role.id)
+        approver_role = RoleFactory(
+            scope=Scope.DATA_PRODUCT,
+            permissions=[Action.DATA_PRODUCT__APPROVE_USER_REQUEST],
+        )
+        DataProductRoleAssignmentFactory(
+            user_id=requester.id,
+            role_id=approver_role.id,
+            data_product_id=data_product.id,
+        )
+        requested_user: User = UserFactory()
+        requested_role: Role = RoleFactory(scope=Scope.DATA_PRODUCT)
+
+        response = client.post(
+            f"{ENDPOINT}/request",
+            json={
+                "user_id": str(requested_user.id),
+                "role_id": str(requested_role.id),
+                "data_product_id": str(data_product.id),
+            },
+        )
+
+        assert response.status_code == 200
+        mock_send_email.assert_not_called()
+
+    @patch(
+        "app.authorization.role_assignments.data_product.router.email.send_role_assignment_request_email"
+    )
+    def test_request_assignment_email_excludes_requester_from_approvers(
+        self, mock_send_email, client: TestClient
+    ):
+        data_product: DataProduct = DataProductFactory()
+        requester = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        other_approver = UserFactory()
+        request_role = RoleFactory(
+            scope=Scope.GLOBAL,
+            permissions=[Action.GLOBAL__REQUEST_DATAPRODUCT_ACCESS],
+        )
+        GlobalRoleAssignmentFactory(user_id=requester.id, role_id=request_role.id)
+        approver_role = RoleFactory(
+            scope=Scope.DATA_PRODUCT,
+            permissions=[Action.DATA_PRODUCT__APPROVE_USER_REQUEST],
+        )
+        for user in [requester, other_approver]:
+            DataProductRoleAssignmentFactory(
+                user_id=user.id,
+                role_id=approver_role.id,
+                data_product_id=data_product.id,
+            )
+        requested_user: User = UserFactory()
+        requested_role: Role = RoleFactory(scope=Scope.DATA_PRODUCT)
+
+        response = client.post(
+            f"{ENDPOINT}/request",
+            json={
+                "user_id": str(requested_user.id),
+                "role_id": str(requested_role.id),
+                "data_product_id": str(data_product.id),
+            },
+        )
+
+        assert response.status_code == 200
+        mock_send_email.assert_called_once()
+        approvers = mock_send_email.call_args.args[2]
+        assert {approver.id for approver in approvers} == {other_approver.id}
+        assert requester.id not in {approver.id for approver in approvers}
+
     def test_request_assignment_no_right(self, client: TestClient):
         data_product: DataProduct = DataProductFactory()
         UserFactory(external_id=settings.DEFAULT_USERNAME)

--- a/backend/tests/app/data_products/output_port_technical_assets_link/test_router.py
+++ b/backend/tests/app/data_products/output_port_technical_assets_link/test_router.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from app.authorization.role_assignments.enums import DecisionStatus
@@ -103,6 +105,83 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
             client, data_product.id, data_output.id, ds.id
         )
         assert response.status_code == 200
+
+    @patch(
+        "app.data_products.output_port_technical_assets_link.router.email.send_link_dataset_email"
+    )
+    def test_request_data_output_link_email_not_sent_when_requester_is_only_approver(
+        self, mock_send_email, client
+    ):
+        requester = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        data_product = DataProductFactory()
+        request_role = RoleFactory(
+            scope=Scope.DATA_PRODUCT,
+            permissions=[Action.DATA_PRODUCT__REQUEST_TECHNICAL_ASSET_LINK],
+        )
+        DataProductRoleAssignmentFactory(
+            user_id=requester.id,
+            role_id=request_role.id,
+            data_product_id=data_product.id,
+        )
+        output_port = DatasetFactory(data_product=data_product)
+        technical_asset = TechnicalAssetFactory(owner=data_product)
+        approver_role = RoleFactory(
+            scope=Scope.DATASET,
+            permissions=[Action.OUTPUT_PORT__APPROVE_TECHNICAL_ASSET_LINK_REQUEST],
+        )
+        DatasetRoleAssignmentFactory(
+            user_id=requester.id,
+            role_id=approver_role.id,
+            dataset=output_port,
+        )
+
+        response = self.request_data_output_dataset_link_new(
+            client, data_product.id, technical_asset.id, output_port.id
+        )
+
+        assert response.status_code == 200
+        mock_send_email.assert_not_called()
+
+    @patch(
+        "app.data_products.output_port_technical_assets_link.router.email.send_link_dataset_email"
+    )
+    def test_request_data_output_link_email_excludes_requester_from_approvers(
+        self, mock_send_email, client
+    ):
+        requester = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        other_approver = UserFactory()
+        data_product = DataProductFactory()
+        request_role = RoleFactory(
+            scope=Scope.DATA_PRODUCT,
+            permissions=[Action.DATA_PRODUCT__REQUEST_TECHNICAL_ASSET_LINK],
+        )
+        DataProductRoleAssignmentFactory(
+            user_id=requester.id,
+            role_id=request_role.id,
+            data_product_id=data_product.id,
+        )
+        output_port = DatasetFactory(data_product=data_product)
+        technical_asset = TechnicalAssetFactory(owner=data_product)
+        approver_role = RoleFactory(
+            scope=Scope.DATASET,
+            permissions=[Action.OUTPUT_PORT__APPROVE_TECHNICAL_ASSET_LINK_REQUEST],
+        )
+        for user in [requester, other_approver]:
+            DatasetRoleAssignmentFactory(
+                user_id=user.id,
+                role_id=approver_role.id,
+                dataset=output_port,
+            )
+
+        response = self.request_data_output_dataset_link_new(
+            client, data_product.id, technical_asset.id, output_port.id
+        )
+
+        assert response.status_code == 200
+        mock_send_email.assert_called_once()
+        approvers = mock_send_email.call_args.kwargs["approvers"]
+        assert {approver.id for approver in approvers} == {other_approver.id}
+        assert requester.id not in {approver.id for approver in approvers}
 
     def test_request_data_output_link_on_dataset_with_diff_parent(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)

--- a/backend/tests/app/data_products/technical_assets/test_router.py
+++ b/backend/tests/app/data_products/technical_assets/test_router.py
@@ -646,6 +646,7 @@ class TestTechnicalAssetsRouter:
     ):
         """Test that email is sent when dataset link request requires manual approval"""
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        other_approver = UserFactory()
         data_product = DataProductFactory()
         dataset = DatasetFactory(data_product=data_product)  # Different owner
         data_output = TechnicalAssetFactory(owner=data_product)
@@ -657,6 +658,15 @@ class TestTechnicalAssetsRouter:
         )
         DataProductRoleAssignmentFactory(
             user_id=user.id, role_id=role.id, data_product_id=data_product.id
+        )
+        approver_role = RoleFactory(
+            scope=Scope.DATASET,
+            permissions=[Action.OUTPUT_PORT__APPROVE_TECHNICAL_ASSET_LINK_REQUEST],
+        )
+        DatasetRoleAssignmentFactory(
+            user_id=other_approver.id,
+            role_id=approver_role.id,
+            dataset_id=dataset.id,
         )
 
         # Mock manual approval scenario (different data product owner)


### PR DESCRIPTION
Closes #3265. Resubmit of #3278 (closed for inactivity) with the unit tests requested.

When a user requests access and is themselves an approver, they were emailed their own request. This filters the requesting actor out of the approvers list before sending, and skips the email entirely when no other approvers remain, across the three request paths (input-port access, data-product role assignment, output-port technical asset link).

Adds unit tests for both cases (requester-only -> no email; other approvers -> email excludes requester) on all three paths. Verified locally: 6 passed.