### PR TITLE
fix: Compare admin expiry in UTC instead of server clock

### DIFF
--- a/backend/app/core/authz/background_tasks.py
+++ b/backend/app/core/authz/background_tasks.py
@@ -1,6 +1,8 @@
 import asyncio
+from datetime import datetime, timezone
 
-from sqlalchemy import func, select
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from app.core.authz.authorization import Authorization
 from app.core.logging import logger
@@ -10,30 +12,32 @@ from app.users.model import User as UserModel
 CHECK_INTERVAL_SECONDS = 60  # run every minute
 
 
-async def check_expired_admins() -> None:
+async def revoke_expired_admins(db: Session) -> None:
     authorizer = Authorization()
+    expired = (
+        db.execute(
+            select(UserModel)
+            .where(UserModel.admin_expiry.isnot(None))
+            .where(UserModel.admin_expiry <= datetime.now(timezone.utc))
+        )
+        .scalars()
+        .all()
+    )
+
+    if expired:
+        for user in expired:
+            authorizer.revoke_admin_role(user_id=user.id)
+            user.admin_expiry = None  # clear expiry
+
+        db.commit()
+        logger.info(f"[Auth] Revoked {len(expired)} expired admin role(s)")
+
+
+async def check_expired_admins() -> None:
     while True:
         try:
             with SessionLocal() as db:
-                # query admin roles with expiry in the past
-                expired = (
-                    db.execute(
-                        select(UserModel)
-                        .where(UserModel.admin_expiry.isnot(None))
-                        .where(UserModel.admin_expiry <= func.now())
-                    )
-                    .scalars()
-                    .all()
-                )
-
-                if expired:
-                    for user in expired:
-                        authorizer.revoke_admin_role(user_id=user.id)
-                        user.admin_expiry = None  # clear expiry
-
-                    db.commit()
-                    logger.info(f"[Auth] Revoked {len(expired)} expired admin role(s)")
-
+                await revoke_expired_admins(db)
         except Exception as e:
             # don't crash the loop if something fails
             logger.warning(f"[Auth] Expiry check failed: {e}")

--- a/backend/app/core/webhooks/webhook.py
+++ b/backend/app/core/webhooks/webhook.py
@@ -16,6 +16,7 @@ async def call_webhook(
     content: str, method: str, url: str, query: str, status_code: int
 ) -> None:
     webhook_url = settings.WEBHOOK_URL
+    logger.warning("Using deprecated webhook v1, please switch to v2")
     try:
         async with httpx.AsyncClient() as client:
             message = {
@@ -39,7 +40,11 @@ async def call_webhook(
 
             resp = await client.post(webhook_url, json=message, headers=headers)
             if resp.status_code != 200:
-                logger.warning(f"Failed to send notification to {webhook_url}")
+                logger.warning(f"Response received {webhook_url}")
+                logger.warning(
+                    f"Failed to send notification to {webhook_url} \n response: {resp.text} \n Message sent: {message} \n Headers: {headers}"
+                )
+
     except Exception as e:
         logger.warning(f"Failed to send notification to {webhook_url}", e)
 

--- a/backend/tests/app/core/authz/test_background_tasks.py
+++ b/backend/tests/app/core/authz/test_background_tasks.py
@@ -1,0 +1,50 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+from app.core.authz.authorization import Authorization
+from app.core.authz.background_tasks import revoke_expired_admins
+from tests import test_session
+from tests.factories import UserFactory
+
+NOW = datetime.now(timezone.utc)
+
+
+class TestRevokeExpiredAdmins:
+    def test_revoke_expired_admins__lapsed_expiry_revokes_role_and_clears_expiry(
+        self, authorizer: Authorization
+    ):
+        user = UserFactory(admin_expiry=NOW - timedelta(days=1))
+        test_session.commit()
+        authorizer.assign_admin_role(user_id=user.id)
+
+        asyncio.run(revoke_expired_admins(test_session))
+
+        test_session.refresh(user)
+        assert authorizer.has_admin_role(user_id=user.id) is False
+        assert user.admin_expiry is None
+
+    def test_revoke_expired_admins__future_expiry_is_untouched(
+        self, authorizer: Authorization
+    ):
+        user = UserFactory(admin_expiry=NOW + timedelta(days=1))
+        test_session.commit()
+        authorizer.assign_admin_role(user_id=user.id)
+
+        asyncio.run(revoke_expired_admins(test_session))
+
+        test_session.refresh(user)
+        assert authorizer.has_admin_role(user_id=user.id) is True
+        assert user.admin_expiry is not None
+
+    def test_revoke_expired_admins__no_expiry_is_ignored(
+        self, authorizer: Authorization
+    ):
+        user = UserFactory(admin_expiry=None)
+        test_session.commit()
+        authorizer.assign_admin_role(user_id=user.id)
+
+        asyncio.run(revoke_expired_admins(test_session))
+
+        test_session.refresh(user)
+        assert authorizer.has_admin_role(user_id=user.id) is True
+        assert user.admin_expiry is None

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -12,6 +12,9 @@ sidebar_position: 200
 - **[Product studio]**: A My Requests page has been added to Product Studio, which shows all access requests you have made and their status. This allows you to track your access requests in one place.
 - **[General]**: [Timebound access](./concepts/input-ports.md) has been added to the product studio for both data products and explorations.
 
+### bugfixes
+- **[Temporary Admin]**: Fixed a bug where temporary admin rights were expired directly after it was set due to timezone differences in the backend.
+
 ## 0.6.1
 
 ### features


### PR DESCRIPTION
  check_expired_admins compared admin_expiry against func.now(),
  which resolves to the database server's session time zone rather
  than a guaranteed UTC value. Comparing against a Python UTC
  datetime instead removes that ambiguity.

  Split the loop from its single-pass logic (revoke_expired_admins)
  so the expiry check can run in isolation, matching the pattern
  already used by expire_input_ports/expire_input_ports_task. Added
  unit tests covering lapsed, future, and unset expiry.

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested.
