### PR TITLE
Ordering is wrong for docs release

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,10 @@ To prepare a new release follow these steps, use the next minor or patch version
 - Create a new branch from main called `chore/version_bump_036`
 - If you do a patch version bump: run `task bump-version -- 0.3.6` in root.
 - If you do a minor / major version bump:
-    - Immediately after you have created your tag and released the major version:
     - Run (where Y is minor version e.g. if updating to v0.5.0 run this for 0.5.x) `task bump-docs -- 0.Y.x` in root. *DO NOT REPLACE x in this case.*
 
 - PRs will be created automatically, add important changes manually to the [Changelog](docs/docs/release-notes.md).
-- Merge the version bump to main when approved.
+- Merge the version bump (and optional doc) PRs to main when approved.
 - Test out the current version of main locally
 - To actually execute the release: checkout main branch (and pull), run `git tag v0.3.6` and `git push --tags`.
 


### PR DESCRIPTION
- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested.

I believe the ordering of release steps and versioning of docs is currently wrong. Reasoning with AI below.
The current README instruction is incorrect for minor/major releases.

The problem: bump-docs -- 0.7.x runs docusaurus:version which snapshots the current docs into versioned_docs/version-0.7.x/. When you then push the v0.7.0 tag, the CI/CD builds and deploys the docs — but if bump-docs hasn't been merged yet, that versioned snapshot isn't in the build. The 0.7.0 release docs ship without a frozen 0.7.x entry.

Running it after the tag means the snapshot only makes it into the docs site if you manually redeploy later (or wait for the next release).

Correct order for a minor/major release (e.g. 0.7.0):

task bump-version -- 0.7.0 → creates PR, merge it
task bump-docs -- 0.7.x → creates PR, merge it
Test main locally
git tag v0.7.0 && git push --tags ← tag now includes the versioned snapshot

0.7.1 (patch): No docs versioning step. The frozen 0.7.x snapshot from when 0.7.0 was released stays as-is. The x label intentionally covers all 0.7.* patches — the assumption is patches don't have doc-breaking changes. So 0.7.x is pinned to the state at 0.7.0 release, and that's correct by design.

0.8.0 (minor): Run task bump-docs -- 0.8.x before tagging. This snapshots the current docs into a new frozen 0.8.x entry. The previous 0.7.x remains untouched.

So the versioned docs map is:

Docs version	Covers releases
0.7.x	0.7.0, 0.7.1, 0.7.2, …
0.8.x	0.8.0, 0.8.1, …
This is the standard Docusaurus model and it's correct. The current README is only wrong in the ordering — it says run bump-docs after the tag, when it must be before.