### PR TITLE
fix: partial/prefix matching in output port search

### DIFF
--- a/backend/app/data_products/output_ports/service.py
+++ b/backend/app/data_products/output_ports/service.py
@@ -1,4 +1,5 @@
 import copy
+import re
 from typing import Iterable, Optional, Sequence
 from uuid import UUID
 
@@ -56,6 +57,8 @@ from app.graph.node import Node, NodeData, NodeType
 from app.resource_names.service import ResourceNameValidityType
 from app.users.model import User as UserModel
 from app.users.schema import User
+
+TSQUERY_TOKEN_PATTERN = re.compile(r"[A-Za-z0-9]+")
 
 
 def get_dataset_load_options() -> Sequence[ExecutableOption]:
@@ -157,12 +160,13 @@ class OutputPortService:
         no filtering is applied other than the limit.
         """
         ordered_by = DatasetModel.name.asc()
-        if query:
+        ts_query_text = self._build_prefix_ts_query(query) if query else None
+        if ts_query_text:
             query_embedding = self.embedding_model.embed(query)
             semantic_score = (
                 1 - DatasetModel.embeddings.cosine_distance(*query_embedding)
             ).label("semantic_score")
-            ts_query = func.websearch_to_tsquery("english", query)
+            ts_query = func.to_tsquery("english", ts_query_text)
             keyword_score = func.coalesce(
                 func.ts_rank_cd(DatasetModel.search_vector, ts_query, 32), 0
             ).label("keyword_score")
@@ -199,6 +203,14 @@ class OutputPortService:
                     return visible_candidates
 
         return visible_candidates
+
+    @staticmethod
+    def _build_prefix_ts_query(query: str) -> Optional[str]:
+        tokens = TSQUERY_TOKEN_PATTERN.findall(query.casefold())
+        if not tokens:
+            return None
+
+        return " & ".join(f"{token}:*" for token in tokens)
 
     @staticmethod
     def recalculate_embeddings_load_options():

--- a/backend/app/data_products/output_ports/service.py
+++ b/backend/app/data_products/output_ports/service.py
@@ -1,11 +1,10 @@
 import copy
-import re
 from typing import Iterable, Optional, Sequence
 from uuid import UUID
 
 from fastapi import HTTPException, status
 from fastembed import TextEmbedding
-from sqlalchemy import func, select
+from sqlalchemy import String, case, func, select
 from sqlalchemy.orm import Session, joinedload, raiseload, selectinload, undefer
 from sqlalchemy.sql.base import ExecutableOption
 
@@ -58,7 +57,8 @@ from app.resource_names.service import ResourceNameValidityType
 from app.users.model import User as UserModel
 from app.users.schema import User
 
-TSQUERY_TOKEN_PATTERN = re.compile(r"[A-Za-z0-9]+")
+TSQUERY_POSITIVE_LEXEME_PATTERN = r"(^|[^!])'([^']+)'"
+TSQUERY_POSITIVE_LEXEME_PREFIX_REPLACEMENT = r"\1'\2':*"
 
 
 def get_dataset_load_options() -> Sequence[ExecutableOption]:
@@ -160,15 +160,22 @@ class OutputPortService:
         no filtering is applied other than the limit.
         """
         ordered_by = DatasetModel.name.asc()
-        ts_query_text = self._build_prefix_ts_query(query) if query else None
-        if ts_query_text:
-            query_embedding = self.embedding_model.embed(query)
+        normalized_query = query.strip() if query else None
+        if normalized_query:
+            query_embedding = self.embedding_model.embed(normalized_query)
             semantic_score = (
                 1 - DatasetModel.embeddings.cosine_distance(*query_embedding)
             ).label("semantic_score")
-            ts_query = func.to_tsquery("english", ts_query_text)
+            ts_query = self._build_search_ts_query(normalized_query)
             keyword_score = func.coalesce(
-                func.ts_rank_cd(DatasetModel.search_vector, ts_query, 32), 0
+                case(
+                    (
+                        DatasetModel.search_vector.bool_op("@@")(ts_query),
+                        func.ts_rank_cd(DatasetModel.search_vector, ts_query, 32),
+                    ),
+                    else_=0,
+                ),
+                0,
             ).label("keyword_score")
 
             semantic_weight = 2.0 / 3.0
@@ -181,7 +188,7 @@ class OutputPortService:
 
         stmt = (
             select(DatasetModel)
-            .order_by(ordered_by)
+            .order_by(ordered_by, DatasetModel.name.asc())
             # We currently apply a limit times 2, the reason is that without a limit the query is really slow, however we might miss results because of that
             .limit(limit * 2)
         )
