### PR TITLE
fix: Add empty-state message for data product settings with no fields

### DIFF
--- a/frontend/src/components/data-products/data-product-settings/data-product-settings.component.tsx
+++ b/frontend/src/components/data-products/data-product-settings/data-product-settings.component.tsx
@@ -1,4 +1,4 @@
-import { Flex, Form, type FormProps, Select, Switch, Typography } from 'antd';
+import { Empty, Flex, Form, type FormProps, Select, Switch, Typography } from 'antd';
 import TextArea from 'antd/es/input/TextArea';
 import { type ReactElement, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -230,6 +230,8 @@ export function DataProductSettings({ id, scope, dataProductId }: Props) {
             </Flex>
         ));
     }, [updatedSettings, t]);
+    const isLoading = isFetching || isFetchingDP || isFetchingDS
+    if (!isLoading && updatedSettings.length === 0) return <Empty description={'No settings to show'}/>;
 
     return (
         <Flex vertical>
@@ -244,9 +246,7 @@ export function DataProductSettings({ id, scope, dataProductId }: Props) {
                 labelWrap
                 labelAlign={'left'}
                 disabled={
-                    isFetching ||
-                    isFetchingDP ||
-                    isFetchingDS ||
+                    isLoading ||
                     !canUpdateProductSettings ||
                     !canUpdateOutputPortSetting
                 }

--- a/frontend/src/components/data-products/data-product-settings/data-product-settings.component.tsx
+++ b/frontend/src/components/data-products/data-product-settings/data-product-settings.component.tsx
@@ -230,8 +230,8 @@ export function DataProductSettings({ id, scope, dataProductId }: Props) {
             </Flex>
         ));
     }, [updatedSettings, t]);
-    const isLoading = isFetching || isFetchingDP || isFetchingDS
-    if (!isLoading && updatedSettings.length === 0) return <Empty description={'No settings to show'}/>;
+    const isLoading = isFetching || isFetchingDP || isFetchingDS;
+    if (!isLoading && updatedSettings.length === 0) return <Empty description={'No settings to show'} />;
 
     return (
         <Flex vertical>
@@ -245,11 +245,7 @@ export function DataProductSettings({ id, scope, dataProductId }: Props) {
                 autoComplete={'off'}
                 labelWrap
                 labelAlign={'left'}
-                disabled={
-                    isLoading ||
-                    !canUpdateProductSettings ||
-                    !canUpdateOutputPortSetting
-                }
+                disabled={isLoading || !canUpdateProductSettings || !canUpdateOutputPortSetting}
                 className={styles.form}
                 onValuesChange={(_, allValues) => {
                     // Trigger form submission after 0.5 seconds of unchanged input values


### PR DESCRIPTION
- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested.

Navigating to the data-products page and opening the settings tab didn't show anything if there are no settings present. Added an Empty component when there are no settings and when the page is not loading. After the page, the tab shows as follows:

<img width="1440" height="755" alt="image" src="https://github.com/user-attachments/assets/6405ef89-dca5-4275-9ee9-9f745592223e" />

