### PR TITLE
fix: stop refetching a deleted output port during tag invalidation (404)

### DIFF
--- a/frontend/src/store/api/services/tags/dataProductsOutputPortsTags.test.ts
+++ b/frontend/src/store/api/services/tags/dataProductsOutputPortsTags.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { STATIC_TAG_ID, TagTypes } from '@/store/api/services/tag-types.ts';
+import { dataProductOutputPortTags } from '@/store/api/services/tags/dataProductsOutputPortsTags.ts';
+
+describe('dataProductOutputPortTags invalidation', () => {
+    const args = { dataProductId: 'dp1', id: 'op1' };
+
+    it('removeOutputPort does not invalidate the deleted port per-id tag (regression guard for 404)', () => {
+        const tags = dataProductOutputPortTags.removeOutputPort.invalidatesTags(undefined, undefined, args);
+
+        expect(tags).not.toContainEqual({ type: TagTypes.OutputPort, id: 'op1' });
+    });
+
+    it('removeOutputPort still invalidates the list and parent tags so the deletion is reflected', () => {
+        const tags = dataProductOutputPortTags.removeOutputPort.invalidatesTags(undefined, undefined, args);
+
+        expect(tags).toContainEqual({ type: TagTypes.OutputPort, id: STATIC_TAG_ID.LIST });
+        expect(tags).toContainEqual({ type: TagTypes.DataProductOutputPorts, id: 'dp1' });
+    });
+
+    it('updateOutputPort still invalidates the per-id tag so the entity refetches', () => {
+        const tags = dataProductOutputPortTags.updateOutputPort.invalidatesTags(undefined, undefined, args);
+
+        expect(tags).toContainEqual({ type: TagTypes.OutputPort, id: 'op1' });
+    });
+});

--- a/frontend/src/store/api/services/tags/dataProductsOutputPortsTags.ts
+++ b/frontend/src/store/api/services/tags/dataProductsOutputPortsTags.ts
@@ -26,6 +26,29 @@ const invalidateOutputPort = (
     },
 ];
 
+// Delete deliberately omits the per-id { OutputPort, id } tag: a still-mounted
+// getOutputPort subscription provides that exact tag, so invalidating it would
+// trigger an eager refetch of the just-deleted port and return a 404. The LIST
+// and parent tags still refresh so the deleted row disappears from listings.
+const invalidateDeletedOutputPort = (
+    _: unknown,
+    __: unknown,
+    { dataProductId, id }: { dataProductId: string; id: string },
+) => [
+    {
+        type: TagTypes.OutputPort as const,
+        id: STATIC_TAG_ID.LIST,
+    },
+    {
+        type: TagTypes.DataProductOutputPorts as const,
+        id: dataProductId,
+    },
+    {
+        type: TagTypes.History as const,
+        id: id,
+    },
+];
+
 export const dataProductOutputPortTags = {
     getDataProductOutputPorts: {
         providesTags: (_, __, id) => [
@@ -59,7 +82,7 @@ export const dataProductOutputPortTags = {
         ],
     },
     removeOutputPort: {
-        invalidatesTags: invalidateOutputPort,
+        invalidatesTags: invalidateDeletedOutputPort,
     },
     updateOutputPort: {
         invalidatesTags: invalidateOutputPort,


### PR DESCRIPTION
## Summary

Deleting an output port no longer triggers a spurious 404. On delete, the cache invalidation now refreshes only the list and parent tags instead of the deleted port's per-id tag.

## Why this matters

Fixes #3057. The `removeOutputPort` mutation reused the shared `invalidateOutputPort` helper, which invalidates the individual `{ type: OutputPort, id }` cache tag. A still-mounted `getOutputPort` subscription provides that exact tag, so RTK Query eagerly refetches `getOutputPort` for the id that was just deleted, and the backend returns 404.

This change adds an `invalidateDeletedOutputPort` variant that omits the per-id `OutputPort` tag and keeps the list-level (`OutputPort` / `LIST`), parent (`DataProductOutputPorts`), and `History` tags. Only `removeOutputPort` is wired to it; `updateOutputPort`, `updateOutputPortAbout`, `updateOutputPortStatus`, and `setValueForOutputPort` keep the original helper so they still refetch the entity. The `LIST` invalidation still refreshes the port list so the deleted row disappears, while dropping only the per-id tag stops the doomed refetch.

## Testing

- Added a vitest unit test on the pure `invalidatesTags` config: `removeOutputPort` no longer includes `{ OutputPort, id }`, still includes `{ OutputPort, LIST }` and `{ DataProductOutputPorts, dataProductId }`, and `updateOutputPort` still includes `{ OutputPort, id }`.
- `npm run typecheck` and `biome check` pass on the changed files.

## Checklist

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md). (not needed: internal bug fix, no user-facing feature)
- [x] When updating the UI please provide screenshots or videos to the reviewers. (no UI changes: cache-invalidation config only)
- [x] Updated sample data so the new feature can be easily tested. (not applicable: no schema or data changes)

Fixes #3057
