### PR TITLE
Disable cv06

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -2,7 +2,8 @@
 dialect = postgres
 large_file_skip_byte_limit = 0
 #Disable long lines for now
-exclude_rules = LT05
+#Also disable CV06 as it takes a long time to run 12s out of 30s at time of benchmarking
+exclude_rules = LT05, CV06
 
 [sqlfluff:templater:jinja]
 apply_dbt_builtins = true


### PR DESCRIPTION
It took about 40% of our runtime, so
removing it for now

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested.
