### PR TITLE
Improve processing of v2 events

### DIFF
--- a/backend/app/core/webhooks/events.py
+++ b/backend/app/core/webhooks/events.py
@@ -23,7 +23,7 @@ class V2Event(BaseModel):
         if "event_type" not in cls.__dict__:
             raise TypeError(f"{cls.__name__} must define an event_type() classmethod")
         if cls.event_type() in cls.events:
-            raise Exception("Duplicated event type detected")
+            raise Exception(f"Duplicated event type detected, {cls.event_type()}")
         cls.events.append(cls.event_type())
 
     @classmethod

--- a/backend/app/core/webhooks/middleware.py
+++ b/backend/app/core/webhooks/middleware.py
@@ -1,0 +1,203 @@
+import asyncio
+from collections.abc import Awaitable, Callable
+from contextlib import suppress
+from typing import Any
+
+from fastapi import FastAPI
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from app.core.context import close_event_context, open_event_context, pop_events
+from app.core.logging import logger
+from app.core.webhooks.events import V2Event
+from app.core.webhooks.v2 import emit_all_events
+from app.settings import settings
+
+_EVENT_QUEUE_MAXSIZE = 1000
+_INFLIGHT_DRAIN_TIMEOUT_SECONDS = 10.0
+_QUEUE_DRAIN_TIMEOUT_SECONDS = 10.0
+_DISPATCHER_STATE_KEY = "webhook_v2_dispatcher"
+
+
+class EventDispatcher:
+    """Dispatches webhook v2 events to a background worker.
+
+    Requests hand off their events to a queue so the response is not delayed by
+    the webhook call. Shutdown waits for in-flight requests to submit their
+    events and for the queue to drain, both under a bounded timeout.
+    """
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[list[V2Event]] = asyncio.Queue(
+            maxsize=_EVENT_QUEUE_MAXSIZE
+        )
+        self._inflight_requests = 0
+        self._idle = asyncio.Event()
+        self._idle.set()
+        self._task = asyncio.create_task(self._worker(), name="webhook_v2_dispatcher")
+        self._task.add_done_callback(_log_task_result)
+        self._loop = asyncio.get_running_loop()
+
+    def is_running(self) -> bool:
+        """Whether the worker is still usable from the running event loop.
+
+        The queue and its worker are bound to the loop they were created on, so
+        a dispatcher outlives its loop only as an unusable leftover.
+        """
+        with suppress(RuntimeError):
+            return not self._task.done() and self._loop is asyncio.get_running_loop()
+        return False
+
+    async def _worker(self) -> None:
+        while True:
+            try:
+                events = await self._queue.get()
+            except asyncio.QueueShutDown:
+                return
+            try:
+                await emit_all_events(events)
+            except Exception:
+                logger.exception("Failed to dispatch queued webhook v2 events")
+            finally:
+                self._queue.task_done()
+
+    def request_started(self) -> None:
+        self._inflight_requests += 1
+        self._idle.clear()
+
+    def request_finished(self) -> None:
+        self._inflight_requests = max(self._inflight_requests - 1, 0)
+        if self._inflight_requests == 0:
+            self._idle.set()
+
+    def submit(self, events: list[V2Event]) -> None:
+        try:
+            self._queue.put_nowait(events)
+        except asyncio.QueueFull:
+            logger.warning(
+                "Webhook v2 event queue is full, dropping %s events", len(events)
+            )
+        except asyncio.QueueShutDown:
+            logger.warning(
+                "Webhook v2 event queue is shut down, dropping %s events", len(events)
+            )
+
+    async def stop(self) -> None:
+        # The queue stays open here so in-flight requests can still submit.
+        await self._wait_for(
+            self._idle.wait(),
+            _INFLIGHT_DRAIN_TIMEOUT_SECONDS,
+            "Timed out waiting for %s in-flight request(s) before webhook v2 shutdown",
+            lambda: self._inflight_requests,
+        )
+
+        self._queue.shutdown(immediate=False)
+        await self._wait_for(
+            self._queue.join(),
+            _QUEUE_DRAIN_TIMEOUT_SECONDS,
+            "Timed out draining webhook v2 event queue, dropping %s queued batch(es)",
+            self._queue.qsize,
+        )
+
+        self._task.cancel()
+        with suppress(asyncio.CancelledError):
+            await self._task
+
+    @staticmethod
+    async def _wait_for(
+        awaitable: Awaitable[Any],
+        timeout: float,
+        message: str,
+        remaining: Callable[[], int],
+    ) -> None:
+        try:
+            await asyncio.wait_for(awaitable, timeout=timeout)
+        except TimeoutError:
+            logger.warning(message, remaining())
+
+
+def _log_task_result(task: asyncio.Task[None]) -> None:
+    if task.cancelled():
+        return
+    if exc := task.exception():
+        logger.exception("Background task '%s' failed", task.get_name(), exc_info=exc)
+
+
+def start_event_dispatcher(app: FastAPI) -> EventDispatcher:
+    """Start a dispatcher, replacing any dispatcher left by a previous run.
+
+    The FastAPI application object is a module level singleton, so its state
+    survives a lifespan cycle and has to be replaced rather than reused.
+    """
+    dispatcher = EventDispatcher()
+    setattr(app.state, _DISPATCHER_STATE_KEY, dispatcher)
+    return dispatcher
+
+
+async def stop_event_dispatcher(app: FastAPI) -> None:
+    dispatcher = getattr(app.state, _DISPATCHER_STATE_KEY, None)
+    if dispatcher is not None:
+        await dispatcher.stop()
+
+
+def _get_event_dispatcher(app: FastAPI) -> EventDispatcher:
+    dispatcher = getattr(app.state, _DISPATCHER_STATE_KEY, None)
+    if dispatcher is None or not dispatcher.is_running():
+        dispatcher = start_event_dispatcher(app)
+    return dispatcher
+
+
+class DispatchQueuedEventsMiddleware:
+    def __init__(self, app: ASGIApp, fastapi_app: FastAPI) -> None:
+        if not isinstance(fastapi_app, FastAPI):
+            raise TypeError(
+                "DispatchQueuedEventsMiddleware requires the FastAPI application, "
+                f"got {type(fastapi_app).__name__}"
+            )
+        self.app = app
+        self.fastapi_app = fastapi_app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Held for the whole request so a restart cannot split the in-flight
+        # bookkeeping across two dispatchers.
+        dispatcher = _get_event_dispatcher(self.fastapi_app)
+        dispatcher.request_started()
+
+        token = open_event_context()
+        status_code = 500
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = int(message["status"])
+            await send(message)
+
+        try:
+            try:
+                await self.app(scope, receive, send_wrapper)
+            finally:
+                events = pop_events()
+                close_event_context(token)
+                # Submit before finishing so a concurrent shutdown never
+                # sees zero in-flight requests while events are pending.
+                self._submit(dispatcher, events, status_code)
+        finally:
+            dispatcher.request_finished()
+
+    @staticmethod
+    def _submit(
+        dispatcher: EventDispatcher, events: list[V2Event], status_code: int
+    ) -> None:
+        if not events or not settings.WEBHOOK_V2_URL:
+            return
+        if status_code >= 400:
+            logger.debug(
+                "Request failed with status %s, dropping %s webhook v2 events",
+                status_code,
+                len(events),
+            )
+            return
+        dispatcher.submit(events)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,12 +24,15 @@ from app.core.auth.device_flows.background_tasks import cleanup_device_flow_tabl
 from app.core.auth.jwt import get_oidc
 from app.core.auth.router import router as auth
 from app.core.authz.background_tasks import check_expired_admins
