### PR TITLE
Feature/3574 timebound access docs

### DIFF
--- a/docs/docs/concepts/input-ports.md
+++ b/docs/docs/concepts/input-ports.md
@@ -21,6 +21,10 @@ what is the justification for accessing this data, for what period of time, who 
 
 Input Ports allow tracking the consumers of a certain **[Output Port](./output-ports)**.
 By listing all the consuming Input Ports, an Output Port owner can easily track the usage of their assets.
-The owner of the data always stays in control, and can revoke access by unlinking an Input Port connected to their Output Port.
+The owner of the data always stays in control, and can **revoke** a consumer's access at any time.
+
+Access can be granted **permanently** or **time-bound** (valid for a limited number of days), depending on the portal's [Access Duration Policy](./output-ports#access-duration-policy) for the consuming type and what the requester asked for.
+A time-bound grant goes through a lifecycle: requested, then approved or denied, and — once approved — either renewed before it lapses, revoked, or left to expire.
+Every request, renewal, approval, denial and revocation is kept as history on the Input Port, so nothing is silently overwritten.
 
 ---

--- a/docs/docs/concepts/output-ports.md
+++ b/docs/docs/concepts/output-ports.md
@@ -24,6 +24,14 @@ An Output Port might contain:
 - Access to Output Ports must be **requested and approved**.
 - Approvals go through the owner of the Output Port.
 - Once access is granted, the Output Port gets registered as an Input Port of the consuming Data Product.
+- Access can be **permanent** or **time-bound**; a time-bound grant expires automatically after a set number of days unless the consumer renews it.
+- The Output Port owner can **revoke** a consumer's access at any time, even before it expires.
+
+### Access Duration Policy
+
+Portal admins configure the default access duration per consumer type (Data Products vs. Explorations) under **Settings → Access Duration Settings**: whether access defaults to permanent or time-bound, the default number of days, and whether requesters are allowed to ask for the alternative duration type instead.
+
+The "expiring soon" warning shown to consumers before a time-bound grant lapses defaults to 14 days out, and can be changed via the `EXPIRING_SOON_THRESHOLD_DAYS` environment variable.
 
 ## Quality Control
 

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -10,6 +10,7 @@ sidebar_position: 200
 
 - **[Input port]**: Input ports now contain a decision note, which can be used by the reviewer of an access request to show why they denied or approved access
 - **[Product studio]**: A My Requests page has been added to Product Studio, which shows all access requests you have made and their status. This allows you to track your access requests in one place.
+- **[General]**: Timebound access has been added to the product studio for both data products and explorations.
 
 ## 0.6.1
 

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -10,7 +10,7 @@ sidebar_position: 200
 
 - **[Input port]**: Input ports now contain a decision note, which can be used by the reviewer of an access request to show why they denied or approved access
 - **[Product studio]**: A My Requests page has been added to Product Studio, which shows all access requests you have made and their status. This allows you to track your access requests in one place.
-- **[General]**: Timebound access has been added to the product studio for both data products and explorations.
+- **[General]**: [Timebound access](./concepts/input-ports.md) has been added to the product studio for both data products and explorations.
 
 ## 0.6.1
 

--- a/docs/docs/user-guide/creating-products.md
+++ b/docs/docs/user-guide/creating-products.md
@@ -117,6 +117,16 @@ For more information about input ports, take a look at the concept page describi
 
 ![Linking an Output port to an Input port](./img/linking-output-input-port.png)
 
+## Managing access over time
+
+Once an Input Port is approved, access may be **permanent** or **time-bound**, depending on the Output Port owner's [Access Duration Policy](../concepts/output-ports.md#access-duration-policy).
+
+- **Expiring soon**: When a time-bound grant is nearing its end, the Input Port shows an **Expiring soon** tag and a **Renew Access** button. Renewing submits a fresh request without losing the history of the current grant.
+- **Cancel Request**: Withdraws a request you made that is still pending a decision.
+- **Revoke Access**: Ends an active grant immediately. Either you (the consumer) or the Output Port owner can revoke access at any time.
+
+If a time-bound grant lapses without being renewed, access ends automatically and you'll need to request or renew it to continue consuming the data.
+
 ## Conclusion
 
 Congratulations :tada:! you succeeded in creating your first Data Product and made it discoverable and consumable through:


### PR DESCRIPTION
## What
Feature: document the timebound access flow for input/output ports.

## Why
Supersedes #3928, which was accidentally branched off `feature/3574-timebound-access-background-task` instead of `main`, so its diff dragged in that whole branch's commits. This branch is cherry-picked cleanly onto `main` with just the docs commit.

## Changes
- Document renewal/expiry behavior for input ports
- Document access duration behavior for output ports
- Add release note entry
- Document creating products with timebound access