### PR TITLE
Switch the helm service to cluster IP

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -85,7 +85,7 @@ securityContext:
   runAsUser: 1000
 
 service:
-  type: NodePort
+  type: ClusterIP
   port: 5050
 
 ingress:


### PR DESCRIPTION
There is no reason for it to be a nodeport
type. It's not used by the ingress controllers
for example, and it's bad practice because a nodeport suddenly opens up the service on every node making it less secure

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested.