-from app.core.context import close_event_context, open_event_context, pop_events
 from app.core.errors.error_handling import add_exception_handlers
 from app.core.logging import logger
 from app.core.logging.posthog_analytics import report_consumption_metrics_task
 from app.core.logging.scarf_analytics import backend_analytics
-from app.core.webhooks.v2 import emit_all_events
+from app.core.webhooks.middleware import (
+    DispatchQueuedEventsMiddleware,
+    start_event_dispatcher,
+    stop_event_dispatcher,
+)
 from app.core.webhooks.webhook import call_webhook, register_webhooks
 from app.database import database
 from app.mcp.mcp import mcp
@@ -74,7 +77,7 @@ async def log_middleware(request: Request, call_next):
 
 
 @asynccontextmanager
-async def lifespan(_: FastAPI):
+async def lifespan(app: FastAPI):
     with database.SessionLocal() as db:
         if settings.AUTHORIZER_STARTUP_SYNC:
             AuthorizationService(db).reload_enforcer()
@@ -86,12 +89,14 @@ async def lifespan(_: FastAPI):
     consumption_metrics_task = asyncio.create_task(report_consumption_metrics_task())
     stuck_deletion_task = asyncio.create_task(check_stuck_deletions())
     input_port_expiry_task = asyncio.create_task(expire_input_ports_task())
