### PR TITLE
Added access mode to technical asset

### DIFF
--- a/backend/app/abstract_data_product/input_ports/model.py
+++ b/backend/app/abstract_data_product/input_ports/model.py
@@ -28,6 +28,7 @@ from app.shared.model import BaseORM, utcnow
 if TYPE_CHECKING:
     from app.abstract_data_product.model import AbstractDataProduct
     from app.data_products.output_ports.model import OutputPort
+    from app.data_products.technical_assets.model import TechnicalAssetAccessMode
     from app.users.model import User
 
 
@@ -198,6 +199,7 @@ class InputPortRequest(
     )
     justification: Mapped[str] = mapped_column(Text)
     decision_note: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    access_mode_name: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     access_duration_type: Mapped[AccessDurationType] = mapped_column(
         Enum(AccessDurationType, native_enum=False),
         default=AccessDurationType.PERMANENT,
@@ -245,3 +247,21 @@ class InputPortRequest(
         foreign_keys=[revoked_by_id],
         lazy="joined",
     )
+
+    @property
+    def access_mode(self) -> Optional["TechnicalAssetAccessMode"]:
+        if not self.access_mode_name:
+            return None
+        am = next(
+            (
+                am
+                for am in self.input_port.output_port.access_modes
+                if am.name == self.access_mode_name
+            ),
+            None,
+        )
+        if am is None:
+            raise ValueError(
+                f"Access mode '{self.access_mode_name}' not found for input port '{self.input_port.id}'"
+            )
+        return am

--- a/backend/app/abstract_data_product/service.py
+++ b/backend/app/abstract_data_product/service.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from datetime import datetime
-from typing import Sequence
+from typing import Optional, Sequence
 
 import pytz
 from fastapi import BackgroundTasks, HTTPException, status
@@ -111,6 +111,7 @@ class AbstractDataProductService:
         output_port: OutputPortModel,
         input_port: InputPortModel,
         justification: str,
+        access_mode_name: Optional[str] = None,
         *,
         actor: User,
     ) -> InputPortModel:
@@ -122,6 +123,7 @@ class AbstractDataProductService:
             access_duration_type=access_duration.access_duration_type,
             requested_duration_days=access_duration.days,
             input_port=input_port,
+            access_mode_name=access_mode_name,
         )
         self.db.add(request)
         self.db.flush()
@@ -153,6 +155,7 @@ class AbstractDataProductService:
         adp: AbstractDataProduct,
         output_port_id: UUID,
         justification: str,
+        access_mode_name: Optional[str] = None,
         *,
         actor: User,
     ) -> InputPortModel:
@@ -162,8 +165,10 @@ class AbstractDataProductService:
             options=[
                 selectinload(OutputPortModel.data_product_links)
                 .selectinload(InputPortModel.consuming_abstract_data_product)
-                .selectinload(AbstractDataProduct.input_ports)
+                .selectinload(AbstractDataProduct.input_ports),
+                selectinload(OutputPortModel.data_output_links),
             ],
+            populate_existing=True,
         )
         self._ensure_not_deleting(adp)
         self._ensure_not_deleting(output_port.data_product)
@@ -183,12 +188,31 @@ class AbstractDataProductService:
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="You do not have access to this private output port",
             )
+        if output_port.access_modes and not access_mode_name:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Can not request access to this output port without specifying an access mode",
+            )
+        if access_mode_name and access_mode_name not in [
+            op.name for op in output_port.access_modes
+        ]:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="The specified access mode does not exist",
+            )
 
         input_port = InputPortModel(
             output_port_id=output_port_id,
             consuming_abstract_data_product=adp,
         )
-        self._create_request(adp, output_port, input_port, justification, actor=actor)
+        self._create_request(
+            adp,
+            output_port,
+            input_port,
+            justification,
+            access_mode_name=access_mode_name,
+            actor=actor,
+        )
         adp.input_ports.append(input_port)
         return input_port
 
@@ -240,8 +264,14 @@ class AbstractDataProductService:
             )
 
         justification = existing.latest_request.justification
+        access_mode_name = existing.latest_request.access_mode_name
         return self._create_request(
-            adp, output_port, existing, justification, actor=actor
+            adp,
+            output_port,
+            existing,
+            justification,
+            actor=actor,
+            access_mode_name=access_mode_name,
         )
 
     def _get_adp_with_input_ports(self, id: UUID) -> AbstractDataProduct:
@@ -267,12 +297,19 @@ class AbstractDataProductService:
         id: UUID,
         output_port_ids: list[UUID],
         justification: str,
+        access_mode_name: Optional[str] = None,
         *,
         actor: User,
     ) -> list[InputPortModel]:
         adp = self._get_adp_with_input_ports(id)
         input_ports = [
-            self._add_single_input_port(adp, output_port_id, justification, actor=actor)
+            self._add_single_input_port(
+                adp,
+                output_port_id,
+                justification,
+                access_mode_name=access_mode_name,
+                actor=actor,
+            )
             for output_port_id in output_port_ids
         ]
         self.db.flush()

--- a/backend/app/data_products/output_port_technical_assets_link/router.py
+++ b/backend/app/data_products/output_port_technical_assets_link/router.py
@@ -32,15 +32,14 @@ from app.events.service import EventService
 from app.users.notifications.service import NotificationService
 from app.users.schema import User
 