@@ -205,12 +212,17 @@ class OutputPortService:
         return visible_candidates
 
     @staticmethod
-    def _build_prefix_ts_query(query: str) -> Optional[str]:
-        tokens = TSQUERY_TOKEN_PATTERN.findall(query.casefold())
-        if not tokens:
-            return None
+    def _build_search_ts_query(query: str):
+        websearch_ts_query = func.websearch_to_tsquery("english", query)
+        prefix_ts_query_text = func.regexp_replace(
+            websearch_ts_query.cast(String),
+            TSQUERY_POSITIVE_LEXEME_PATTERN,
+            TSQUERY_POSITIVE_LEXEME_PREFIX_REPLACEMENT,
+            "g",
+        )
+        prefix_ts_query = func.to_tsquery("english", prefix_ts_query_text)
 
-        return " & ".join(f"{token}:*" for token in tokens)
+        return websearch_ts_query.op("||")(prefix_ts_query)
 
     @staticmethod
     def recalculate_embeddings_load_options():

--- a/backend/tests/app/data_products/output_ports/test_service.py
+++ b/backend/tests/app/data_products/output_ports/test_service.py
@@ -19,6 +19,13 @@ from tests.factories import (
     UserFactory,
 )
 
+SEARCH_EMBEDDING = [1.0, *([0.0] * 383)]
+
+
+class StaticEmbeddingModel:
+    def embed(self, query):
+        return [SEARCH_EMBEDDING]
+
 
 class TestDatasetsService:
     def test_private_dataset_not_visible(self):
@@ -163,6 +170,53 @@ class TestDatasetsService:
             "Owner should also see public datasets"
         )
 
+    def test_search_output_ports_matches_partial_prefix(self):
+        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        wind_dataset = DatasetFactory(
+            name="Wind Turbine Output", description="Renewable generation metrics"
+        )
+        unrelated_dataset = DatasetFactory(
+            name="Finance Budget", description="Quarterly accounting metrics"
+        )
+        self.set_search_state(wind_dataset, unrelated_dataset)
+
+        partial_results = self.search_with_static_embeddings("win", user, limit=1)
+        full_word_results = self.search_with_static_embeddings("wind", user, limit=1)
+
+        assert [result.id for result in partial_results] == [wind_dataset.id]
+        assert [result.id for result in full_word_results] == [wind_dataset.id]
+
+    def test_search_output_ports_matches_multi_word_partial_prefix_case_insensitive(
+        self,
+    ):
+        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        clinical_dataset = DatasetFactory(
+            name="Clinical Dataset", description="Patient outcome measures"
+        )
+        unrelated_dataset = DatasetFactory(
+            name="Marketing Metrics", description="Campaign performance"
+        )
+        self.set_search_state(clinical_dataset, unrelated_dataset)
+
+        results = self.search_with_static_embeddings("CLIN DATA", user, limit=1)
+
+        assert [result.id for result in results] == [clinical_dataset.id]
+
+    def test_search_output_ports_handles_empty_punctuation_and_stop_word_queries(self):
+        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        alpha_dataset = DatasetFactory(name="Alpha Dataset")
+        zulu_dataset = DatasetFactory(name="Zulu Dataset")
+        self.set_search_state(alpha_dataset, zulu_dataset)
+
+        whitespace_results = self.search_with_static_embeddings("   ", user, limit=2)
+        punctuation_results = self.search_with_static_embeddings("?!...", user, limit=2)
+        stop_word_results = self.search_with_static_embeddings("the and", user, limit=2)
+
+        expected_default_order = [alpha_dataset.id, zulu_dataset.id]
+        assert [result.id for result in whitespace_results] == expected_default_order
+        assert [result.id for result in punctuation_results] == expected_default_order
+        assert {result.id for result in stop_word_results} == set(expected_default_order)
+
     @staticmethod
     def get_dataset(dataset: Dataset) -> Dataset:
         return test_session.get(
@@ -170,4 +224,20 @@ class TestDatasetsService:
             dataset.id,
             options=[selectinload(Dataset.data_product_links)],
             populate_existing=True,
+        )
+
+    @staticmethod
+    def set_search_state(*datasets: Dataset) -> None:
+        for dataset in datasets:
+            dataset.embeddings = SEARCH_EMBEDDING
+            OutputPortService._recalculate_search_vector(dataset)
+            test_session.add(dataset)
+        test_session.commit()
+
+    @staticmethod
+    def search_with_static_embeddings(query: str, user, limit: int):
+        service = OutputPortService(test_session)
+        service.embedding_model = StaticEmbeddingModel()
+        return service.search_output_ports(
+            query=query, limit=limit, user=user, current_user_assigned=False
         )