+    start_event_dispatcher(app)
     yield
     admin_task.cancel()
     device_flow_cleanup_task.cancel()
     consumption_metrics_task.cancel()
     stuck_deletion_task.cancel()
     input_port_expiry_task.cancel()
+    await stop_event_dispatcher(app)
 
 
 mcp.add_middleware(LoggingMiddleware())
@@ -152,6 +157,7 @@ add_exception_handlers(app)
 register_webhooks(app)
 
 app.add_middleware(BaseHTTPMiddleware, dispatch=log_middleware)
+app.add_middleware(DispatchQueuedEventsMiddleware, fastapi_app=app)
 app.add_middleware(
     CorrelationIdMiddleware,
     header_name="X-Request-ID",
@@ -196,19 +202,6 @@ async def send_response_to_webhook(
                 status_code=response.status_code,
             )
         )
-    return response
-
-
-@app.middleware("http")
-async def dispatch_queued_events(request: Request, call_next):
-    token = open_event_context()
-    try:
-        response = await call_next(request)
-    finally:
-        events = pop_events()
-        close_event_context(token)
-    if response.status_code < 400 and settings.WEBHOOK_V2_URL and events:
-        asyncio.create_task(emit_all_events(events))
     return response
 
 

--- a/backend/tests/app/core/webhooks/test_dispatch_queued_events_middleware.py
+++ b/backend/tests/app/core/webhooks/test_dispatch_queued_events_middleware.py
@@ -1,0 +1,387 @@
+"""Tests for the webhook v2 event dispatch middleware."""
+
+import asyncio
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import FastAPI, HTTPException
+
+from app.core.context import queue_event
+from app.core.webhooks import middleware as mw
+from app.core.webhooks.events import V2Event
+from app.core.webhooks.middleware import (
+    DispatchQueuedEventsMiddleware,
+    EventDispatcher,
+    start_event_dispatcher,
+    stop_event_dispatcher,
+)
+from tests.conftest import webhook_v2_config
+
+
+class _SampleEvent(V2Event):
+    @classmethod
+    def event_type(cls) -> str:
+        return "dispatch.sample.event"
+
+    value: str = "sample"
+
+
+def build_app() -> FastAPI:
+    """An app wired like main.py, with routes covering the relevant outcomes."""
+    app = FastAPI()
+    app.add_middleware(DispatchQueuedEventsMiddleware, fastapi_app=app)
+
+    @app.get("/ok")
+    async def ok() -> dict[str, bool]:
+        queue_event(_SampleEvent())
+        return {"ok": True}
+
+    @app.get("/no-events")
+    async def no_events() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.get("/client-error")
+    async def client_error() -> None:
+        queue_event(_SampleEvent())
+        raise HTTPException(status_code=400)
+
+    @app.get("/crash")
+    async def crash() -> None:
+        queue_event(_SampleEvent())
+        raise ValueError("boom")
+
+    return app
+
+
+def client(app: FastAPI) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+def capture_emitted(emitted: list[V2Event]) -> Any:
+    async def _emit(events: list[V2Event]) -> None:
+        emitted.extend(events)
+
+    return patch.object(mw, "emit_all_events", _emit)
+
+
+class TestEventDispatching:
+    @pytest.mark.asyncio
+    async def test_dispatches_events_of_successful_request(self):
+        app = build_app()
+        start_event_dispatcher(app)
+        emitted: list[V2Event] = []
+
+        with webhook_v2_config(), capture_emitted(emitted):
+            async with client(app) as http:
+                response = await http.get("/ok")
+            await stop_event_dispatcher(app)
+
+        assert response.status_code == 200
+        assert [type(event) for event in emitted] == [_SampleEvent]
+
+    @pytest.mark.asyncio
+    async def test_does_not_dispatch_when_url_not_configured(self):
+        app = build_app()
+        start_event_dispatcher(app)
+        emitted: list[V2Event] = []
+
+        with webhook_v2_config(url=None), capture_emitted(emitted):
+            async with client(app) as http:
+                await http.get("/ok")
+            await stop_event_dispatcher(app)
+
+        assert emitted == []
+
+    @pytest.mark.asyncio
+    async def test_does_not_dispatch_events_of_failed_request(self):
+        app = build_app()
+        start_event_dispatcher(app)
+        emitted: list[V2Event] = []
+
+        with webhook_v2_config(), capture_emitted(emitted):
+            async with client(app) as http:
+                response = await http.get("/client-error")
+            await stop_event_dispatcher(app)
+
+        assert response.status_code == 400
+        assert emitted == []
+
+    @pytest.mark.asyncio
+    async def test_does_not_dispatch_when_handler_raises(self):
+        app = build_app()
+        start_event_dispatcher(app)
+        emitted: list[V2Event] = []
+
+        with webhook_v2_config(), capture_emitted(emitted):
+            async with client(app) as http:
+                response = await http.get("/crash")
+            await stop_event_dispatcher(app)
+
+        assert response.status_code == 500
+        assert emitted == []
+
+    @pytest.mark.asyncio
+    async def test_request_succeeds_when_dispatching_fails(self):
+        """A broken webhook target must not surface in the response."""
+        app = build_app()
+        start_event_dispatcher(app)
+
+        async def _boom(events: list[V2Event]) -> None:
+            raise RuntimeError("webhook exploded")
+
+        with webhook_v2_config(), patch.object(mw, "emit_all_events", _boom):
+            async with client(app) as http:
+                response = await http.get("/ok")
+            await stop_event_dispatcher(app)
+
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_drops_events_when_queue_is_full(self):
+        """A full queue drops events instead of failing the request."""
+        app = build_app()
+        dispatcher = start_event_dispatcher(app)
+        dispatching = asyncio.Event()
+        blocked = asyncio.Event()
+
+        async def _block(events: list[V2Event]) -> None:
+            dispatching.set()
+            await blocked.wait()
+
+        with webhook_v2_config(), patch.object(mw, "emit_all_events", _block):
+            # Occupy the worker so that it stops draining the queue.
+            dispatcher._queue.put_nowait([_SampleEvent()])
+            await asyncio.wait_for(dispatching.wait(), timeout=5)
+            while not dispatcher._queue.full():
+                dispatcher._queue.put_nowait([_SampleEvent()])
+
+            with patch.object(mw.logger, "warning") as warning:
+                async with client(app) as http:
+                    response = await http.get("/ok")
+
+            blocked.set()
+            with patch.object(mw, "_QUEUE_DRAIN_TIMEOUT_SECONDS", 5):
+                await stop_event_dispatcher(app)
+
+        assert response.status_code == 200
+        assert "queue is full" in warning.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_submitting_to_stopped_dispatcher_drops_events(self):
+        app = build_app()
+        dispatcher = start_event_dispatcher(app)
+        await stop_event_dispatcher(app)
+
+        with patch.object(mw.logger, "warning") as warning:
+            dispatcher.submit([_SampleEvent()])
+
+        assert "shut down" in warning.call_args.args[0]
+
+
+class TestInflightTracking:
+    @pytest.mark.asyncio
+    async def test_inflight_returns_to_zero_after_request(self):
+        app = build_app()
+        dispatcher = start_event_dispatcher(app)
+
+        with webhook_v2_config(), capture_emitted([]):
+            async with client(app) as http:
+                await http.get("/ok")
+                await http.get("/crash")
+            await stop_event_dispatcher(app)
+
+        assert dispatcher._inflight_requests == 0
+
+    @pytest.mark.asyncio
+    async def test_shutdown_dispatches_events_of_inflight_request(self):
+        """Events submitted while shutdown is draining must still be sent."""
+        app = build_app()
+        start_event_dispatcher(app)
+        emitted: list[V2Event] = []
+        release = asyncio.Event()
+
+        @app.get("/blocked")
+        async def blocked() -> dict[str, bool]:
+            await release.wait()
+            queue_event(_SampleEvent())
+            return {"ok": True}
+
+        app.middleware_stack = None
+
+        with webhook_v2_config(), capture_emitted(emitted):
+            async with client(app) as http:
+                request = asyncio.create_task(http.get("/blocked"))
+                await asyncio.sleep(0)
+                shutdown = asyncio.create_task(stop_event_dispatcher(app))
+                await asyncio.sleep(0)
+
+                release.set()
+                await request
+                await shutdown
+
+        assert len(emitted) == 1
+
+    @pytest.mark.asyncio
+    async def test_shutdown_gives_up_on_stuck_request(self):
+        """A never-finishing request must not block shutdown forever."""
+        app = build_app()
+        start_event_dispatcher(app)
+
+        @app.get("/hangs")
+        async def hangs() -> None:
+            await asyncio.sleep(60)
+
+        app.middleware_stack = None
+
+        with (
+            webhook_v2_config(),
+            patch.object(mw, "_INFLIGHT_DRAIN_TIMEOUT_SECONDS", 0.05),
+        ):
+            async with client(app) as http:
+                request = asyncio.create_task(http.get("/hangs"))
+                await asyncio.sleep(0)
+
+                await asyncio.wait_for(stop_event_dispatcher(app), timeout=5)
+
+                request.cancel()
+
+
+class TestDispatcherLifecycle:
+    @pytest.mark.asyncio
+    async def test_shutdown_gives_up_on_slow_dispatching(self):
+        app = build_app()
+        dispatcher = start_event_dispatcher(app)
+        for _ in range(3):
+            dispatcher._queue.put_nowait([_SampleEvent()])
+
+        async def _slow(events: list[V2Event]) -> None:
+            await asyncio.sleep(60)
+
+        with (
+            patch.object(mw, "emit_all_events", _slow),
+            patch.object(mw, "_QUEUE_DRAIN_TIMEOUT_SECONDS", 0.05),
+        ):
+            await asyncio.wait_for(stop_event_dispatcher(app), timeout=5)
+
+        assert dispatcher._task.done()
+
+    @pytest.mark.asyncio
+    async def test_stop_is_a_noop_without_dispatcher(self):
+        await stop_event_dispatcher(FastAPI())
+
+    @pytest.mark.asyncio
+    async def test_restart_dispatches_events_again(self):
+        """The app object is a singleton, so a second lifespan must work."""
+        app = build_app()
+        start_event_dispatcher(app)
+        await stop_event_dispatcher(app)
+        start_event_dispatcher(app)
+        emitted: list[V2Event] = []
+
+        with webhook_v2_config(), capture_emitted(emitted):
+            async with client(app) as http:
+                await http.get("/ok")
+            await stop_event_dispatcher(app)
+
+        assert len(emitted) == 1
+
+    @pytest.mark.asyncio
+    async def test_dispatcher_is_replaced_when_bound_to_another_loop(self):
+        """Each TestClient runs its own loop; a dispatcher cannot cross loops."""
+        app = build_app()
+        emitted: list[V2Event] = []
+
+        with _dispatcher_on_another_loop() as stale:
+            setattr(app.state, "webhook_v2_dispatcher", stale)
+            assert not stale.is_running()
+
+            with webhook_v2_config(), capture_emitted(emitted):
+                async with client(app) as http:
+                    await http.get("/ok")
+                await stop_event_dispatcher(app)
+
+            assert getattr(app.state, "webhook_v2_dispatcher") is not stale
+            assert stale._queue.empty()
+
+        assert len(emitted) == 1
+
+    @pytest.mark.asyncio
+    async def test_dispatcher_is_replaced_when_worker_stopped(self):
+        app = build_app()
+        dispatcher = start_event_dispatcher(app)
+        await stop_event_dispatcher(app)
+        emitted: list[V2Event] = []
+
+        assert not dispatcher.is_running()
+
+        with webhook_v2_config(), capture_emitted(emitted):
+            async with client(app) as http:
+                await http.get("/ok")
+            await stop_event_dispatcher(app)
+
+        assert getattr(app.state, "webhook_v2_dispatcher") is not dispatcher
+        assert len(emitted) == 1
+
+    @pytest.mark.asyncio
+    async def test_running_dispatcher_is_reused(self):
+        app = build_app()
+        dispatcher = start_event_dispatcher(app)
+
+        with webhook_v2_config(), capture_emitted([]):
+            async with client(app) as http:
+                await http.get("/ok")
+                await http.get("/ok")
+
+            assert getattr(app.state, "webhook_v2_dispatcher") is dispatcher
+            await stop_event_dispatcher(app)
+
+
+@contextmanager
+def _dispatcher_on_another_loop() -> Iterator[EventDispatcher]:
+    """A dispatcher owned by a second, still running event loop."""
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    try:
+        dispatcher = asyncio.run_coroutine_threadsafe(_make_dispatcher(), loop).result(
+            timeout=5
+        )
+        yield dispatcher
+    finally:
+        loop.call_soon_threadsafe(dispatcher._task.cancel)
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+        loop.close()
+
+
+async def _make_dispatcher() -> EventDispatcher:
+    return EventDispatcher()
+
+
+class TestMiddlewareConstruction:
+    def test_requires_the_fastapi_application(self):
+        async def inner(scope, receive, send) -> None: ...
+
+        with pytest.raises(TypeError, match="requires the FastAPI application"):
+            DispatchQueuedEventsMiddleware(inner, fastapi_app=inner)
+
+    @pytest.mark.asyncio
+    async def test_passes_through_non_http_scopes(self):
+        """Non-http scopes bypass event handling entirely."""
+        received: list[str] = []
+
+        async def inner(scope, receive, send) -> None:
+            received.append(scope["type"])
+
+        app = FastAPI()
+        middleware = DispatchQueuedEventsMiddleware(inner, fastapi_app=app)
+        await middleware({"type": "websocket"}, None, None)
+
+        assert received == ["websocket"]
+        assert not hasattr(app.state, "webhook_v2_dispatcher")


### PR DESCRIPTION
Move v2 events to a bounded in-memory queue
and process them via a single worker.
The worker is tracked through the app state
and restarted when needed, it's also cleanly
stopped on shutdown.
This replaces the fire-and-forget dispatch
that would make a lot of async background tasks

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested.
