### PR TITLE
Improve technical asset form

### DIFF
--- a/frontend/src/components/data-products/data-product-data-output-link-popup/data-product-data-output-link-popup.component.tsx
+++ b/frontend/src/components/data-products/data-product-data-output-link-popup/data-product-data-output-link-popup.component.tsx
@@ -37,6 +37,7 @@ export function DataProductLinkPopup({ onClose, isOpen, title, formRef, children
                 </Space>
             )}
             centered
+            styles={{ body: { maxHeight: '80vh', overflowY: 'auto' } }}
         >
             {children}
         </Modal>

--- a/frontend/src/components/data-products/technical-asset-form/technical-asset-form.component.tsx
+++ b/frontend/src/components/data-products/technical-asset-form/technical-asset-form.component.tsx
@@ -33,7 +33,6 @@ import { selectFilterOptionByLabel } from '@/utils/form.helper';
 import { getIcon } from '@/utils/icon-loader';
 import { AccessModeSelector } from './access-mode-selector.component';
 import { TechnicalAssetConfigurationForm } from './technical-asset-configuration-form.component';
-import styles from './technical-asset-form.module.scss';
 
 const { TextArea } = Input;
 
@@ -309,7 +308,7 @@ export function TechnicalAssetForm({ mode, formRef, dataProductId, modalCallback
 
             <Form.Item name="platform_id">
                 <Radio.Group>
-                    <Space wrap className={styles.radioButtonContainer}>
+                    <Space wrap>
                         {dataPlatforms.map((dataPlatform) => (
                             <TechnicalAssetPlatformTile<string>
                                 key={dataPlatform.value}
@@ -330,7 +329,7 @@ export function TechnicalAssetForm({ mode, formRef, dataProductId, modalCallback
             </Form.Item>
             <Form.Item name="service_id" hidden={selectedDataPlatform?.children?.length === 0}>
                 <Radio.Group>
-                    <Space wrap className={styles.radioButtonContainer}>
+                    <Space wrap>
                         {selectedDataPlatform?.children?.map((dataPlatform) => (
                             <TechnicalAssetPlatformTile<string>
                                 key={dataPlatform.value}
@@ -373,6 +372,7 @@ export function TechnicalAssetForm({ mode, formRef, dataProductId, modalCallback
                         <Form.Item<TechnicalAssetsCreateForm>
                             name="access_mode_type"
                             label={t('Access mode')}
+                            initialValue="single"
                             rules={[{ required: true, message: t('Please select an access mode') }]}
                         >
                             <CardSelection<AccessModeType>

--- a/frontend/src/components/data-products/technical-asset-form/technical-asset-form.module.scss
+++ b/frontend/src/components/data-products/technical-asset-form/technical-asset-form.module.scss
@@ -1,1 +1,0 @@
-@use "@/styles/globals";

--- a/frontend/src/tests/pages/data-product/components/data-product-tabs/data-output-tab/components/add-technical-asset-popup/add-technical-asset-popup.test.tsx
+++ b/frontend/src/tests/pages/data-product/components/data-product-tabs/data-output-tab/components/add-technical-asset-popup/add-technical-asset-popup.test.tsx
@@ -46,7 +46,8 @@ describe('TechnicalAssetPopup', async () => {
         const descriptionInput = screen.getByLabelText(/description/i);
         await user.type(descriptionInput, 'My new technical asset is the best one ever');
     };
-    it('should be able to fill in the whole form with single access mode', async () => {
+
+    it('should be able to fill in the whole form', async () => {
         defaultMocks();
         mockCreateTechnicalAsset(mockDataProducts[0].id);
 
@@ -63,8 +64,6 @@ describe('TechnicalAssetPopup', async () => {
 
         await fillInNameAndDescription(user);
         await fillInS3(user);
-
-        await user.click(screen.getByText('Single access mode'));
 
         const createButton = screen.getByRole('button', { name: /Create/i });
         await user.click(createButton);
@@ -99,25 +98,6 @@ describe('TechnicalAssetPopup', async () => {
         await user.click(createButton);
 
         await waitFor(() => expect(mockCloseFunction).toHaveBeenCalled());
-    }, 15000);
-
-    it('should fail when not specifying single or multiple access mode', async () => {
-        defaultMocks();
-
-        const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
-        renderWithProviders(
-            <AddTechnicalAssetPopup onClose={vi.fn()} isOpen dataProductId={mockDataProducts[0].id} debounce={0} />,
-        );
-
-        await waitFor(() => expect(screen.getByLabelText(/name/i)).not.toBeDisabled());
-
-        await fillInNameAndDescription(user);
-        await fillInS3(user);
-
-        const createButton = screen.getByRole('button', { name: /Create/i });
-        await user.click(createButton);
-
-        await waitFor(() => expect(screen.getByText(/Please select an access mode/i)).toBeInTheDocument());
     }, 15000);
 
     it('should fail when specifying multiple access mode but no mode is selected from the table', async () => {


### PR DESCRIPTION
Single access mode selected by default,
made the modal max size 80vh, and made
scrolling within possible

In support of: #3981

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested.

scroll inside:
<img width="978" height="950" alt="image" src="https://github.com/user-attachments/assets/623007ba-e021-4dcc-a665-8fb39f5d2705" />

single access mode default:
<img width="870" height="906" alt="Screenshot 2026-08-07 at 11 04 49" src="https://github.com/user-attachments/assets/4aa9a800-3cf5-4a66-ad4e-e26624c97b34" />