-router = APIRouter(tags=["Data Products - Technical assets"])
-
-route = (
-    "/v2/data_products/{data_product_id}/output_ports/{output_port_id}/technical_assets"
+router = APIRouter(
+    tags=["Data Products - Technical assets"],
+    prefix="/v2/data_products/{data_product_id}/output_ports/{output_port_id}/technical_assets",
 )
 
 
 @router.post(
-    f"{route}/approve_link_request",
+    "/approve_link_request",
     dependencies=[
         Depends(
             Authorization.enforce(
@@ -82,7 +81,7 @@ def approve_output_port_technical_asset_link(
 
 
 @router.post(
-    f"{route}/deny_link_request",
+    "/deny_link_request",
     dependencies=[
         Depends(
             Authorization.enforce(
@@ -125,7 +124,7 @@ def deny_output_port_technical_asset_link(
 
 
 @router.post(
-    f"{route}/add",
+    "/add",
     responses={
         404: {
             "description": "Data Product not found",
@@ -177,7 +176,7 @@ def link_output_port_to_technical_asset(
     other_approvers = [a for a in approvers if a != authenticated_user]
     if other_approvers:
         background_tasks.add_task(
-            email.send_link_dataset_email(
+            email.send_link_output_port_email(
                 dataset_link.output_port,
                 dataset_link.data_output,
                 requester=deepcopy(authenticated_user),
@@ -188,7 +187,7 @@ def link_output_port_to_technical_asset(
 
 
 @router.delete(
-    f"{route}/remove",
+    "/remove",
     responses={
         404: {
             "description": "Data Product not found",

--- a/backend/app/data_products/output_port_technical_assets_link/schema_response.py
+++ b/backend/app/data_products/output_port_technical_assets_link/schema_response.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from typing import Optional
 from uuid import UUID
-from warnings import deprecated
 
 from pydantic import Field
 
@@ -19,15 +18,7 @@ class OwnedTechnicalAsset(TechnicalAssetBaseSchema):
     owner: DataProduct
 
 
-@deprecated("Use OwnedTechnicalAsset instead")
-class DataOutput(TechnicalAssetBaseSchema):
-    owner: DataProduct
-
-    def convert(self) -> OwnedTechnicalAsset:
-        return OwnedTechnicalAsset(**self.model_dump())
-
-
-class BaseTechnicalAssetOutputPortAssociationGet(ORMModel):
+class TechnicalAssetOutputPortAssociationsGet(ORMModel):
     id: UUID
     output_port_id: UUID = Field(validation_alias="output_port_id")
     output_port: OutputPort = Field(validation_alias="output_port")
@@ -41,12 +32,6 @@ class BaseTechnicalAssetOutputPortAssociationGet(ORMModel):
     requested_by: User
     denied_by: Optional[User]
     approved_by: Optional[User]
-
-
-class TechnicalAssetOutputPortAssociationsGet(
-    BaseTechnicalAssetOutputPortAssociationGet
-):
-    pass
 
 
 class LinkTechnicalAssetsToOutputPortResponse(ORMModel):

--- a/backend/app/data_products/output_ports/model.py
+++ b/backend/app/data_products/output_ports/model.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from app.configuration.data_product_lifecycles.model import DataProductLifecycle
     from app.configuration.data_product_settings.model import DataProductSettingValue
     from app.data_products.model import DataProduct
+    from app.data_products.technical_assets.model import TechnicalAssetAccessMode
 
 
 class OutputPort(Base, BaseORM, EventTrackedMixin):
@@ -86,7 +87,7 @@ class OutputPort(Base, BaseORM, EventTrackedMixin):
         lazy="raise",
     )
     tags: Mapped[list[Tag]] = relationship(
-        secondary=tag_dataset_table, back_populates="datasets", lazy="joined"
+        secondary=tag_dataset_table, back_populates="datasets", lazy="selectin"
     )
     data_product_settings: Mapped[list["DataProductSettingValue"]] = relationship(
         "DataProductSettingValue",
@@ -116,6 +117,12 @@ class OutputPort(Base, BaseORM, EventTrackedMixin):
     @property
     def data_product_name(self) -> str:
         return self.data_product.name
+
+    @property
+    def access_modes(self) -> list["TechnicalAssetAccessMode"]:
+        if not self.data_output_links:
+            return []
+        return self.data_output_links[0].data_output.access_modes
 
     abstract_data_product_count = deferred(
         column_property(

--- a/backend/app/data_products/output_ports/router.py
+++ b/backend/app/data_products/output_ports/router.py
@@ -116,7 +116,7 @@ def get_output_port(
     db: Session = Depends(get_db_session),
     user: User = Depends(get_authenticated_user),
 ):
-    return OutputPortService(db).get_visible_output_port(id, user, data_product_id)
+    return OutputPortService(db).get_output_port(id, user, data_product_id)
 
 
 @router.get(f"{route}/{{id}}/history")

--- a/backend/app/data_products/output_ports/schema_response.py
+++ b/backend/app/data_products/output_ports/schema_response.py
@@ -13,11 +13,13 @@ from app.configuration.tags.schema import Tag
 from app.data_products.output_port_technical_assets_link.schema import (
     TechnicalAssetOutputPortAssociation,
 )
-from app.data_products.output_ports.data_quality.enums import DataQualityStatus
 from app.data_products.output_ports.enums import OutputPortAccessType
 from app.data_products.output_ports.schema import OutputPort
 from app.data_products.output_ports.status import OutputPortStatus
-from app.data_products.technical_assets.schema import TechnicalAsset
+from app.data_products.technical_assets.schema import (
+    TechnicalAsset,
+    TechnicalAssetAccessMode,
+)
 from app.shared.schema import ORMModel
 
 
@@ -55,19 +57,13 @@ class BaseOutputPortGet(ORMModel):
 
 class GetOutputPortResponse(BaseOutputPortGet):
     about: Optional[str]
+    access_modes: list[TechnicalAssetAccessMode]
 
     rolled_up_tags: set[Tag]
     data_product_settings: list[OutputPortSettingValue]
     technical_asset_links: list[TechnicalAssetLink] = Field(
         validation_alias="data_output_links"
     )
-
-
-class OutputPortsGet(BaseOutputPortGet):
-    abstract_data_product_count: int
-    technical_assets_count: int
-    data_product_name: str
-    quality_status: Optional[DataQualityStatus]
 
 
 class GetDataProductOutputPortsResponse(ORMModel):

--- a/backend/app/data_products/output_ports/service.py
+++ b/backend/app/data_products/output_ports/service.py
@@ -94,49 +94,11 @@ class OutputPortService:
                 detail=f"Data product '{dp.name}' is pending deletion and cannot be modified",
             )
 
-    def get_dataset(
-        self, id: UUID, data_product_id: Optional[UUID] = None
-    ) -> OutputPortModel:
-        """DB fetch with all required eager loads, lifecycle defaulting, and tag roll-up.
-
-        Does not enforce any visibility policy — callers decide whether to gate on user.
-        """
-        query = select(OutputPortModel).where(OutputPortModel.id == id)
-
-        if data_product_id is not None:
-            query = query.where(OutputPortModel.data_product_id == data_product_id)
-
-        output_port = self.db.scalar(
-            query.options(
-                selectinload(OutputPortModel.data_output_links),
-                selectinload(OutputPortModel.data_product_settings),
-            )
-        )
-
-        if not output_port:
-            raise self.not_found_exception(id)
-
-        rolled_up_tags = set()
-        for output_link in output_port.data_output_links:
-            rolled_up_tags.update(output_link.data_output.tags)
-
-        output_port.rolled_up_tags = rolled_up_tags
-
-        if not output_port.lifecycle:
-            default_lifecycle = self.db.scalar(
-                select(DataProductLifeCycleModel).where(
-                    DataProductLifeCycleModel.is_default
-                )
-            )
-            output_port.lifecycle = default_lifecycle
-        output_port.domain = output_port.data_product.domain
-        return output_port
-
     def get_access_durations(
         self, id: UUID, user: UserModel, data_product_id: Optional[UUID] = None
     ) -> GetOutputPortAccessDurationsResponse:
 
-        dataset = self.get_visible_output_port(id, user, data_product_id)
+        dataset = self.get_output_port(id, user, data_product_id)
 
         time_bound_days: dict[AbstractDataProductType, int] = {
             row.abstract_data_product_type: row.days
@@ -175,23 +137,44 @@ class OutputPortService:
             else time_bound_days.get(product_type, -1),
         )
 
-    def get_visible_output_port(
+    def get_output_port(
         self, id: UUID, user: UserModel, data_product_id: Optional[UUID] = None
     ) -> OutputPortModel:
-        """Fetch a dataset, raising 403 if the user cannot see it as a consumer.
+        query = select(OutputPortModel).where(OutputPortModel.id == id)
 
-        Use this for endpoints where dataset visibility must be enforced.
+        if data_product_id is not None:
+            query = query.where(OutputPortModel.data_product_id == data_product_id)
 
-        For system/internal callers already authorised at the endpoint level, use
-        get_dataset() instead.
-        """
-        dataset = self.get_dataset(id, data_product_id)
-        if not self.is_visible_to_user(dataset, user):
+        output_port = self.db.scalar(
+            query.options(
+                selectinload(OutputPortModel.data_output_links),
+                selectinload(OutputPortModel.data_product_settings),
+            )
+        )
+
+        if not output_port:
+            raise self.not_found_exception(id)
+
+        rolled_up_tags = set()
+        for output_link in output_port.data_output_links:
+            rolled_up_tags.update(output_link.data_output.tags)
+
+        output_port.rolled_up_tags = rolled_up_tags
+
+        if not output_port.lifecycle:
+            default_lifecycle = self.db.scalar(
+                select(DataProductLifeCycleModel).where(
+                    DataProductLifeCycleModel.is_default
+                )
+            )
+            output_port.lifecycle = default_lifecycle
+        output_port.domain = output_port.data_product.domain
+        if not self.is_visible_to_user(output_port, user):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="You do not have access to this private dataset",
             )
-        return dataset
+        return output_port
 
     def search_output_ports(
         self,

--- a/backend/app/data_products/schema_response.py
+++ b/backend/app/data_products/schema_response.py
@@ -10,13 +10,7 @@ from app.configuration.data_product_settings.schema import DataProductSettingVal
 from app.configuration.data_product_types.schema import DataProductType
 from app.configuration.domains.schema import Domain
 from app.configuration.tags.schema import Tag
-from app.data_products.output_port_technical_assets_link.schema_response import (
-    BaseTechnicalAssetOutputPortAssociationGet,
-)
 from app.data_products.status import AbstractDataProductStatus
-from app.data_products.technical_assets.schema_response import (
-    BaseTechnicalAssetGet,
-)
 from app.shared.schema import ORMModel
 
 
@@ -33,10 +27,6 @@ class BaseDataProductGet(ORMModel):
     domain: Domain
     type: DataProductType
     lifecycle: Optional[DataProductLifeCycle]
-
-
-class TechnicalAssetLinks(BaseTechnicalAssetGet):
-    output_port_links: list[BaseTechnicalAssetOutputPortAssociationGet]
 
 
 class GetDataProductResponse(BaseDataProductGet):

--- a/backend/app/data_products/technical_assets/email.py
+++ b/backend/app/data_products/technical_assets/email.py
@@ -10,7 +10,7 @@ from app.settings import settings
 from app.users.schema import User
 
 
-def send_link_dataset_email(
+def send_link_output_port_email(
     output_port: OutputPort,
     data_output: TechnicalAsset,
     *,

--- a/backend/app/data_products/technical_assets/model.py
+++ b/backend/app/data_products/technical_assets/model.py
@@ -27,6 +27,16 @@ from app.database.database import Base, ensure_exists
 from app.shared.model import BaseORM
 
 
+class TechnicalAssetAccessMode(Base, BaseORM):
+    __tablename__ = "technical_asset_access_modes"
+
+    technical_asset_id = Column(
+        UUID(as_uuid=True), ForeignKey("data_outputs.id"), primary_key=True
+    )
+    name = Column(String, primary_key=True)
+    description = Column(String, nullable=True)
+
+
 class TechnicalAsset(Base, BaseORM, EventTrackedMixin):
     __tablename__ = "data_outputs"
 
@@ -57,7 +67,7 @@ class TechnicalAsset(Base, BaseORM, EventTrackedMixin):
         lazy="raise",
     )
     tags: Mapped[list[Tag]] = relationship(
-        secondary=tag_data_output_table, back_populates="data_outputs", lazy="joined"
+        secondary=tag_data_output_table, back_populates="data_outputs", lazy="selectin"
     )
 
     environment_configurations: Mapped[
@@ -69,6 +79,12 @@ class TechnicalAsset(Base, BaseORM, EventTrackedMixin):
         ),
         lazy="raise",
         viewonly=True,
+    )
+    access_modes: Mapped[list["TechnicalAssetAccessMode"]] = relationship(
+        "TechnicalAssetAccessMode",
+        foreign_keys="TechnicalAssetAccessMode.technical_asset_id",
+        order_by="TechnicalAssetAccessMode.name",
+        lazy="selectin",
     )
 
     def to_event(self) -> TechnicalAssetEvent:

--- a/backend/app/data_products/technical_assets/router.py
+++ b/backend/app/data_products/technical_assets/router.py
@@ -35,35 +35,36 @@ from app.graph.graph import Graph
 from app.users.notifications.service import NotificationService
 from app.users.schema import User
 
-route = "/v2/data_products/{data_product_id}/technical_assets"
+router = APIRouter(
+    tags=["Data Products - Technical assets"],
+    prefix="/v2/data_products/{data_product_id}/technical_assets",
+)
 
-router = APIRouter(tags=["Data Products - Technical assets"])
 
-
-@router.get(route)
+@router.get("/")
 def get_data_product_technical_assets(
     data_product_id: UUID, db: Session = Depends(get_db_session)
 ) -> GetTechnicalAssetsResponse:
     return GetTechnicalAssetsResponse(
         technical_assets=[
             GetTechnicalAssetsResponseItem.model_validate(do)
-            for do in DataOutputService(db).get_data_outputs_for_data_product(
+            for do in DataOutputService(db).get_technical_assets_for_data_product(
                 data_product_id
             )
         ]
     )
 
 
-@router.get(f"{route}/{{id}}")
+@router.get("/{id}")
 def get_technical_asset(
     data_product_id: UUID, id: UUID, db: Session = Depends(get_db_session)
 ) -> GetTechnicalAssetsResponseItem:
     return GetTechnicalAssetsResponseItem.model_validate(
-        DataOutputService(db).get_data_output(data_product_id, id)
+        DataOutputService(db).get_technical_asset(data_product_id, id)
     )
 
 
-@router.get(f"{route}/{{id}}/history")
+@router.get("/{id}/history")
 def get_technical_asset_event_history(
     data_product_id: UUID, id: UUID, db: Session = Depends(get_db_session)
 ) -> GetEventHistoryResponse:
@@ -79,7 +80,7 @@ def get_technical_asset_event_history(
 
 
 @router.delete(
-    f"{route}/{{id}}",
+    "/{id}",
     responses={
         404: {
             "description": "Technical asset not found",
@@ -124,7 +125,7 @@ def remove_technical_asset(
 
 
 @router.put(
-    f"{route}/{{id}}",
+    "/{id}",
     responses={
         404: {
             "description": "Technical asset not found",
@@ -164,7 +165,7 @@ def update_technical_asset(
 
 
 @router.put(
-    f"{route}/{{id}}/status",
+    "/{id}/status",
     responses={
         404: {
             "description": "Data Output not found",
@@ -202,7 +203,7 @@ def update_technical_asset_status(
     )
 
 
-@router.get(f"{route}/{{id}}/graph")
+@router.get("/{id}/graph")
 def get_technical_asset_graph_data(
     data_product_id: UUID,
     id: UUID,
@@ -213,7 +214,7 @@ def get_technical_asset_graph_data(
 
 
 @router.post(
-    route,
+    "/",
     responses={
         200: {
             "description": "Technical asset successfully created",
@@ -240,7 +241,7 @@ def create_technical_asset(
     db: Session = Depends(get_db_session),
     authenticated_user: User = Depends(get_authenticated_user),
 ) -> CreateTechnicalAssetResponse:
-    technical_asset = DataOutputService(db).create_data_output(
+    technical_asset = DataOutputService(db).create_technical_asset(
         data_product_id, technical_asset
     )
     event_id = EventService(db).create_event(

--- a/backend/app/data_products/technical_assets/schema.py
+++ b/backend/app/data_products/technical_assets/schema.py
@@ -1,6 +1,9 @@
 from uuid import UUID
 
 from app.data_products.technical_assets.enums import TechnicalMapping
+from app.data_products.technical_assets.model import (
+    TechnicalAssetAccessMode as TechnicalAssetAccessModeModel,
+)
 from app.data_products.technical_assets.status import TechnicalAssetStatus
 from app.shared.schema import ORMModel
 from app.technical_asset_configuration.schema_union import DataOutputConfiguration
@@ -18,3 +21,11 @@ class TechnicalAsset(ORMModel):
     service_id: UUID
 
     configuration: DataOutputConfiguration
+
+
+class TechnicalAssetAccessMode(ORMModel):
+    name: str
+    description: str
+
+    class Meta:
+        orm_model = TechnicalAssetAccessModeModel

--- a/backend/app/data_products/technical_assets/schema_request.py
+++ b/backend/app/data_products/technical_assets/schema_request.py
@@ -4,6 +4,7 @@ from warnings import deprecated, warn
 from pydantic import Field, model_validator
 
 from app.data_products.technical_assets.enums import TechnicalMapping
+from app.data_products.technical_assets.schema import TechnicalAssetAccessMode
 from app.data_products.technical_assets.status import TechnicalAssetStatus
 from app.shared.schema import ORMModel
 from app.technical_asset_configuration.schema_union import DataOutputConfiguration
@@ -25,6 +26,7 @@ class CreateTechnicalAssetRequest(ORMModel):
     technical_mapping: TechnicalMapping | None = Field(
         default=None,
     )
+    access_modes: list[TechnicalAssetAccessMode] = Field(default=[])
     tag_ids: list[UUID]
 
     @model_validator(mode="after")

--- a/backend/app/data_products/technical_assets/schema_response.py
+++ b/backend/app/data_products/technical_assets/schema_response.py
@@ -14,6 +14,7 @@ from app.data_products.output_port_technical_assets_link.schema import (
 from app.data_products.output_ports.schema import OutputPort
 from app.data_products.schema import DataProduct
 from app.data_products.technical_assets.enums import TechnicalMapping
+from app.data_products.technical_assets.schema import TechnicalAssetAccessMode
 from app.data_products.technical_assets.status import TechnicalAssetStatus
 from app.shared.schema import ORMModel
 from app.technical_asset_configuration.schema_union import DataOutputConfiguration
@@ -46,7 +47,11 @@ def compute_technical_info(
     return result
 
 
-class BaseTechnicalAssetGet(ORMModel):
+class OutputPortLink(TechnicalAssetOutputPortAssociation):
+    output_port: OutputPort
+
+
+class GetTechnicalAssetsResponseItem(ORMModel):
     id: UUID
     name: str
     description: str
@@ -56,6 +61,7 @@ class BaseTechnicalAssetGet(ORMModel):
     service_id: UUID
     status: TechnicalAssetStatus
     technical_mapping: TechnicalMapping
+    access_modes: list[TechnicalAssetAccessMode]
 
     configuration: DataOutputConfiguration
     owner: DataProduct
@@ -81,12 +87,6 @@ class BaseTechnicalAssetGet(ORMModel):
             self.configuration, self.service, self.environment_configurations
         )
 
-
-class OutputPortLink(TechnicalAssetOutputPortAssociation):
-    output_port: OutputPort
-
-
-class GetTechnicalAssetsResponseItem(BaseTechnicalAssetGet):
     output_port_links: list[OutputPortLink] = Field(validation_alias="dataset_links")
     tags: list[Tag]
 

--- a/backend/app/data_products/technical_assets/service.py
+++ b/backend/app/data_products/technical_assets/service.py
@@ -76,8 +76,10 @@ class DataOutputService:
             .all()
         )
 
-    def get_data_output(self, data_product_id: UUID, id: UUID) -> TechnicalAssetModel:
-        data_output = self.db.scalar(
+    def get_technical_asset(
+        self, data_product_id: UUID, id: UUID
+    ) -> TechnicalAssetModel:
+        technical_asset = self.db.scalar(
             (
                 select(TechnicalAssetModel)
                 .where(TechnicalAssetModel.id == id)
@@ -87,19 +89,19 @@ class DataOutputService:
                 selectinload(TechnicalAssetModel.environment_configurations),
             )
         )
-        if not data_output:
+        if not technical_asset:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Technical asset not found",
             )
-        return data_output
+        return technical_asset
 
-    def create_data_output(
-        self, id: UUID, data_output: CreateTechnicalAssetRequest
+    def create_technical_asset(
+        self, id: UUID, technical_asset: CreateTechnicalAssetRequest
     ) -> TechnicalAssetModel:
         if (
             validity := self.namespace_validator.validate_namespace(
-                data_output.namespace, self.db, id
+                technical_asset.namespace, self.db, id
             ).validity
         ) != ResourceNameValidityType.VALID:
             raise HTTPException(
@@ -107,15 +109,15 @@ class DataOutputService:
                 detail=f"Invalid namespace: {validity.value}",
             )
 
-        if data_output.technical_mapping == TechnicalMapping.Default:
+        if technical_asset.technical_mapping == TechnicalMapping.Default:
             data_product = self.db.get(DataProductModel, id)
-            data_output.configuration.validate_configuration(data_product, self.db)
+            technical_asset.configuration.validate_configuration(data_product, self.db)
 
-        data_output_schema = data_output.parse_pydantic_schema()
+        data_output_schema = technical_asset.parse_pydantic_schema()
         tags = self._get_tags(data_output_schema.pop("tag_ids", []))
         data_output_schema.pop("sourceAligned")  # Remove deprecated field
 
-        technical_asset_status = self.get_status_for(data_output.technical_mapping)  # type: ignore[arg-type]
+        technical_asset_status = self.get_status_for(technical_asset.technical_mapping)  # type: ignore[arg-type]
         model = TechnicalAssetModel(
             **data_output_schema,
             tags=tags,
@@ -142,7 +144,7 @@ class DataOutputService:
     def get_data_output_with_links(
         self, data_product_id: UUID, id: UUID
     ) -> TechnicalAssetModel:
-        data_output: TechnicalAssetModel | None = self.get_data_output(
+        data_output: TechnicalAssetModel | None = self.get_technical_asset(
             data_product_id, id
         )
         if not data_output:
@@ -180,47 +182,61 @@ class DataOutputService:
         *,
         actor: User,
     ) -> DataOutputDatasetAssociationModel:
-        dataset = ensure_output_port_exists(
+        output_port = ensure_output_port_exists(
             output_port_id,
             self.db,
             data_product_id=data_product_id,
-            options=[selectinload(OutputPortModel.data_product_links)],
+            options=[
+                selectinload(OutputPortModel.data_product_links),
+                selectinload(OutputPortModel.data_output_links).selectinload(
+                    DataOutputDatasetAssociationModel.data_output
+                ),
+            ],
         )
-        data_output = self.get_data_output(data_product_id, id)
-        if data_output.status != TechnicalAssetStatus.ACTIVE:
+        technical_asset = self.get_technical_asset(data_product_id, id)
+        if technical_asset.status != TechnicalAssetStatus.ACTIVE:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Cannot link technical asset that is not active",
             )
 
-        if dataset.id in [
+        if output_port.id in [
             link.output_port_id
-            for link in data_output.dataset_links
+            for link in technical_asset.dataset_links
             if link.status != DecisionStatus.DENIED
         ]:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Dataset {output_port_id} already exists in data product {id}",
+                detail=f"Technical Asset {id} already exists in output port {output_port_id}",
+            )
+        if (
+            technical_asset.access_modes
+            and output_port.access_modes
+            and sorted(output_port.access_modes, key=lambda am: am.name)
+            != sorted(technical_asset.access_modes, key=lambda am: am.name)
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Access modes of technical asset {id} are incompatible with access modes of technical assets already part of output port {output_port_id}",
             )
 
         # Data output requests always need to be approved
-        dataset_link = DataOutputDatasetAssociationModel(
+        output_port_link = DataOutputDatasetAssociationModel(
             output_port_id=output_port_id,
             status=DecisionStatus.PENDING,
             requested_by=actor,
             requested_on=datetime.now(tz=pytz.utc),
         )
-        data_output.dataset_links.append(dataset_link)
+        technical_asset.dataset_links.append(output_port_link)
         self.db.flush()
         OutputPortService(self.db).recalculate_search(output_port_id)
-        self.db.commit()
-        return dataset_link
+        return output_port_link
 
     def unlink_dataset_from_data_output(
         self, data_product_id: UUID, id: UUID, output_port_id: UUID
     ) -> TechnicalAssetModel:
         ensure_output_port_exists(output_port_id, self.db)
-        data_output = self.get_data_output(data_product_id, id)
+        data_output = self.get_technical_asset(data_product_id, id)
 
         data_output_dataset = next(
             (
@@ -272,7 +288,7 @@ class DataOutputService:
 
         return graph
 
-    def get_data_outputs_for_data_product(
+    def get_technical_assets_for_data_product(
         self, data_product_id: UUID
     ) -> Sequence[TechnicalAssetModel]:
         return (

--- a/backend/app/database/alembic/versions/2025_02_28_1505-269e6dbd565c_add_general_settings.py
+++ b/backend/app/database/alembic/versions/2025_02_28_1505-269e6dbd565c_add_general_settings.py
@@ -10,9 +10,8 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy import orm
 
-from app.configuration.theme_settings.model import SETTINGS_ID, ThemeSettings
+from app.configuration.theme_settings.model import SETTINGS_ID
 
 # revision identifiers, used by Alembic.
 revision: str = "269e6dbd565c"
@@ -28,13 +27,14 @@ def upgrade() -> None:
         sa.Column("portal_name", sa.String),
     )
 
-    # Adding initial data
-    bind = op.get_bind()
-    session = orm.Session(bind=bind)
-
-    settings = ThemeSettings(id=SETTINGS_ID, portal_name="Data Product Portal")
-    session.add(settings)
-    session.commit()
+    op.bulk_insert(
+        sa.table(
+            "theme_settings",
+            sa.column("id", sa.Integer),
+            sa.column("portal_name", sa.String),
+        ),
+        [{"id": SETTINGS_ID, "portal_name": "Data Product Portal"}],
+    )
 
 
 def downgrade() -> None:

--- a/backend/app/database/alembic/versions/2026_08_03_0915-b15295e377ac_technical_asset_access_modes.py
+++ b/backend/app/database/alembic/versions/2026_08_03_0915-b15295e377ac_technical_asset_access_modes.py
@@ -1,0 +1,57 @@
+"""technical asset access modes
+
+Revision ID: b15295e377ac
+Revises: c3d8a1f56e42
+Create Date: 2026-08-03 09:15:10.090671
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from app.shared.model import utcnow
+
+# revision identifiers, used by Alembic.
+revision: str = "b15295e377ac"
+down_revision: Union[str, None] = "c3d8a1f56e42"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "technical_asset_access_modes",
+        sa.Column("name", sa.Text(), primary_key=True),
+        sa.Column(
+            "technical_asset_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("data_outputs.id", ondelete="CASCADE"),
+            nullable=False,
+            primary_key=True,
+        ),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column("created_on", sa.DateTime(timezone=False), server_default=utcnow()),
+        sa.Column("updated_on", sa.DateTime(timezone=False), onupdate=utcnow()),
+    )
+    op.create_index(
+        "ix_technical_asset_access_modes_technical_asset_id",
+        "technical_asset_access_modes",
+        ["technical_asset_id"],
+        unique=False,
+    )
+    op.add_column(
+        "input_port_requests",
+        sa.Column("access_mode_name", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_technical_asset_access_modes_technical_asset_id",
+        table_name="technical_asset_access_modes",
+    )
+    op.drop_table("technical_asset_access_modes")
+    op.drop_column("input_port_requests", "access_mode_name")

--- a/backend/app/mcp/config.py
+++ b/backend/app/mcp/config.py
@@ -10,7 +10,7 @@ from app.configuration.domains.schema_response import GetDomainsItem
 from app.configuration.domains.service import DomainService
 from app.configuration.environments.schema_response import EnvironmentGetItem
 from app.configuration.environments.service import EnvironmentService
-from app.data_products.output_ports.schema_response import OutputPortsGet
+from app.data_products.output_ports.schema import OutputPort
 from app.data_products.output_ports.service import OutputPortService
 from app.data_products.schema_response import (
     GetDataProductResponse,
@@ -141,8 +141,7 @@ def register_config_tools(mcp) -> None:
                 "output_ports_count": len(output_ports),
                 "technical_assets_count": len(related_technical_assets),
                 "output_ports": [
-                    OutputPortsGet.model_validate(ds).model_dump()
-                    for ds in output_ports
+                    OutputPort.model_validate(ds).model_dump() for ds in output_ports
                 ],
                 "technical_assets": [
                     GetTechnicalAssetsResponseItem.model_validate(do).model_dump()

--- a/backend/app/mcp/details.py
+++ b/backend/app/mcp/details.py
@@ -36,9 +36,7 @@ def get_output_port_details(
     db: Session = Depends(get_db_session),
     user: UserModel = Depends(get_mcp_authenticated_user),
 ) -> dict[str, Any]:
-    dataset = OutputPortService(db).get_visible_output_port(
-        id=UUID(output_port_id), user=user
-    )
+    dataset = OutputPortService(db).get_output_port(id=UUID(output_port_id), user=user)
     return GetOutputPortResponse.model_validate(dataset).model_dump()
 
 
@@ -47,7 +45,7 @@ def get_technical_asset_details(
     db: Session = Depends(get_db_session),
 ) -> dict[str, Any]:
     do = ensure_technical_asset_exists(UUID(technical_asset_id), db=db)
-    data_output = DataOutputService(db).get_data_output(
+    data_output = DataOutputService(db).get_technical_asset(
         do.owner_id,
         id=UUID(technical_asset_id),
     )

--- a/backend/app/mcp/resources.py
+++ b/backend/app/mcp/resources.py
@@ -56,7 +56,7 @@ def register_resources(mcp) -> None:
         db: Session = Depends(get_db_session),
         user: UserModel = Depends(get_mcp_authenticated_user),
     ) -> str:
-        output_port = OutputPortService(db).get_visible_output_port(
+        output_port = OutputPortService(db).get_output_port(
             id=UUID(output_port_id), user=user
         )
 

--- a/backend/app/search_output_ports/schema_response.py
+++ b/backend/app/search_output_ports/schema_response.py
@@ -1,11 +1,13 @@
 from typing import Sequence
 
-from app.data_products.output_ports.schema_response import OutputPortsGet
+from app.data_products.output_ports.schema_response import BaseOutputPortGet
 from app.shared.schema import ORMModel
 
 
-class SearchOutputPortsResponseItem(OutputPortsGet):
-    pass
+class SearchOutputPortsResponseItem(BaseOutputPortGet):
+    abstract_data_product_count: int
+    technical_assets_count: int
+    data_product_name: str
 
 
 class SearchOutputPortsResponse(ORMModel):

--- a/backend/app/technical_asset_configuration/glue/mcp_tools.py
+++ b/backend/app/technical_asset_configuration/glue/mcp_tools.py
@@ -176,7 +176,9 @@ def register_tools(mcp: FastMCP) -> None:
         """
         asset_uuid = UUID(technical_asset_id)
         do = ensure_technical_asset_exists(asset_uuid, db=db)
-        data_output = DataOutputService(db).get_data_output(do.owner_id, id=asset_uuid)
+        data_output = DataOutputService(db).get_technical_asset(
+            do.owner_id, id=asset_uuid
+        )
 
         configuration: DataOutputConfiguration = data_output.configuration  # type: ignore[assignment]
         if not isinstance(configuration, GlueTechnicalAssetConfigurationModel):

--- a/backend/tests/app/abstract_data_product/test_request_input_ports.py
+++ b/backend/tests/app/abstract_data_product/test_request_input_ports.py
@@ -22,6 +22,9 @@ from tests.factories import (
     ExplorationFactory,
     InputPortFactory,
     OutputPortFactory,
+    TechnicalAssetAccessModeFactory,
+    TechnicalAssetFactory,
+    TechnicalAssetOutputPortAssociationFactory,
     UserFactory,
 )
 
@@ -39,7 +42,9 @@ def _request_for(input_port):
 
 
 class TestRequestInputPortsDuration:
-    def test_request_input_ports__time_bound_data_product_port_sets_window(self):
+    def test_request_input_ports__time_bound_data_product_port_sets_window(
+        self, session
+    ):
         actor = UserFactory()
         dp = DataProductFactory()
         port = OutputPortFactory(
@@ -130,6 +135,72 @@ class TestRequestInputPortsDuration:
             )
         assert exc.value.status_code == 400
         assert len(_requests_for(link.id)) == 1
+
+    def test_request_input_ports__access_mode(self):
+        actor = UserFactory()
+        dp = DataProductFactory()
+        port = OutputPortFactory(
+            access_type=OutputPortAccessType.UNRESTRICTED,
+        )
+        TechnicalAssetOutputPortAssociationFactory(
+            data_output=TechnicalAssetFactory(
+                access_modes=[TechnicalAssetAccessModeFactory(name="a name")]
+            ),
+            output_port=port,
+        )
+
+        [ip] = AbstractDataProductService(test_session).request_input_ports(
+            dp.id,
+            [port.id],
+            "need access",
+            actor=actor,
+            access_mode_name="a name",
+        )
+        assert ip.latest_request.access_mode_name == "a name"
+
+    def test_request_input_ports__access_mode_required(self):
+        actor = UserFactory()
+        dp = DataProductFactory()
+        port = OutputPortFactory(
+            access_type=OutputPortAccessType.UNRESTRICTED,
+        )
+        TechnicalAssetOutputPortAssociationFactory(
+            data_output=TechnicalAssetFactory(
+                access_modes=[TechnicalAssetAccessModeFactory(name="a name")]
+            ),
+            output_port=port,
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            AbstractDataProductService(test_session).request_input_ports(
+                dp.id, [port.id], "need access", actor=actor
+            )
+
+        assert exc.value.status_code == 400
+
+    def test_request_input_ports__access_mode_does_not_exist(self):
+        actor = UserFactory()
+        dp = DataProductFactory()
+        port = OutputPortFactory(
+            access_type=OutputPortAccessType.UNRESTRICTED,
+        )
+        TechnicalAssetOutputPortAssociationFactory(
+            data_output=TechnicalAssetFactory(
+                access_modes=[TechnicalAssetAccessModeFactory(name="a name")]
+            ),
+            output_port=port,
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            AbstractDataProductService(test_session).request_input_ports(
+                dp.id,
+                [port.id],
+                "need access",
+                actor=actor,
+                access_mode_name="bla",
+            )
+
+        assert exc.value.status_code == 400
 
     def _restricted_time_bound_port(self):
         port = OutputPortFactory(
@@ -251,6 +322,38 @@ class TestRequestInputPortsDuration:
                 dp.id, port.id, actor=actor
             )
         assert exc.value.status_code == 404
+
+    def test_renew_input_port__access_mode(self):
+        actor = UserFactory()
+        dp = DataProductFactory()
+        port = OutputPortFactory(
+            access_type=OutputPortAccessType.UNRESTRICTED,
+        )
+        TechnicalAssetOutputPortAssociationFactory(
+            data_output=TechnicalAssetFactory(
+                access_modes=[TechnicalAssetAccessModeFactory(name="a mode")]
+            ),
+            output_port=port,
+        )
+        link = InputPortFactory(
+            consuming_abstract_data_product=dp,
+            output_port=port,
+            status=DecisionStatus.APPROVED,
+            request__access_duration_type=AccessDurationType.TIME_BOUND,
+            request__requested_duration_days=30,
+            request__valid_until=date.today() + timedelta(days=10),
+            request__access_mode_name="a mode",
+        )
+
+        ip = AbstractDataProductService(test_session).renew_input_port(
+            dp.id, port.id, actor=actor
+        )
+
+        assert ip.id == link.id
+        reqs = _requests_for(link.id)
+        assert len(reqs) == 2
+        for req in reqs:
+            assert req.access_mode_name == "a mode"
 
     def test_revoke_input_port__revokes_the_active_grant(self):
         actor = UserFactory()

--- a/backend/tests/app/data_products/output_port_technical_assets_link/test_router.py
+++ b/backend/tests/app/data_products/output_port_technical_assets_link/test_router.py
@@ -17,6 +17,7 @@ from tests.factories import (
     InputPortFactory,
     OutputPortFactory,
     RoleFactory,
+    TechnicalAssetAccessModeFactory,
     TechnicalAssetFactory,
     TechnicalAssetOutputPortAssociationFactory,
     UserFactory,
@@ -31,7 +32,7 @@ DATA_OUTPUTS_DATASETS_ENDPOINT = (
 class TestOutputPortsTechnicalAssetsLinkRouter:
     invalid_id = "00000000-0000-0000-0000-000000000000"
 
-    def test_request_data_output_link(self, client):
+    def test_request_technical_asset_link(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.DATA_PRODUCT,
@@ -42,22 +43,22 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
             user_id=user.id, role_id=role.id, data_product_id=data_product.id
         )
 
-        data_output = TechnicalAssetFactory(owner=data_product)
+        technical_asset = TechnicalAssetFactory(owner=data_product)
         ds = OutputPortFactory(data_product=data_product)
 
-        response = self.request_data_output_dataset_link_new(
-            client, data_product.id, data_output.id, ds.id
+        response = self.request_technical_asset_output_port_link(
+            client, data_product.id, technical_asset.id, ds.id
         )
         assert response.status_code == 200
 
-    def test_request_data_output_link_generates_webhook_v2_event(
+    def test_request_technical_asset_link_generates_webhook_v2_event(
         self, client, mock_webhook
     ):
-        self.test_request_data_output_link(client)
+        self.test_request_technical_asset_link(client)
         assert_event_in_queue("output_port_technical_asset_link.event", mock_webhook)
 
     @pytest.mark.parametrize("enabled", [True, False])
-    def test_request_data_output_link_with_consumers_and_event_sending_active_generates_webhook_v2_event(
+    def test_request_technical_asset_link_with_consumers_and_event_sending_active_generates_webhook_v2_event(
         self, client, mock_webhook, enabled: bool
     ):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
@@ -70,15 +71,15 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
             user_id=user.id, role_id=role.id, data_product_id=data_product.id
         )
 
-        data_output = TechnicalAssetFactory(owner=data_product)
+        technical_asset = TechnicalAssetFactory(owner=data_product)
         ds = OutputPortFactory(data_product=data_product)
         InputPortFactory(output_port=ds)
 
         with webhook_v2_input_port_events_from_technical_asset_output_port_link(
             enabled=enabled
         ):
-            response = self.request_data_output_dataset_link_new(
-                client, data_product.id, data_output.id, ds.id
+            response = self.request_technical_asset_output_port_link(
+                client, data_product.id, technical_asset.id, ds.id
             )
         assert response.status_code == 200
         assert_event_in_queue("output_port_technical_asset_link.event", mock_webhook)
@@ -87,7 +88,7 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
         else:
             assert_event_not_in_queue("input_port.event", mock_webhook)
 
-    def test_request_data_output_new(self, client):
+    def test_request_technical_asset_link_incompatible_access_modes(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.DATA_PRODUCT,
@@ -98,18 +99,29 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
             user_id=user.id, role_id=role.id, data_product_id=data_product.id
         )
 
-        data_output = TechnicalAssetFactory(owner=data_product)
+        technical_asset = TechnicalAssetFactory(
+            owner=data_product,
+            access_modes=[TechnicalAssetAccessModeFactory(name="different")],
+        )
         ds = OutputPortFactory(data_product=data_product)
 
-        response = self.request_data_output_dataset_link_new(
-            client, data_product.id, data_output.id, ds.id
+        TechnicalAssetOutputPortAssociationFactory(
+            data_output=TechnicalAssetFactory(
+                access_modes=[TechnicalAssetAccessModeFactory(name="a name")]
+            ),
+            output_port=ds,
         )
-        assert response.status_code == 200
+
+        response = self.request_technical_asset_output_port_link(
+            client, data_product.id, technical_asset.id, ds.id
+        )
+        assert response.status_code == 400, response.text
+        assert "incompatible" in response.text, response.text
 
     @patch(
-        "app.data_products.output_port_technical_assets_link.router.email.send_link_dataset_email"
+        "app.data_products.output_port_technical_assets_link.router.email.send_link_output_port_email"
     )
-    def test_request_data_output_link_email_not_sent_when_requester_is_only_approver(
+    def test_request_technical_asset_link_email_not_sent_when_requester_is_only_approver(
         self, mock_send_email, client
     ):
         requester = UserFactory(external_id=settings.DEFAULT_USERNAME)
@@ -135,7 +147,7 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
             output_port=output_port,
         )
 
-        response = self.request_data_output_dataset_link_new(
+        response = self.request_technical_asset_output_port_link(
             client, data_product.id, technical_asset.id, output_port.id
         )
 
@@ -143,9 +155,9 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
         mock_send_email.assert_not_called()
 
     @patch(
-        "app.data_products.output_port_technical_assets_link.router.email.send_link_dataset_email"
+        "app.data_products.output_port_technical_assets_link.router.email.send_link_output_port_email"
     )
-    def test_request_data_output_link_email_excludes_requester_from_approvers(
+    def test_request_technical_asset_link_email_excludes_requester_from_approvers(
         self, mock_send_email, client
     ):
         requester = UserFactory(external_id=settings.DEFAULT_USERNAME)
@@ -173,7 +185,7 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
                 output_port=output_port,
             )
 
-        response = self.request_data_output_dataset_link_new(
+        response = self.request_technical_asset_output_port_link(
             client, data_product.id, technical_asset.id, output_port.id
         )
 
@@ -183,7 +195,7 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
         assert {approver.id for approver in approvers} == {other_approver.id}
         assert requester.id not in {approver.id for approver in approvers}
 
-    def test_request_data_output_link_on_dataset_with_diff_parent(self, client):
+    def test_request_technical_asset_link_on_output_port_with_diff_parent(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.DATA_PRODUCT,
@@ -194,11 +206,11 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
             user_id=user.id, role_id=role.id, data_product_id=data_product.id
         )
 
-        data_output = TechnicalAssetFactory(owner=data_product)
+        technical_asset = TechnicalAssetFactory(owner=data_product)
         ds = OutputPortFactory()
 
-        response = self.request_data_output_dataset_link_new(
-            client, data_product.id, data_output.id, ds.id
+        response = self.request_technical_asset_output_port_link(
+            client, data_product.id, technical_asset.id, ds.id
         )
         assert response.status_code == 404
 
@@ -213,32 +225,32 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
             user_id=user.id, role_id=role.id, data_product_id=data_product.id
         )
 
-        data_output = TechnicalAssetFactory(owner=data_product)
+        technical_asset = TechnicalAssetFactory(owner=data_product)
         ds = OutputPortFactory(data_product=data_product)
 
-        response = self.request_data_output_dataset_link_new(
-            client, data_product.id, data_output.id, ds.id
+        response = self.request_technical_asset_output_port_link(
+            client, data_product.id, technical_asset.id, ds.id
         )
         assert response.status_code == 200
-        response = self.request_data_output_dataset_link_new(
-            client, data_product.id, data_output.id, ds.id
+        response = self.request_technical_asset_output_port_link(
+            client, data_product.id, technical_asset.id, ds.id
         )
         assert response.status_code == 400
 
-    def test_request_data_output_link_private_dataset_no_access(self, client):
+    def test_request_technical_asset_link_private_output_port_no_access(self, client):
         data_product = DataProductFactory()
-        data_output = TechnicalAssetFactory(owner=data_product)
+        technical_asset = TechnicalAssetFactory(owner=data_product)
         ds = OutputPortFactory(access_type=OutputPortAccessType.PRIVATE)
 
-        response = self.request_data_output_dataset_link_new(
-            client, data_product.id, data_output.id, ds.id
+        response = self.request_technical_asset_output_port_link(
+            client, data_product.id, technical_asset.id, ds.id
         )
         assert response.status_code == 403
 
-    def test_request_data_output_link_private_dataset(self, client):
+    def test_request_technical_asset_link_private_output_port(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         data_product = DataProductFactory()
-        data_output = TechnicalAssetFactory(owner=data_product)
+        technical_asset = TechnicalAssetFactory(owner=data_product)
         ds = OutputPortFactory(
             access_type=OutputPortAccessType.PRIVATE, data_product=data_product
         )
@@ -249,15 +261,15 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
         DataProductRoleAssignmentFactory(
             user_id=user.id, role_id=role.id, data_product_id=data_product.id
         )
-        response = self.request_data_output_dataset_link_new(
-            client, data_product.id, data_output.id, ds.id
+        response = self.request_technical_asset_output_port_link(
+            client, data_product.id, technical_asset.id, ds.id
         )
         assert response.status_code == 200
 
-    def test_request_data_output_remove(self, client):
+    def test_request_technical_asset_remove(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         data_product = DataProductFactory()
-        data_output = TechnicalAssetFactory(owner=data_product)
+        technical_asset = TechnicalAssetFactory(owner=data_product)
         ds = OutputPortFactory(data_product=data_product)
         role = RoleFactory(
             scope=Scope.DATA_PRODUCT,
@@ -269,21 +281,21 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
         DataProductRoleAssignmentFactory(
             user_id=user.id, role_id=role.id, data_product_id=data_product.id
         )
-        response = self.request_data_output_dataset_link_new(
-            client, data_product.id, data_output.id, ds.id
+        response = self.request_technical_asset_output_port_link(
+            client, data_product.id, technical_asset.id, ds.id
         )
 
         assert response.status_code == 200
 
-        response = self.request_data_output_dataset_unlink_new(
-            client, data_product.id, data_output.id, ds.id
+        response = self.request_technical_asset_output_port_unlink(
+            client, data_product.id, technical_asset.id, ds.id
         )
         assert response.status_code == 200
 
-    def test_request_data_output_remove_new(self, client):
+    def test_request_technical_asset_remove_new(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         data_product = DataProductFactory()
-        data_output = TechnicalAssetFactory(owner=data_product)
+        technical_asset = TechnicalAssetFactory(owner=data_product)
         ds = OutputPortFactory(data_product=data_product)
         role = RoleFactory(
             scope=Scope.DATA_PRODUCT,
@@ -295,30 +307,30 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
         DataProductRoleAssignmentFactory(
             user_id=user.id, role_id=role.id, data_product_id=data_product.id
         )
-        response = self.request_data_output_dataset_link_new(
-            client, data_product.id, data_output.id, ds.id
+        response = self.request_technical_asset_output_port_link(
+            client, data_product.id, technical_asset.id, ds.id
         )
 
         assert response.status_code == 200
 
-        response = self.request_data_output_dataset_unlink_new(
-            client, data_product.id, data_output.id, ds.id
+        response = self.request_technical_asset_output_port_unlink(
+            client, data_product.id, technical_asset.id, ds.id
         )
         assert response.status_code == 200
 
     @pytest.mark.usefixtures("admin")
-    def test_request_data_output_link_by_admin(self, client):
+    def test_request_technical_asset_link_by_admin(self, client):
         data_product = DataProductFactory()
-        data_output = TechnicalAssetFactory(owner=data_product)
+        technical_asset = TechnicalAssetFactory(owner=data_product)
 
         ds = OutputPortFactory(data_product=data_product)
 
-        link = self.request_data_output_dataset_link_new(
-            client, data_product.id, data_output.id, ds.id
+        link = self.request_technical_asset_output_port_link(
+            client, data_product.id, technical_asset.id, ds.id
         )
         assert link.status_code == 200
 
-    def test_approve_data_output_link(self, client):
+    def test_approve_technical_asset_link(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         ds = OutputPortFactory()
         role = RoleFactory(
@@ -357,7 +369,7 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
         assert response.status_code == 200, response.text
 
     @pytest.mark.usefixtures("admin")
-    def test_approve_data_output_link_by_admin(self, client):
+    def test_approve_technical_asset_link_by_admin(self, client):
         ds = OutputPortFactory()
         link = TechnicalAssetOutputPortAssociationFactory(
             output_port=ds, status=DecisionStatus.PENDING
@@ -383,7 +395,7 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
             == "You don't have permission to perform this action"
         )
 
-    def test_deny_data_output_link(self, client):
+    def test_deny_technical_asset_link(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         ds = OutputPortFactory()
         role = RoleFactory(
@@ -421,7 +433,7 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
         assert response.status_code == 200
 
     @pytest.mark.usefixtures("admin")
-    def test_deny_data_output_link_by_admin(self, client):
+    def test_deny_technical_asset_link_by_admin(self, client):
         ds = OutputPortFactory()
         link = TechnicalAssetOutputPortAssociationFactory(
             output_port=ds, status=DecisionStatus.PENDING
@@ -447,7 +459,7 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
             == "You don't have permission to perform this action"
         )
 
-    def test_remove_data_output_link(self, client):
+    def test_remove_technical_asset_link(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         ds = OutputPortFactory()
         role = RoleFactory(
@@ -457,38 +469,38 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
         DataProductRoleAssignmentFactory(
             user_id=user.id, role_id=role.id, data_product_id=ds.data_product.id
         )
-        data_output = TechnicalAssetFactory(owner=ds.data_product)
+        technical_asset = TechnicalAssetFactory(owner=ds.data_product)
         TechnicalAssetOutputPortAssociationFactory(
-            output_port=ds, data_output=data_output
+            output_port=ds, data_output=technical_asset
         )
 
-        response = self.request_data_output_dataset_unlink_new(
-            client, ds.data_product.id, data_output.id, ds.id
+        response = self.request_technical_asset_output_port_unlink(
+            client, ds.data_product.id, technical_asset.id, ds.id
         )
         assert response.status_code == 200, response.text
 
     @pytest.mark.usefixtures("admin")
-    def test_remove_data_output_link_by_admin(self, client):
+    def test_remove_technical_asset_link_by_admin(self, client):
         ds = OutputPortFactory()
-        data_output = TechnicalAssetFactory(owner=ds.data_product)
+        technical_asset = TechnicalAssetFactory(owner=ds.data_product)
         TechnicalAssetOutputPortAssociationFactory(
-            output_port=ds, data_output=data_output
+            output_port=ds, data_output=technical_asset
         )
 
-        response = self.request_data_output_dataset_unlink_new(
-            client, ds.data_product.id, data_output.id, ds.id
+        response = self.request_technical_asset_output_port_unlink(
+            client, ds.data_product.id, technical_asset.id, ds.id
         )
         assert response.status_code == 200
 
-    def test_request_dataset_link_with_invalid_dataset_id(self, client):
+    def test_request_output_port_link_with_invalid_output_port_id(self, client):
         data_product = DataProductFactory()
-        data_output = TechnicalAssetFactory(owner=data_product)
-        response = self.request_data_output_dataset_link_new(
-            client, data_product.id, data_output.id, self.invalid_id
+        technical_asset = TechnicalAssetFactory(owner=data_product)
+        response = self.request_technical_asset_output_port_link(
+            client, data_product.id, technical_asset.id, self.invalid_id
         )
         assert response.status_code == 403
 
-    def test_delete_dataset_with_data_output_link(self, client):
+    def test_delete_output_port_with_technical_asset_link(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         ds = OutputPortFactory()
         role = RoleFactory(
@@ -514,7 +526,7 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
         )
         assert len(response.json()["technical_assets"][0]["output_port_links"]) == 0
 
-    def test_history_event_created_on_request_data_output_link(self, client):
+    def test_history_event_created_on_request_technical_asset_link(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         role = RoleFactory(
             scope=Scope.DATA_PRODUCT,
@@ -525,20 +537,20 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
             user_id=user.id, role_id=role.id, data_product_id=data_product.id
         )
 
-        data_output = TechnicalAssetFactory(owner=data_product)
+        technical_asset = TechnicalAssetFactory(owner=data_product)
         ds = OutputPortFactory(data_product=data_product)
 
-        response = self.request_data_output_dataset_link_new(
-            client, data_product.id, data_output.id, ds.id
+        response = self.request_technical_asset_output_port_link(
+            client, data_product.id, technical_asset.id, ds.id
         )
         assert response.status_code == 200
 
-        history = self.get_data_output_history(
-            client, data_product.id, data_output.id
+        history = self.get_technical_asset_history(
+            client, data_product.id, technical_asset.id
         ).json()
         assert len(history["events"]) == 1
 
-    def test_history_event_created_on_remove_data_output_link(self, client):
+    def test_history_event_created_on_remove_technical_asset_link(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         ds = OutputPortFactory()
         role = RoleFactory(
@@ -555,15 +567,15 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
         owner_id = link.data_output.owner.id
         output_id = link.data_output.id
 
-        response = self.request_data_output_dataset_unlink_new(
+        response = self.request_technical_asset_output_port_unlink(
             client, ds.data_product.id, technical_asset.id, ds.id
         )
         assert response.status_code == 200
 
-        history = self.get_data_output_history(client, owner_id, output_id).json()
+        history = self.get_technical_asset_history(client, owner_id, output_id).json()
         assert len(history["events"]) == 1
 
-    def test_history_event_created_on_approve_data_output_link(self, client):
+    def test_history_event_created_on_approve_technical_asset_link(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         ds = OutputPortFactory()
         role = RoleFactory(
@@ -582,12 +594,12 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
         )
         assert response.status_code == 200
 
-        history = self.get_data_output_history(
+        history = self.get_technical_asset_history(
             client, link.data_output.owner.id, link.data_output.id
         ).json()
         assert len(history["events"]) == 1
 
-    def test_history_event_created_on_deny_data_output_link(self, client):
+    def test_history_event_created_on_deny_technical_asset_link(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         ds = OutputPortFactory()
         role = RoleFactory(
@@ -605,15 +617,15 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
         )
         assert response.status_code == 200
 
-        history = self.get_data_output_history(
+        history = self.get_technical_asset_history(
             client, link.data_output.owner.id, link.data_output.id
         ).json()
         assert len(history["events"]) == 1
 
-    def test_history_event_created_on_unlink_data_output_link(self, client):
+    def test_history_event_created_on_unlink_technical_asset_link(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         data_product = DataProductFactory()
-        data_output = TechnicalAssetFactory(owner=data_product)
+        technical_asset = TechnicalAssetFactory(owner=data_product)
         ds = OutputPortFactory(data_product=data_product)
         role = RoleFactory(
             scope=Scope.DATA_PRODUCT,
@@ -625,24 +637,24 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
         DataProductRoleAssignmentFactory(
             user_id=user.id, role_id=role.id, data_product_id=data_product.id
         )
-        response = self.request_data_output_dataset_link_new(
-            client, data_product.id, data_output.id, ds.id
+        response = self.request_technical_asset_output_port_link(
+            client, data_product.id, technical_asset.id, ds.id
         )
 
         assert response.status_code == 200
 
-        response = self.request_data_output_dataset_unlink_new(
-            client, data_product.id, data_output.id, ds.id
+        response = self.request_technical_asset_output_port_unlink(
+            client, data_product.id, technical_asset.id, ds.id
         )
         assert response.status_code == 200
 
-        history = self.get_data_output_history(
-            client, data_product.id, data_output.id
+        history = self.get_technical_asset_history(
+            client, data_product.id, technical_asset.id
         ).json()
         assert len(history["events"]) == 2
 
     @staticmethod
-    def request_data_output_dataset_link_new(
+    def request_technical_asset_output_port_link(
         client, data_product_id, technical_asset_id, output_port_id
     ):
         return client.post(
@@ -669,7 +681,7 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
         )
 
     @staticmethod
-    def request_data_output_dataset_unlink_new(
+    def request_technical_asset_output_port_unlink(
         client, data_product_id, technical_asset_id, output_port_id
     ):
         return client.request(
@@ -679,7 +691,7 @@ class TestOutputPortsTechnicalAssetsLinkRouter:
         )
 
     @staticmethod
-    def get_data_output_history(client, data_product_id, data_output_id):
+    def get_technical_asset_history(client, data_product_id, technical_asset_id):
         return client.get(
-            f"/api/v2/data_products/{data_product_id}/technical_assets/{data_output_id}/history"
+            f"/api/v2/data_products/{data_product_id}/technical_assets/{technical_asset_id}/history"
         )

--- a/backend/tests/app/data_products/output_ports/test_router.py
+++ b/backend/tests/app/data_products/output_ports/test_router.py
@@ -203,7 +203,7 @@ class TestOutputPortRouter:
         )
         assert created_dataset.status_code == 400
 
-    def test_get_datasets(self, client):
+    def test_get_output_ports(self, client):
         ds = OutputPortFactory()
         response = client.get(ENDPOINT.format(ds.data_product.id))
         assert response.status_code == 200
@@ -378,30 +378,10 @@ class TestOutputPortRouter:
         response = self.get_output_port(client, ds.id, ds.data_product.id)
         assert response.status_code == 404
 
-    def test_get_dataset_with_invalid_dataset_id(self, client):
+    def test_get_output_port_with_invalid_id(self, client):
         dp = DataProductFactory()
         dataset = self.get_output_port(client, dp.id, self.invalid_id)
         assert dataset.status_code == 404
-
-    def test_get_dataset(
-        self,
-        client,
-    ):
-        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
-        role = RoleFactory(
-            scope=Scope.DATASET, permissions=[AuthorizationAction.OUTPUT_PORT__DELETE]
-        )
-        data_product = DataProductFactory()
-        data_output = TechnicalAssetFactory(owner=data_product)
-        ds = OutputPortFactory(data_product=data_product)
-        TechnicalAssetOutputPortAssociationFactory(
-            output_port=ds, data_output=data_output
-        )
-        DatasetRoleAssignmentFactory(
-            user_id=user.id, role_id=role.id, output_port_id=ds.id
-        )
-        dataset = self.get_output_port(client, ds.id, data_product.id)
-        assert dataset.status_code == 200
 
     def test_get_output_port(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)

--- a/backend/tests/app/data_products/technical_assets/test_router.py
+++ b/backend/tests/app/data_products/technical_assets/test_router.py
@@ -81,7 +81,7 @@ def data_output_payload_not_owner():
 class TestTechnicalAssetsRouter:
     invalid_id = "00000000-0000-0000-0000-000000000000"
 
-    def test_create_data_output_source_aligned(
+    def test_create_technical_asset_source_aligned(
         self, data_output_payload, client: TestClient
     ):
         role = RoleFactory(
@@ -94,8 +94,41 @@ class TestTechnicalAssetsRouter:
             data_product_id=data_output_payload["owner_id"],
         )
         created_data_output = self.create_technical_asset(client, data_output_payload)
-        assert created_data_output.status_code == 200
+        assert created_data_output.status_code == 200, created_data_output.text
         assert "id" in created_data_output.json()
+
+    def test_create_technical_asset_with_access_modes(
+        self, data_output_payload, client
+    ):
+        role = RoleFactory(
+            scope=Scope.DATA_PRODUCT,
+            permissions=[Action.DATA_PRODUCT__CREATE_TECHNICAL_ASSET],
+        )
+        DataProductRoleAssignmentFactory(
+            user_id=data_output_payload["user_id"],
+            role_id=role.id,
+            data_product_id=data_output_payload["owner_id"],
+        )
+        data_output_payload["access_modes"] = [
+            {"name": "read", "description": "Read access"},
+            {"name": "write", "description": "Write access"},
+        ]
+
+        created_technical_asset = self.create_technical_asset(
+            client, data_output_payload
+        )
+        assert created_technical_asset.status_code == 200
+
+        technical_asset = self.get_technical_asset(
+            client,
+            data_output_payload["owner_id"],
+            created_technical_asset.json()["id"],
+        )
+        assert technical_asset.status_code == 200, technical_asset.text
+        assert (
+            technical_asset.json()["access_modes"]
+            == data_output_payload["access_modes"]
+        )
 
     def test_create_technical_assert_generates_webhook_v2_event(
         self,
@@ -103,10 +136,10 @@ class TestTechnicalAssetsRouter:
         client: TestClient,
         mock_webhook,
     ):
-        self.test_create_data_output_source_aligned(data_output_payload, client)
+        self.test_create_technical_asset_source_aligned(data_output_payload, client)
         assert_event_in_queue("technical_asset.event", mock_webhook)
 
-    def test_create_data_output_product_aligned(
+    def test_create_technical_asset_product_aligned(
         self, data_output_payload, client: TestClient
     ):
         role = RoleFactory(
@@ -170,7 +203,7 @@ class TestTechnicalAssetsRouter:
             == "custom"
         )
 
-    def test_create_data_output_not_product_owner(
+    def test_create_technical_asset_not_product_owner(
         self, data_output_payload_not_owner, client: TestClient
     ):
         created_data_output = self.create_technical_asset(
@@ -397,7 +430,7 @@ class TestTechnicalAssetsRouter:
         assert response.status_code == 200
         assert body["validity"] == "VALID"
 
-    def test_create_data_output_duplicate_namespace(
+    def test_create_technical_asset_duplicate_namespace(
         self, data_output_payload, client: TestClient
     ):
         role = RoleFactory(
@@ -421,7 +454,7 @@ class TestTechnicalAssetsRouter:
         response = self.create_technical_asset(client, create_payload)
         assert response.status_code == 400
 
-    def test_create_data_output_invalid_characters_namespace(
+    def test_create_technical_asset_invalid_characters_namespace(
         self, data_output_payload, client: TestClient
     ):
         role = RoleFactory(
@@ -439,7 +472,7 @@ class TestTechnicalAssetsRouter:
         response = self.create_technical_asset(client, create_payload)
         assert response.status_code == 400
 
-    def test_create_data_output_invalid_length_namespace(
+    def test_create_technical_asset_invalid_length_namespace(
         self, data_output_payload, client: TestClient
     ):
         role = RoleFactory(
@@ -604,7 +637,7 @@ class TestTechnicalAssetsRouter:
             == data_output_name
         )
 
-    @patch("app.data_products.technical_assets.email.send_link_dataset_email")
+    @patch("app.data_products.technical_assets.email.send_link_output_port_email")
     def test_dataset_link_auto_approval_no_email_sent(
         self, mock_send_email, client: TestClient
     ):
@@ -640,7 +673,7 @@ class TestTechnicalAssetsRouter:
         # Verify no email was sent for auto-approved request
         mock_send_email.assert_not_called()
 
-    @patch("app.data_products.technical_assets.email.send_link_dataset_email")
+    @patch("app.data_products.technical_assets.email.send_link_output_port_email")
     def test_dataset_link_manual_approval_email_sent(
         self, mock_send_email, client: TestClient
     ):

--- a/backend/tests/app/database/test_sql_alchemy_best_practices.py
+++ b/backend/tests/app/database/test_sql_alchemy_best_practices.py
@@ -8,7 +8,7 @@ models = [mapper.class_ for mapper in Base.registry.mappers]
 # The purpose of this list is to ensure we don't have to fix everything all at once
 # We can ignore our tech debt for now and improve it later, but we won't make it worse
 ignore_list = {
-    "TechnicalAsset": ["tags"],
+    "TechnicalAsset": ["tags", "access_modes"],
     "Platform": ["services"],
     "User": ["data_product_roles", "dataset_roles"],
     "OutputPort": ["tags"],

--- a/backend/tests/factories/__init__.py
+++ b/backend/tests/factories/__init__.py
@@ -30,6 +30,7 @@ from .role_assignment_global import GlobalRoleAssignmentFactory
 from .s3_data_output import S3DataOutputFactory
 from .tags import TagFactory
 from .technical_asset import TechnicalAssetFactory
+from .technical_asset_access_mode import TechnicalAssetAccessModeFactory
 from .technical_asset_output_ports import TechnicalAssetOutputPortAssociationFactory
 from .theme_settings import ThemeSettingsFactory
 from .user import UserFactory
@@ -78,6 +79,7 @@ factories = [
     ThemeSettingsFactory,
     NotificationFactory,
     ExplorationFactory,
+    TechnicalAssetAccessModeFactory,
 ]
 
 for factory_model in factories:

--- a/backend/tests/factories/technical_asset_access_mode.py
+++ b/backend/tests/factories/technical_asset_access_mode.py
@@ -1,0 +1,15 @@
+import factory
+
+from app.data_products.technical_assets.model import TechnicalAssetAccessMode
+from tests.factories.technical_asset import TechnicalAssetFactory
+
+
+class TechnicalAssetAccessModeFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = TechnicalAssetAccessMode
+        exclude = ("technical_asset",)
+
+    technical_asset = factory.SubFactory(TechnicalAssetFactory)
+    technical_asset_id = factory.SelfAttribute("technical_asset.id")
+    name = factory.Faker("word")
+    description = factory.Faker("text", max_nb_chars=120)

--- a/cli/golang/pkg/api/oas_client_gen.go
+++ b/cli/golang/pkg/api/oas_client_gen.go
@@ -148,7 +148,7 @@ type Invoker interface {
 	//
 	// Create Technical Asset.
 	//
-	// POST /api/v2/data_products/{data_product_id}/technical_assets
+	// POST /api/v2/data_products/{data_product_id}/technical_assets/
 	CreateTechnicalAsset(ctx context.Context, request *CreateTechnicalAssetRequest, params CreateTechnicalAssetParams) (CreateTechnicalAssetRes, error)
 	// CreateUser invokes create_user operation.
 	//
@@ -280,7 +280,7 @@ type Invoker interface {
 	//
 	// Get Data Product Technical Assets.
 	//
-	// GET /api/v2/data_products/{data_product_id}/technical_assets
+	// GET /api/v2/data_products/{data_product_id}/technical_assets/
 	GetDataProductTechnicalAssets(ctx context.Context, params GetDataProductTechnicalAssetsParams) (GetDataProductTechnicalAssetsRes, error)
 	// GetDataProductType invokes get_data_product_type operation.
 	//
@@ -2199,7 +2199,7 @@ func (c *Client) sendCreateTag(ctx context.Context, request *TagCreate) (res Cre
 //
 // Create Technical Asset.
 //
-// POST /api/v2/data_products/{data_product_id}/technical_assets
+// POST /api/v2/data_products/{data_product_id}/technical_assets/
 func (c *Client) CreateTechnicalAsset(ctx context.Context, request *CreateTechnicalAssetRequest, params CreateTechnicalAssetParams) (CreateTechnicalAssetRes, error) {
 	res, err := c.sendCreateTechnicalAsset(ctx, request, params)
 	return res, err
@@ -2228,7 +2228,7 @@ func (c *Client) sendCreateTechnicalAsset(ctx context.Context, request *CreateTe
 		}
 		pathParts[1] = encoded
 	}
-	pathParts[2] = "/technical_assets"
+	pathParts[2] = "/technical_assets/"
 	uri.AddPathParts(u, pathParts[:]...)
 
 	r, err := ht.NewRequest(ctx, "POST", u)
@@ -3557,7 +3557,7 @@ func (c *Client) sendGetDataProductSettings(ctx context.Context, params GetDataP
 //
 // Get Data Product Technical Assets.
 //
-// GET /api/v2/data_products/{data_product_id}/technical_assets
+// GET /api/v2/data_products/{data_product_id}/technical_assets/
 func (c *Client) GetDataProductTechnicalAssets(ctx context.Context, params GetDataProductTechnicalAssetsParams) (GetDataProductTechnicalAssetsRes, error) {
 	res, err := c.sendGetDataProductTechnicalAssets(ctx, params)
 	return res, err
@@ -3586,7 +3586,7 @@ func (c *Client) sendGetDataProductTechnicalAssets(ctx context.Context, params G
 		}
 		pathParts[1] = encoded
 	}
-	pathParts[2] = "/technical_assets"
+	pathParts[2] = "/technical_assets/"
 	uri.AddPathParts(u, pathParts[:]...)
 
 	r, err := ht.NewRequest(ctx, "GET", u)

--- a/cli/golang/pkg/api/oas_defaults_gen.go
+++ b/cli/golang/pkg/api/oas_defaults_gen.go
@@ -27,6 +27,14 @@ func (s *BitolContractRequest) setDefaults() {
 }
 
 // setDefaults set default value of fields.
+func (s *CreateTechnicalAssetRequest) setDefaults() {
+	{
+		var defaultVal0 []TechnicalAssetAccessMode
+		s.AccessModes = defaultVal0
+	}
+}
+
+// setDefaults set default value of fields.
 func (s *DataProductCreate) setDefaults() {
 	{
 		var defaultVal0 []uuid.UUID

--- a/cli/golang/pkg/api/oas_json_gen.go
+++ b/cli/golang/pkg/api/oas_json_gen.go
@@ -4169,6 +4169,16 @@ func (s *CreateTechnicalAssetRequest) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.AccessModes != nil {
+			e.FieldStart("access_modes")
+			e.ArrStart()
+			for _, elem := range s.AccessModes {
+				elem.Encode(e)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
 		e.FieldStart("tag_ids")
 		e.ArrStart()
 		for _, elem := range s.TagIds {
@@ -4178,7 +4188,7 @@ func (s *CreateTechnicalAssetRequest) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfCreateTechnicalAssetRequest = [9]string{
+var jsonFieldsNameOfCreateTechnicalAssetRequest = [10]string{
 	0: "name",
 	1: "description",
 	2: "namespace",
@@ -4187,7 +4197,8 @@ var jsonFieldsNameOfCreateTechnicalAssetRequest = [9]string{
 	5: "configuration",
 	6: "sourceAligned",
 	7: "technical_mapping",
-	8: "tag_ids",
+	8: "access_modes",
+	9: "tag_ids",
 }
 
 // Decode decodes CreateTechnicalAssetRequest from json.
@@ -4196,6 +4207,7 @@ func (s *CreateTechnicalAssetRequest) Decode(d *jx.Decoder) error {
 		return errors.New("invalid: unable to decode CreateTechnicalAssetRequest to nil")
 	}
 	var requiredBitSet [2]uint8
+	s.setDefaults()
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
@@ -4289,8 +4301,25 @@ func (s *CreateTechnicalAssetRequest) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"technical_mapping\"")
 			}
+		case "access_modes":
+			if err := func() error {
+				s.AccessModes = make([]TechnicalAssetAccessMode, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem TechnicalAssetAccessMode
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.AccessModes = append(s.AccessModes, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"access_modes\"")
+			}
 		case "tag_ids":
-			requiredBitSet[1] |= 1 << 0
+			requiredBitSet[1] |= 1 << 1
 			if err := func() error {
 				s.TagIds = make([]uuid.UUID, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -4320,7 +4349,7 @@ func (s *CreateTechnicalAssetRequest) Decode(d *jx.Decoder) error {
 	var failures []validate.FieldError
 	for i, mask := range [2]uint8{
 		0b00111111,
-		0b00000001,
+		0b00000010,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -15288,6 +15317,14 @@ func (s *GetOutputPortResponse) encodeFields(e *jx.Encoder) {
 		s.About.Encode(e)
 	}
 	{
+		e.FieldStart("access_modes")
+		e.ArrStart()
+		for _, elem := range s.AccessModes {
+			elem.Encode(e)
+		}
+		e.ArrEnd()
+	}
+	{
 		e.FieldStart("rolled_up_tags")
 		e.ArrStart()
 		for _, elem := range s.RolledUpTags {
@@ -15313,7 +15350,7 @@ func (s *GetOutputPortResponse) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfGetOutputPortResponse = [17]string{
+var jsonFieldsNameOfGetOutputPortResponse = [18]string{
 	0:  "id",
 	1:  "namespace",
 	2:  "name",
@@ -15328,9 +15365,10 @@ var jsonFieldsNameOfGetOutputPortResponse = [17]string{
 	11: "domain",
 	12: "lifecycle",
 	13: "about",
-	14: "rolled_up_tags",
-	15: "data_product_settings",
-	16: "technical_asset_links",
+	14: "access_modes",
+	15: "rolled_up_tags",
+	16: "data_product_settings",
+	17: "technical_asset_links",
 }
 
 // Decode decodes GetOutputPortResponse from json.
@@ -15500,8 +15538,26 @@ func (s *GetOutputPortResponse) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"about\"")
 			}
-		case "rolled_up_tags":
+		case "access_modes":
 			requiredBitSet[1] |= 1 << 6
+			if err := func() error {
+				s.AccessModes = make([]TechnicalAssetAccessMode, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem TechnicalAssetAccessMode
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.AccessModes = append(s.AccessModes, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"access_modes\"")
+			}
+		case "rolled_up_tags":
+			requiredBitSet[1] |= 1 << 7
 			if err := func() error {
 				s.RolledUpTags = make([]Tag, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -15519,7 +15575,7 @@ func (s *GetOutputPortResponse) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"rolled_up_tags\"")
 			}
 		case "data_product_settings":
-			requiredBitSet[1] |= 1 << 7
+			requiredBitSet[2] |= 1 << 0
 			if err := func() error {
 				s.DataProductSettings = make([]OutputPortSettingValue, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -15537,7 +15593,7 @@ func (s *GetOutputPortResponse) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"data_product_settings\"")
 			}
 		case "technical_asset_links":
-			requiredBitSet[2] |= 1 << 0
+			requiredBitSet[2] |= 1 << 1
 			if err := func() error {
 				s.TechnicalAssetLinks = make([]TechnicalAssetLink, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -15566,7 +15622,7 @@ func (s *GetOutputPortResponse) Decode(d *jx.Decoder) error {
 	for i, mask := range [3]uint8{
 		0b11111111,
 		0b11111111,
-		0b00000001,
+		0b00000011,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -16060,6 +16116,14 @@ func (s *GetTechnicalAssetsResponseItem) encodeFields(e *jx.Encoder) {
 		s.TechnicalMapping.Encode(e)
 	}
 	{
+		e.FieldStart("access_modes")
+		e.ArrStart()
+		for _, elem := range s.AccessModes {
+			elem.Encode(e)
+		}
+		e.ArrEnd()
+	}
+	{
 		e.FieldStart("configuration")
 		s.Configuration.Encode(e)
 	}
@@ -16101,7 +16165,7 @@ func (s *GetTechnicalAssetsResponseItem) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfGetTechnicalAssetsResponseItem = [16]string{
+var jsonFieldsNameOfGetTechnicalAssetsResponseItem = [17]string{
 	0:  "id",
 	1:  "name",
 	2:  "description",
@@ -16111,13 +16175,14 @@ var jsonFieldsNameOfGetTechnicalAssetsResponseItem = [16]string{
 	6:  "service_id",
 	7:  "status",
 	8:  "technical_mapping",
-	9:  "configuration",
-	10: "owner",
-	11: "output_port_links",
-	12: "tags",
-	13: "sourceAligned",
-	14: "result_string",
-	15: "technical_info",
+	9:  "access_modes",
+	10: "configuration",
+	11: "owner",
+	12: "output_port_links",
+	13: "tags",
+	14: "sourceAligned",
+	15: "result_string",
+	16: "technical_info",
 }
 
 // Decode decodes GetTechnicalAssetsResponseItem from json.
@@ -16125,7 +16190,7 @@ func (s *GetTechnicalAssetsResponseItem) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode GetTechnicalAssetsResponseItem to nil")
 	}
-	var requiredBitSet [2]uint8
+	var requiredBitSet [3]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
@@ -16233,8 +16298,26 @@ func (s *GetTechnicalAssetsResponseItem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"technical_mapping\"")
 			}
-		case "configuration":
+		case "access_modes":
 			requiredBitSet[1] |= 1 << 1
+			if err := func() error {
+				s.AccessModes = make([]TechnicalAssetAccessMode, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem TechnicalAssetAccessMode
+					if err := elem.Decode(d); err != nil {
+						return err
+					}
+					s.AccessModes = append(s.AccessModes, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"access_modes\"")
+			}
+		case "configuration":
+			requiredBitSet[1] |= 1 << 2
 			if err := func() error {
 				if err := s.Configuration.Decode(d); err != nil {
 					return err
@@ -16244,7 +16327,7 @@ func (s *GetTechnicalAssetsResponseItem) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"configuration\"")
 			}
 		case "owner":
-			requiredBitSet[1] |= 1 << 2
+			requiredBitSet[1] |= 1 << 3
 			if err := func() error {
 				if err := s.Owner.Decode(d); err != nil {
 					return err
@@ -16254,7 +16337,7 @@ func (s *GetTechnicalAssetsResponseItem) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"owner\"")
 			}
 		case "output_port_links":
-			requiredBitSet[1] |= 1 << 3
+			requiredBitSet[1] |= 1 << 4
 			if err := func() error {
 				s.OutputPortLinks = make([]OutputPortLink, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -16272,7 +16355,7 @@ func (s *GetTechnicalAssetsResponseItem) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"output_port_links\"")
 			}
 		case "tags":
-			requiredBitSet[1] |= 1 << 4
+			requiredBitSet[1] |= 1 << 5
 			if err := func() error {
 				s.Tags = make([]Tag, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -16290,7 +16373,7 @@ func (s *GetTechnicalAssetsResponseItem) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"tags\"")
 			}
 		case "sourceAligned":
-			requiredBitSet[1] |= 1 << 5
+			requiredBitSet[1] |= 1 << 6
 			if err := func() error {
 				v, err := d.Bool()
 				s.SourceAligned = bool(v)
@@ -16302,7 +16385,7 @@ func (s *GetTechnicalAssetsResponseItem) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"sourceAligned\"")
 			}
 		case "result_string":
-			requiredBitSet[1] |= 1 << 6
+			requiredBitSet[1] |= 1 << 7
 			if err := func() error {
 				v, err := d.Str()
 				s.ResultString = string(v)
@@ -16314,7 +16397,7 @@ func (s *GetTechnicalAssetsResponseItem) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"result_string\"")
 			}
 		case "technical_info":
-			requiredBitSet[1] |= 1 << 7
+			requiredBitSet[2] |= 1 << 0
 			if err := func() error {
 				s.TechnicalInfo = make([]TechnicalInfo, 0)
 				if err := d.Arr(func(d *jx.Decoder) error {
@@ -16340,9 +16423,10 @@ func (s *GetTechnicalAssetsResponseItem) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [2]uint8{
+	for i, mask := range [3]uint8{
 		0b11111111,
 		0b11111111,
+		0b00000001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -19377,50 +19461,6 @@ func (s NilDataProductLifeCycle) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *NilDataProductLifeCycle) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes DataQualityStatus as json.
-func (o NilDataQualityStatus) Encode(e *jx.Encoder) {
-	if o.Null {
-		e.Null()
-		return
-	}
-	e.Str(string(o.Value))
-}
-
-// Decode decodes DataQualityStatus from json.
-func (o *NilDataQualityStatus) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode NilDataQualityStatus to nil")
-	}
-	if d.Next() == jx.Null {
-		if err := d.Null(); err != nil {
-			return err
-		}
-
-		var v DataQualityStatus
-		o.Value = v
-		o.Null = true
-		return nil
-	}
-	o.Null = false
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s NilDataQualityStatus) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *NilDataQualityStatus) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -31176,13 +31216,9 @@ func (s *SearchOutputPortsResponseItem) encodeFields(e *jx.Encoder) {
 		e.FieldStart("data_product_name")
 		e.Str(s.DataProductName)
 	}
-	{
-		e.FieldStart("quality_status")
-		s.QualityStatus.Encode(e)
-	}
 }
 
-var jsonFieldsNameOfSearchOutputPortsResponseItem = [17]string{
+var jsonFieldsNameOfSearchOutputPortsResponseItem = [16]string{
 	0:  "id",
 	1:  "namespace",
 	2:  "name",
@@ -31199,7 +31235,6 @@ var jsonFieldsNameOfSearchOutputPortsResponseItem = [17]string{
 	13: "abstract_data_product_count",
 	14: "technical_assets_count",
 	15: "data_product_name",
-	16: "quality_status",
 }
 
 // Decode decodes SearchOutputPortsResponseItem from json.
@@ -31207,7 +31242,7 @@ func (s *SearchOutputPortsResponseItem) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode SearchOutputPortsResponseItem to nil")
 	}
-	var requiredBitSet [3]uint8
+	var requiredBitSet [2]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
@@ -31395,16 +31430,6 @@ func (s *SearchOutputPortsResponseItem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"data_product_name\"")
 			}
-		case "quality_status":
-			requiredBitSet[2] |= 1 << 0
-			if err := func() error {
-				if err := s.QualityStatus.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"quality_status\"")
-			}
 		default:
 			return d.Skip()
 		}
@@ -31414,10 +31439,9 @@ func (s *SearchOutputPortsResponseItem) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [3]uint8{
+	for i, mask := range [2]uint8{
 		0b11111111,
 		0b11111111,
-		0b00000001,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -32728,6 +32752,119 @@ func (s *TechnicalAsset) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *TechnicalAsset) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *TechnicalAssetAccessMode) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *TechnicalAssetAccessMode) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("name")
+		e.Str(s.Name)
+	}
+	{
+		e.FieldStart("description")
+		e.Str(s.Description)
+	}
+}
+
+var jsonFieldsNameOfTechnicalAssetAccessMode = [2]string{
+	0: "name",
+	1: "description",
+}
+
+// Decode decodes TechnicalAssetAccessMode from json.
+func (s *TechnicalAssetAccessMode) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode TechnicalAssetAccessMode to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "name":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.Name = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"name\"")
+			}
+		case "description":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.Description = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"description\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode TechnicalAssetAccessMode")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfTechnicalAssetAccessMode) {
+					name = jsonFieldsNameOfTechnicalAssetAccessMode[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *TechnicalAssetAccessMode) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *TechnicalAssetAccessMode) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/cli/golang/pkg/api/oas_schemas_gen.go
+++ b/cli/golang/pkg/api/oas_schemas_gen.go
@@ -1312,9 +1312,10 @@ type CreateTechnicalAssetRequest struct {
 	// DEPRECATED: Use 'technical_mapping' instead. This field will be removed in a future version.
 	//
 	// Deprecated: schema marks this property as deprecated.
-	SourceAligned    OptNilBool             `json:"sourceAligned"`
-	TechnicalMapping OptNilTechnicalMapping `json:"technical_mapping"`
-	TagIds           []uuid.UUID            `json:"tag_ids"`
+	SourceAligned    OptNilBool                 `json:"sourceAligned"`
+	TechnicalMapping OptNilTechnicalMapping     `json:"technical_mapping"`
+	AccessModes      []TechnicalAssetAccessMode `json:"access_modes"`
+	TagIds           []uuid.UUID                `json:"tag_ids"`
 }
 
 // GetName returns the value of Name.
@@ -1355,6 +1356,11 @@ func (s *CreateTechnicalAssetRequest) GetSourceAligned() OptNilBool {
 // GetTechnicalMapping returns the value of TechnicalMapping.
 func (s *CreateTechnicalAssetRequest) GetTechnicalMapping() OptNilTechnicalMapping {
 	return s.TechnicalMapping
+}
+
+// GetAccessModes returns the value of AccessModes.
+func (s *CreateTechnicalAssetRequest) GetAccessModes() []TechnicalAssetAccessMode {
+	return s.AccessModes
 }
 
 // GetTagIds returns the value of TagIds.
@@ -1400,6 +1406,11 @@ func (s *CreateTechnicalAssetRequest) SetSourceAligned(val OptNilBool) {
 // SetTechnicalMapping sets the value of TechnicalMapping.
 func (s *CreateTechnicalAssetRequest) SetTechnicalMapping(val OptNilTechnicalMapping) {
 	s.TechnicalMapping = val
+}
+
+// SetAccessModes sets the value of AccessModes.
+func (s *CreateTechnicalAssetRequest) SetAccessModes(val []TechnicalAssetAccessMode) {
+	s.AccessModes = val
 }
 
 // SetTagIds sets the value of TagIds.
@@ -5254,23 +5265,24 @@ func (*GetOutputPortAccessDurationsResponse) getOutputPortAccessDurationsRes() {
 
 // Ref: #/components/schemas/GetOutputPortResponse
 type GetOutputPortResponse struct {
-	ID                            uuid.UUID                `json:"id"`
-	Namespace                     string                   `json:"namespace"`
-	Name                          string                   `json:"name"`
-	Description                   string                   `json:"description"`
-	Status                        OutputPortStatus         `json:"status"`
-	Usage                         NilString                `json:"usage"`
-	AccessType                    OutputPortAccessType     `json:"access_type"`
-	DataProductAccessDurationType AccessDurationType       `json:"data_product_access_duration_type"`
-	ExplorationAccessDurationType AccessDurationType       `json:"exploration_access_duration_type"`
-	DataProductID                 uuid.UUID                `json:"data_product_id"`
-	Tags                          []Tag                    `json:"tags"`
-	Domain                        Domain                   `json:"domain"`
-	Lifecycle                     NilDataProductLifeCycle  `json:"lifecycle"`
-	About                         NilString                `json:"about"`
-	RolledUpTags                  []Tag                    `json:"rolled_up_tags"`
-	DataProductSettings           []OutputPortSettingValue `json:"data_product_settings"`
-	TechnicalAssetLinks           []TechnicalAssetLink     `json:"technical_asset_links"`
+	ID                            uuid.UUID                  `json:"id"`
+	Namespace                     string                     `json:"namespace"`
+	Name                          string                     `json:"name"`
+	Description                   string                     `json:"description"`
+	Status                        OutputPortStatus           `json:"status"`
+	Usage                         NilString                  `json:"usage"`
+	AccessType                    OutputPortAccessType       `json:"access_type"`
+	DataProductAccessDurationType AccessDurationType         `json:"data_product_access_duration_type"`
+	ExplorationAccessDurationType AccessDurationType         `json:"exploration_access_duration_type"`
+	DataProductID                 uuid.UUID                  `json:"data_product_id"`
+	Tags                          []Tag                      `json:"tags"`
+	Domain                        Domain                     `json:"domain"`
+	Lifecycle                     NilDataProductLifeCycle    `json:"lifecycle"`
+	About                         NilString                  `json:"about"`
+	AccessModes                   []TechnicalAssetAccessMode `json:"access_modes"`
+	RolledUpTags                  []Tag                      `json:"rolled_up_tags"`
+	DataProductSettings           []OutputPortSettingValue   `json:"data_product_settings"`
+	TechnicalAssetLinks           []TechnicalAssetLink       `json:"technical_asset_links"`
 }
 
 // GetID returns the value of ID.
@@ -5341,6 +5353,11 @@ func (s *GetOutputPortResponse) GetLifecycle() NilDataProductLifeCycle {
 // GetAbout returns the value of About.
 func (s *GetOutputPortResponse) GetAbout() NilString {
 	return s.About
+}
+
+// GetAccessModes returns the value of AccessModes.
+func (s *GetOutputPortResponse) GetAccessModes() []TechnicalAssetAccessMode {
+	return s.AccessModes
 }
 
 // GetRolledUpTags returns the value of RolledUpTags.
@@ -5426,6 +5443,11 @@ func (s *GetOutputPortResponse) SetLifecycle(val NilDataProductLifeCycle) {
 // SetAbout sets the value of About.
 func (s *GetOutputPortResponse) SetAbout(val NilString) {
 	s.About = val
+}
+
+// SetAccessModes sets the value of AccessModes.
+func (s *GetOutputPortResponse) SetAccessModes(val []TechnicalAssetAccessMode) {
+	s.AccessModes = val
 }
 
 // SetRolledUpTags sets the value of RolledUpTags.
@@ -5515,6 +5537,7 @@ type GetTechnicalAssetsResponseItem struct {
 	ServiceID        uuid.UUID                                   `json:"service_id"`
 	Status           TechnicalAssetStatus                        `json:"status"`
 	TechnicalMapping TechnicalMapping                            `json:"technical_mapping"`
+	AccessModes      []TechnicalAssetAccessMode                  `json:"access_modes"`
 	Configuration    GetTechnicalAssetsResponseItemConfiguration `json:"configuration"`
 	Owner            DataProduct                                 `json:"owner"`
 	OutputPortLinks  []OutputPortLink                            `json:"output_port_links"`
@@ -5568,6 +5591,11 @@ func (s *GetTechnicalAssetsResponseItem) GetStatus() TechnicalAssetStatus {
 // GetTechnicalMapping returns the value of TechnicalMapping.
 func (s *GetTechnicalAssetsResponseItem) GetTechnicalMapping() TechnicalMapping {
 	return s.TechnicalMapping
+}
+
+// GetAccessModes returns the value of AccessModes.
+func (s *GetTechnicalAssetsResponseItem) GetAccessModes() []TechnicalAssetAccessMode {
+	return s.AccessModes
 }
 
 // GetConfiguration returns the value of Configuration.
@@ -5648,6 +5676,11 @@ func (s *GetTechnicalAssetsResponseItem) SetStatus(val TechnicalAssetStatus) {
 // SetTechnicalMapping sets the value of TechnicalMapping.
 func (s *GetTechnicalAssetsResponseItem) SetTechnicalMapping(val TechnicalMapping) {
 	s.TechnicalMapping = val
+}
+
+// SetAccessModes sets the value of AccessModes.
+func (s *GetTechnicalAssetsResponseItem) SetAccessModes(val []TechnicalAssetAccessMode) {
+	s.AccessModes = val
 }
 
 // SetConfiguration sets the value of Configuration.
@@ -6909,51 +6942,6 @@ func (o NilDataProductLifeCycle) Get() (v DataProductLifeCycle, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o NilDataProductLifeCycle) Or(d DataProductLifeCycle) DataProductLifeCycle {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
-
-// NewNilDataQualityStatus returns new NilDataQualityStatus with value set to v.
-func NewNilDataQualityStatus(v DataQualityStatus) NilDataQualityStatus {
-	return NilDataQualityStatus{
-		Value: v,
-	}
-}
-
-// NilDataQualityStatus is nullable DataQualityStatus.
-type NilDataQualityStatus struct {
-	Value DataQualityStatus
-	Null  bool
-}
-
-// SetTo sets value to v.
-func (o *NilDataQualityStatus) SetTo(v DataQualityStatus) {
-	o.Null = false
-	o.Value = v
-}
-
-// IsNull returns true if value is Null.
-func (o NilDataQualityStatus) IsNull() bool { return o.Null }
-
-// SetToNull sets value to null.
-func (o *NilDataQualityStatus) SetToNull() {
-	o.Null = true
-	var v DataQualityStatus
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o NilDataQualityStatus) Get() (v DataQualityStatus, ok bool) {
-	if o.Null {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o NilDataQualityStatus) Or(d DataQualityStatus) DataQualityStatus {
 	if v, ok := o.Get(); ok {
 		return v
 	}
@@ -12605,7 +12593,6 @@ type SearchOutputPortsResponseItem struct {
 	AbstractDataProductCount      int                     `json:"abstract_data_product_count"`
 	TechnicalAssetsCount          int                     `json:"technical_assets_count"`
 	DataProductName               string                  `json:"data_product_name"`
-	QualityStatus                 NilDataQualityStatus    `json:"quality_status"`
 }
 
 // GetID returns the value of ID.
@@ -12688,11 +12675,6 @@ func (s *SearchOutputPortsResponseItem) GetDataProductName() string {
 	return s.DataProductName
 }
 
-// GetQualityStatus returns the value of QualityStatus.
-func (s *SearchOutputPortsResponseItem) GetQualityStatus() NilDataQualityStatus {
-	return s.QualityStatus
-}
-
 // SetID sets the value of ID.
 func (s *SearchOutputPortsResponseItem) SetID(val uuid.UUID) {
 	s.ID = val
@@ -12771,11 +12753,6 @@ func (s *SearchOutputPortsResponseItem) SetTechnicalAssetsCount(val int) {
 // SetDataProductName sets the value of DataProductName.
 func (s *SearchOutputPortsResponseItem) SetDataProductName(val string) {
 	s.DataProductName = val
-}
-
-// SetQualityStatus sets the value of QualityStatus.
-func (s *SearchOutputPortsResponseItem) SetQualityStatus(val NilDataQualityStatus) {
-	s.QualityStatus = val
 }
 
 // Option for select UI elements.
@@ -13183,6 +13160,32 @@ func (s *TechnicalAsset) SetServiceID(val uuid.UUID) {
 // SetConfiguration sets the value of Configuration.
 func (s *TechnicalAsset) SetConfiguration(val TechnicalAssetConfiguration) {
 	s.Configuration = val
+}
+
+// Ref: #/components/schemas/TechnicalAssetAccessMode
+type TechnicalAssetAccessMode struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// GetName returns the value of Name.
+func (s *TechnicalAssetAccessMode) GetName() string {
+	return s.Name
+}
+
+// GetDescription returns the value of Description.
+func (s *TechnicalAssetAccessMode) GetDescription() string {
+	return s.Description
+}
+
+// SetName sets the value of Name.
+func (s *TechnicalAssetAccessMode) SetName(val string) {
+	s.Name = val
+}
+
+// SetDescription sets the value of Description.
+func (s *TechnicalAssetAccessMode) SetDescription(val string) {
+	s.Description = val
 }
 
 // TechnicalAssetConfiguration represents sum type.

--- a/cli/golang/pkg/api/oas_validators_gen.go
+++ b/cli/golang/pkg/api/oas_validators_gen.go
@@ -2431,6 +2431,17 @@ func (s *GetOutputPortResponse) Validate() error {
 		})
 	}
 	if err := func() error {
+		if s.AccessModes == nil {
+			return errors.New("nil is invalid value")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "access_modes",
+			Error: err,
+		})
+	}
+	if err := func() error {
 		if s.RolledUpTags == nil {
 			return errors.New("nil is invalid value")
 		}
@@ -2642,6 +2653,17 @@ func (s *GetTechnicalAssetsResponseItem) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "technical_mapping",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if s.AccessModes == nil {
+			return errors.New("nil is invalid value")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "access_modes",
 			Error: err,
 		})
 	}
@@ -4673,24 +4695,6 @@ func (s *SearchOutputPortsResponseItem) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "tags",
-			Error: err,
-		})
-	}
-	if err := func() error {
-		if value, ok := s.QualityStatus.Get(); ok {
-			if err := func() error {
-				if err := value.Validate(); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return err
-			}
-		}
-		return nil
-	}(); err != nil {
-		failures = append(failures, validate.FieldError{
-			Name:  "quality_status",
 			Error: err,
 		})
 	}

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -3884,7 +3884,7 @@
         }
       }
     },
-    "/api/v2/data_products/{data_product_id}/technical_assets": {
+    "/api/v2/data_products/{data_product_id}/technical_assets/": {
       "get": {
         "tags": [
           "Data Products - Technical assets"
@@ -9533,6 +9533,14 @@
               }
             ]
           },
+          "access_modes": {
+            "items": {
+              "$ref": "#/components/schemas/TechnicalAssetAccessMode"
+            },
+            "type": "array",
+            "title": "Access Modes",
+            "default": []
+          },
           "tag_ids": {
             "items": {
               "type": "string",
@@ -12188,6 +12196,13 @@
             ],
             "title": "About"
           },
+          "access_modes": {
+            "items": {
+              "$ref": "#/components/schemas/TechnicalAssetAccessMode"
+            },
+            "type": "array",
+            "title": "Access Modes"
+          },
           "rolled_up_tags": {
             "items": {
               "$ref": "#/components/schemas/Tag"
@@ -12227,6 +12242,7 @@
           "domain",
           "lifecycle",
           "about",
+          "access_modes",
           "rolled_up_tags",
           "data_product_settings",
           "technical_asset_links"
@@ -12321,6 +12337,13 @@
           "technical_mapping": {
             "$ref": "#/components/schemas/TechnicalMapping"
           },
+          "access_modes": {
+            "items": {
+              "$ref": "#/components/schemas/TechnicalAssetAccessMode"
+            },
+            "type": "array",
+            "title": "Access Modes"
+          },
           "configuration": {
             "oneOf": [
               {
@@ -12408,6 +12431,7 @@
           "service_id",
           "status",
           "technical_mapping",
+          "access_modes",
           "configuration",
           "owner",
           "output_port_links",
@@ -15509,16 +15533,6 @@
           "data_product_name": {
             "type": "string",
             "title": "Data Product Name"
-          },
-          "quality_status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/DataQualityStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "type": "object",
@@ -15538,8 +15552,7 @@
           "lifecycle",
           "abstract_data_product_count",
           "technical_assets_count",
-          "data_product_name",
-          "quality_status"
+          "data_product_name"
         ],
         "title": "SearchOutputPortsResponseItem"
       },
@@ -15812,6 +15825,24 @@
           "configuration"
         ],
         "title": "TechnicalAsset"
+      },
+      "TechnicalAssetAccessMode": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "description"
+        ],
+        "title": "TechnicalAssetAccessMode"
       },
       "TechnicalAssetEvent": {
         "properties": {

--- a/frontend/src/store/api/services/generated/dataProductsOutputPortsApi.ts
+++ b/frontend/src/store/api/services/generated/dataProductsOutputPortsApi.ts
@@ -518,6 +518,10 @@ export type DataProductLifeCycle = {
   color: string;
   is_default: boolean;
 };
+export type TechnicalAssetAccessMode = {
+  name: string;
+  description: string;
+};
 export type DataProductSetting = {
   id: string;
   category: string;
@@ -658,6 +662,7 @@ export type GetOutputPortResponse = {
   domain: Domain;
   lifecycle: DataProductLifeCycle | null;
   about: string | null;
+  access_modes: TechnicalAssetAccessMode[];
   rolled_up_tags: Tag[];
   data_product_settings: OutputPortSettingValue[];
   technical_asset_links: TechnicalAssetLink[];

--- a/frontend/src/store/api/services/generated/dataProductsTechnicalAssetsApi.ts
+++ b/frontend/src/store/api/services/generated/dataProductsTechnicalAssetsApi.ts
@@ -46,7 +46,7 @@ const injectedRtkApi = api.injectEndpoints({
       GetDataProductTechnicalAssetsApiArg
     >({
       query: (queryArg) => ({
-        url: `/api/v2/data_products/${queryArg}/technical_assets`,
+        url: `/api/v2/data_products/${queryArg}/technical_assets/`,
       }),
     }),
     createTechnicalAsset: build.mutation<
@@ -54,7 +54,7 @@ const injectedRtkApi = api.injectEndpoints({
       CreateTechnicalAssetApiArg
     >({
       query: (queryArg) => ({
-        url: `/api/v2/data_products/${queryArg.dataProductId}/technical_assets`,
+        url: `/api/v2/data_products/${queryArg.dataProductId}/technical_assets/`,
         method: "POST",
         body: queryArg.createTechnicalAssetRequest,
       }),
@@ -220,6 +220,10 @@ export type LinkTechnicalAssetToOutputPortRequest = {
 export type UnLinkTechnicalAssetToOutputPortRequest = {
   technical_asset_id: string;
 };
+export type TechnicalAssetAccessMode = {
+  name: string;
+  description: string;
+};
 export type AzureBlobTechnicalAssetConfiguration = {
   configuration_type: "AzureBlobTechnicalAssetConfiguration";
   domain?: string;
@@ -334,6 +338,7 @@ export type GetTechnicalAssetsResponseItem = {
   service_id: string;
   status: TechnicalAssetStatus;
   technical_mapping: TechnicalMapping;
+  access_modes: TechnicalAssetAccessMode[];
   configuration:
     | ({
         configuration_type: "AzureBlobTechnicalAssetConfiguration";
@@ -407,6 +412,7 @@ export type CreateTechnicalAssetRequest = {
   /** DEPRECATED: Use 'technical_mapping' instead. This field will be removed in a future version. */
   sourceAligned?: boolean | null;
   technical_mapping?: TechnicalMapping | null;
+  access_modes?: TechnicalAssetAccessMode[];
   tag_ids: string[];
 };
 export type UpdateTechnicalAssetResponse = {

--- a/frontend/src/store/api/services/generated/outputPortsSearchApi.ts
+++ b/frontend/src/store/api/services/generated/outputPortsSearchApi.ts
@@ -58,7 +58,6 @@ export type SearchOutputPortsResponseItem = {
   abstract_data_product_count: number;
   technical_assets_count: number;
   data_product_name: string;
-  quality_status: DataQualityStatus | null;
 };
 export type SearchOutputPortsResponse = {
   output_ports: SearchOutputPortsResponseItem[];
@@ -87,13 +86,6 @@ export enum OutputPortAccessType {
 export enum AccessDurationType {
   Permanent = "permanent",
   TimeBound = "time_bound",
-}
-export enum DataQualityStatus {
-  Success = "success",
-  Failure = "failure",
-  Warning = "warning",
-  Error = "error",
-  Unknown = "unknown",
 }
 export const { useSearchOutputPortsQuery, useLazySearchOutputPortsQuery } =
   injectedRtkApi;

--- a/frontend/src/tests/mocks/outputPortsSearch.ts
+++ b/frontend/src/tests/mocks/outputPortsSearch.ts
@@ -27,7 +27,6 @@ export const mockOutputPorts: SearchOutputPortsResponseItem[] = [
         abstract_data_product_count: 1,
         technical_assets_count: 1,
         data_product_name: 'dp-1',
-        quality_status: null,
         data_product_access_duration_type: AccessDurationType.Permanent,
         exploration_access_duration_type: AccessDurationType.Permanent,
     },

--- a/sdk/sdk/api_client/api/data_products_technical_assets/create_technical_asset.py
+++ b/sdk/sdk/api_client/api/data_products_technical_assets/create_technical_asset.py
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "post",
-        "url": "/api/v2/data_products/{data_product_id}/technical_assets".format(
+        "url": "/api/v2/data_products/{data_product_id}/technical_assets/".format(
             data_product_id=quote(str(data_product_id), safe=""),
         ),
     }

--- a/sdk/sdk/api_client/api/data_products_technical_assets/get_data_product_technical_assets.py
+++ b/sdk/sdk/api_client/api/data_products_technical_assets/get_data_product_technical_assets.py
@@ -18,7 +18,7 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/api/v2/data_products/{data_product_id}/technical_assets".format(
+        "url": "/api/v2/data_products/{data_product_id}/technical_assets/".format(
             data_product_id=quote(str(data_product_id), safe=""),
         ),
     }

--- a/sdk/sdk/api_client/models/__init__.py
+++ b/sdk/sdk/api_client/models/__init__.py
@@ -326,6 +326,7 @@ from .tag_update import TagUpdate
 from .tags_get import TagsGet
 from .tags_get_item import TagsGetItem
 from .technical_asset import TechnicalAsset
+from .technical_asset_access_mode import TechnicalAssetAccessMode
 from .technical_asset_event import TechnicalAssetEvent
 from .technical_asset_link import TechnicalAssetLink
 from .technical_asset_output_port_request import TechnicalAssetOutputPortRequest
@@ -612,6 +613,7 @@ __all__ = (
     "TagsGetItem",
     "TagUpdate",
     "TechnicalAsset",
+    "TechnicalAssetAccessMode",
     "TechnicalAssetEvent",
     "TechnicalAssetLink",
     "TechnicalAssetOutputPortRequest",

--- a/sdk/sdk/api_client/models/create_technical_asset_request.py
+++ b/sdk/sdk/api_client/models/create_technical_asset_request.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from ..models.snowflake_technical_asset_configuration import (
         SnowflakeTechnicalAssetConfiguration,
     )
+    from ..models.technical_asset_access_mode import TechnicalAssetAccessMode
 
 
 T = TypeVar("T", bound="CreateTechnicalAssetRequest")
@@ -55,6 +56,7 @@ class CreateTechnicalAssetRequest:
         source_aligned (bool | None | Unset): DEPRECATED: Use 'technical_mapping' instead. This field will be removed in
             a future version.
         technical_mapping (None | TechnicalMapping | Unset):
+        access_modes (list[TechnicalAssetAccessMode] | Unset):
     """
 
     name: str
@@ -75,6 +77,7 @@ class CreateTechnicalAssetRequest:
     tag_ids: list[UUID]
     source_aligned: bool | None | Unset = UNSET
     technical_mapping: None | TechnicalMapping | Unset = UNSET
+    access_modes: list[TechnicalAssetAccessMode] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -149,6 +152,13 @@ class CreateTechnicalAssetRequest:
         else:
             technical_mapping = self.technical_mapping
 
+        access_modes: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.access_modes, Unset):
+            access_modes = []
+            for access_modes_item_data in self.access_modes:
+                access_modes_item = access_modes_item_data.to_dict()
+                access_modes.append(access_modes_item)
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -166,6 +176,8 @@ class CreateTechnicalAssetRequest:
             field_dict["sourceAligned"] = source_aligned
         if technical_mapping is not UNSET:
             field_dict["technical_mapping"] = technical_mapping
+        if access_modes is not UNSET:
+            field_dict["access_modes"] = access_modes
 
         return field_dict
 
@@ -195,6 +207,7 @@ class CreateTechnicalAssetRequest:
         from ..models.snowflake_technical_asset_configuration import (
             SnowflakeTechnicalAssetConfiguration,
         )
+        from ..models.technical_asset_access_mode import TechnicalAssetAccessMode
 
         d = dict(src_dict)
         name = d.pop("name")
@@ -326,6 +339,17 @@ class CreateTechnicalAssetRequest:
 
         technical_mapping = _parse_technical_mapping(d.pop("technical_mapping", UNSET))
 
+        _access_modes = d.pop("access_modes", UNSET)
+        access_modes: list[TechnicalAssetAccessMode] | Unset = UNSET
+        if _access_modes is not UNSET:
+            access_modes = []
+            for access_modes_item_data in _access_modes:
+                access_modes_item = TechnicalAssetAccessMode.from_dict(
+                    access_modes_item_data
+                )
+
+                access_modes.append(access_modes_item)
+
         create_technical_asset_request = cls(
             name=name,
             description=description,
@@ -336,6 +360,7 @@ class CreateTechnicalAssetRequest:
             tag_ids=tag_ids,
             source_aligned=source_aligned,
             technical_mapping=technical_mapping,
+            access_modes=access_modes,
         )
 
         create_technical_asset_request.additional_properties = d

--- a/sdk/sdk/api_client/models/get_output_port_response.py
+++ b/sdk/sdk/api_client/models/get_output_port_response.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from ..models.domain import Domain
     from ..models.output_port_setting_value import OutputPortSettingValue
     from ..models.tag import Tag
+    from ..models.technical_asset_access_mode import TechnicalAssetAccessMode
     from ..models.technical_asset_link import TechnicalAssetLink
 
 
@@ -40,6 +41,7 @@ class GetOutputPortResponse:
         domain (Domain):
         lifecycle (DataProductLifeCycle | None):
         about (None | str):
+        access_modes (list[TechnicalAssetAccessMode]):
         rolled_up_tags (list[Tag]):
         data_product_settings (list[OutputPortSettingValue]):
         technical_asset_links (list[TechnicalAssetLink]):
@@ -59,6 +61,7 @@ class GetOutputPortResponse:
     domain: Domain
     lifecycle: DataProductLifeCycle | None
     about: None | str
+    access_modes: list[TechnicalAssetAccessMode]
     rolled_up_tags: list[Tag]
     data_product_settings: list[OutputPortSettingValue]
     technical_asset_links: list[TechnicalAssetLink]
@@ -104,6 +107,11 @@ class GetOutputPortResponse:
         about: None | str
         about = self.about
 
+        access_modes = []
+        for access_modes_item_data in self.access_modes:
+            access_modes_item = access_modes_item_data.to_dict()
+            access_modes.append(access_modes_item)
+
         rolled_up_tags = []
         for rolled_up_tags_item_data in self.rolled_up_tags:
             rolled_up_tags_item = rolled_up_tags_item_data.to_dict()
@@ -137,6 +145,7 @@ class GetOutputPortResponse:
                 "domain": domain,
                 "lifecycle": lifecycle,
                 "about": about,
+                "access_modes": access_modes,
                 "rolled_up_tags": rolled_up_tags,
                 "data_product_settings": data_product_settings,
                 "technical_asset_links": technical_asset_links,
@@ -151,6 +160,7 @@ class GetOutputPortResponse:
         from ..models.domain import Domain
         from ..models.output_port_setting_value import OutputPortSettingValue
         from ..models.tag import Tag
+        from ..models.technical_asset_access_mode import TechnicalAssetAccessMode
         from ..models.technical_asset_link import TechnicalAssetLink
 
         d = dict(src_dict)
@@ -214,6 +224,15 @@ class GetOutputPortResponse:
 
         about = _parse_about(d.pop("about"))
 
+        access_modes = []
+        _access_modes = d.pop("access_modes")
+        for access_modes_item_data in _access_modes:
+            access_modes_item = TechnicalAssetAccessMode.from_dict(
+                access_modes_item_data
+            )
+
+            access_modes.append(access_modes_item)
+
         rolled_up_tags = []
         _rolled_up_tags = d.pop("rolled_up_tags")
         for rolled_up_tags_item_data in _rolled_up_tags:
@@ -254,6 +273,7 @@ class GetOutputPortResponse:
             domain=domain,
             lifecycle=lifecycle,
             about=about,
+            access_modes=access_modes,
             rolled_up_tags=rolled_up_tags,
             data_product_settings=data_product_settings,
             technical_asset_links=technical_asset_links,

--- a/sdk/sdk/api_client/models/get_technical_assets_response_item.py
+++ b/sdk/sdk/api_client/models/get_technical_assets_response_item.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
         SnowflakeTechnicalAssetConfiguration,
     )
     from ..models.tag import Tag
+    from ..models.technical_asset_access_mode import TechnicalAssetAccessMode
     from ..models.technical_info import TechnicalInfo
 
 
@@ -55,6 +56,7 @@ class GetTechnicalAssetsResponseItem:
         service_id (UUID):
         status (TechnicalAssetStatus):
         technical_mapping (TechnicalMapping):
+        access_modes (list[TechnicalAssetAccessMode]):
         configuration (AzureBlobTechnicalAssetConfiguration | DatabricksTechnicalAssetConfiguration |
             GlueTechnicalAssetConfiguration | OSISemanticModelTechnicalAssetConfiguration |
             PostgreSQLTechnicalAssetConfiguration | RedshiftTechnicalAssetConfiguration | S3TechnicalAssetConfiguration |
@@ -77,6 +79,7 @@ class GetTechnicalAssetsResponseItem:
     service_id: UUID
     status: TechnicalAssetStatus
     technical_mapping: TechnicalMapping
+    access_modes: list[TechnicalAssetAccessMode]
     configuration: (
         AzureBlobTechnicalAssetConfiguration
         | DatabricksTechnicalAssetConfiguration
@@ -136,6 +139,11 @@ class GetTechnicalAssetsResponseItem:
 
         technical_mapping = self.technical_mapping.value
 
+        access_modes = []
+        for access_modes_item_data in self.access_modes:
+            access_modes_item = access_modes_item_data.to_dict()
+            access_modes.append(access_modes_item)
+
         configuration: dict[str, Any]
         if isinstance(self.configuration, S3TechnicalAssetConfiguration):
             configuration = self.configuration.to_dict()
@@ -190,6 +198,7 @@ class GetTechnicalAssetsResponseItem:
                 "service_id": service_id,
                 "status": status,
                 "technical_mapping": technical_mapping,
+                "access_modes": access_modes,
                 "configuration": configuration,
                 "owner": owner,
                 "output_port_links": output_port_links,
@@ -231,6 +240,7 @@ class GetTechnicalAssetsResponseItem:
             SnowflakeTechnicalAssetConfiguration,
         )
         from ..models.tag import Tag
+        from ..models.technical_asset_access_mode import TechnicalAssetAccessMode
         from ..models.technical_info import TechnicalInfo
 
         d = dict(src_dict)
@@ -251,6 +261,15 @@ class GetTechnicalAssetsResponseItem:
         status = TechnicalAssetStatus(d.pop("status"))
 
         technical_mapping = TechnicalMapping(d.pop("technical_mapping"))
+
+        access_modes = []
+        _access_modes = d.pop("access_modes")
+        for access_modes_item_data in _access_modes:
+            access_modes_item = TechnicalAssetAccessMode.from_dict(
+                access_modes_item_data
+            )
+
+            access_modes.append(access_modes_item)
 
         def _parse_configuration(
             data: object,
@@ -377,6 +396,7 @@ class GetTechnicalAssetsResponseItem:
             service_id=service_id,
             status=status,
             technical_mapping=technical_mapping,
+            access_modes=access_modes,
             configuration=configuration,
             owner=owner,
             output_port_links=output_port_links,

--- a/sdk/sdk/api_client/models/search_output_ports_response_item.py
+++ b/sdk/sdk/api_client/models/search_output_ports_response_item.py
@@ -8,7 +8,6 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..models.access_duration_type import AccessDurationType
-from ..models.data_quality_status import DataQualityStatus
 from ..models.output_port_access_type import OutputPortAccessType
 from ..models.output_port_status import OutputPortStatus
 
@@ -41,7 +40,6 @@ class SearchOutputPortsResponseItem:
         abstract_data_product_count (int):
         technical_assets_count (int):
         data_product_name (str):
-        quality_status (DataQualityStatus | None):
     """
 
     id: UUID
@@ -60,7 +58,6 @@ class SearchOutputPortsResponseItem:
     abstract_data_product_count: int
     technical_assets_count: int
     data_product_name: str
-    quality_status: DataQualityStatus | None
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -106,12 +103,6 @@ class SearchOutputPortsResponseItem:
 
         data_product_name = self.data_product_name
 
-        quality_status: None | str
-        if isinstance(self.quality_status, DataQualityStatus):
-            quality_status = self.quality_status.value
-        else:
-            quality_status = self.quality_status
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -132,7 +123,6 @@ class SearchOutputPortsResponseItem:
                 "abstract_data_product_count": abstract_data_product_count,
                 "technical_assets_count": technical_assets_count,
                 "data_product_name": data_product_name,
-                "quality_status": quality_status,
             }
         )
 
@@ -204,21 +194,6 @@ class SearchOutputPortsResponseItem:
 
         data_product_name = d.pop("data_product_name")
 
-        def _parse_quality_status(data: object) -> DataQualityStatus | None:
-            if data is None:
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                quality_status_type_0 = DataQualityStatus(data)
-
-                return quality_status_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(DataQualityStatus | None, data)
-
-        quality_status = _parse_quality_status(d.pop("quality_status"))
-
         search_output_ports_response_item = cls(
             id=id,
             namespace=namespace,
@@ -236,7 +211,6 @@ class SearchOutputPortsResponseItem:
             abstract_data_product_count=abstract_data_product_count,
             technical_assets_count=technical_assets_count,
             data_product_name=data_product_name,
-            quality_status=quality_status,
         )
 
         search_output_ports_response_item.additional_properties = d

--- a/sdk/sdk/api_client/models/technical_asset_access_mode.py
+++ b/sdk/sdk/api_client/models/technical_asset_access_mode.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="TechnicalAssetAccessMode")
+
+
+@_attrs_define
+class TechnicalAssetAccessMode:
+    """
+    Attributes:
+        name (str):
+        description (str):
+    """
+
+    name: str
+    description: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        description = self.description
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "name": name,
+                "description": description,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        description = d.pop("description")
+
+        technical_asset_access_mode = cls(
+            name=name,
+            description=description,
+        )
+
+        technical_asset_access_mode.additional_properties = d
+        return technical_asset_access_mode
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties


### PR DESCRIPTION
Currently only implement the backend:
- Access mode can be added during creation of technical asset
- Access modes can be seen on output port
- Only compatible technical assets can be added to a single output port
- User can request a single access mode when requesting access

In support of: #3981

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested.