--- a/backend/tests/app/data_products/output_ports/test_service.py
+++ b/backend/tests/app/data_products/output_ports/test_service.py
@@ -202,6 +202,73 @@ class TestDatasetsService:
 
         assert [result.id for result in results] == [clinical_dataset.id]
 
+    def test_search_output_ports_preserves_or_operator(self):
+        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        finance_dataset = DatasetFactory(
+            name="Finance Ledger", description="Accounting metrics"
+        )
+        budget_dataset = DatasetFactory(
+            name="Budget Forecast", description="Planning metrics"
+        )
+        unrelated_dataset = DatasetFactory(
+            name="Telemetry Events", description="Device metrics"
+        )
+        self.set_search_state(finance_dataset, budget_dataset, unrelated_dataset)
+
+        results = self.search_with_static_embeddings(
+            "finance OR budget", user, limit=2
+        )
+
+        assert {result.id for result in results} == {
+            finance_dataset.id,
+            budget_dataset.id,
+        }
+
+    def test_search_output_ports_preserves_exclusion_operator(self):
+        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        excluded_dataset = DatasetFactory(
+            name="Finance Budget", description="Restricted budget planning"
+        )
+        matching_dataset = DatasetFactory(
+            name="Finance Forecast", description="Revenue planning"
+        )
+        unrelated_dataset = DatasetFactory(
+            name="Marketing Leads", description="Pipeline metrics"
+        )
+        self.set_search_state(excluded_dataset, matching_dataset, unrelated_dataset)
+
+        results = self.search_with_static_embeddings("finance -budget", user, limit=1)
+
+        assert [result.id for result in results] == [matching_dataset.id]
+
+    def test_search_output_ports_preserves_quoted_phrase_operator(self):
+        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        reversed_dataset = DatasetFactory(
+            name="Alpha Data Customer", description="Reversed word order"
+        )
+        phrase_dataset = DatasetFactory(
+            name="Zulu Customer Data", description="Customer data mart"
+        )
+        self.set_search_state(reversed_dataset, phrase_dataset)
+
+        results = self.search_with_static_embeddings('"customer data"', user, limit=1)
+
+        assert [result.id for result in results] == [phrase_dataset.id]
+
+    def test_search_output_ports_preserves_accented_unicode_terms(self):
+        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        unrelated_dataset = DatasetFactory(
+            name="Aachen Mobility", description="Regional transport metrics"
+        )
+        unicode_dataset = DatasetFactory(
+            name="München Mobility", description="Regional transport metrics"
+        )
+        self.set_search_state(unrelated_dataset, unicode_dataset)
+
+        results = self.search_with_static_embeddings("München", user, limit=1)
+
+        assert [result.id for result in results] == [unicode_dataset.id]
+
     def test_search_output_ports_handles_empty_punctuation_and_stop_word_queries(self):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         alpha_dataset = DatasetFactory(name="Alpha Dataset")


### PR DESCRIPTION
## Summary

Output-port search now matches on partial/prefix terms, so typing part of a name or description returns the relevant results instead of requiring a full-word match. Documented web-search operators (`OR`, quoted phrases, leading `-` for exclusion) and Unicode/accented terms keep working.

## Why this matters

Issue #2273 reports that output-port search only matched whole words, so a partial term like `fin` did not surface `finance`. The fix adds prefix matching, but naively rebuilding the tsquery would have regressed two documented behaviors: web-search operators (`finance OR budget`, `foo -bar`, quoted phrases) and non-Latin/accented queries.

This keeps `websearch_to_tsquery` for operator semantics and OR-s a prefix `tsquery` (derived from the parsed query) on top, so `foo` prefix-matches `foobar` while `a OR b` and `foo -bar` retain their meaning. Ranking is gated behind `@@` so excluded terms do not still receive a keyword score. The ASCII-only tokenizer was removed so terms like `München` and `データ` are preserved as Postgres lexemes.

## Testing

`pytest tests/app/data_products/output_ports/test_service.py` — 16 passed, with new coverage for prefix matching, an `OR` query, a `-term` exclusion, a quoted phrase, and an accented Unicode term. `ruff check` clean on the changed files.

Fixes #2273

- [x] Update the release notes document if needed (backend search bugfix; no user-facing release note needed)
- [x] When updating the UI please provide screenshots (N/A — backend-only change)
- [x] Updated sample data so the new feature can be easily tested (N/A — covered by unit tests)
