### PR TITLE
Added access mode to access requests modal

### DIFF
--- a/backend/sample_data.sql
+++ b/backend/sample_data.sql
@@ -11,6 +11,7 @@
 {% set access_mode_unlinked_admin_technical_asset_id = "d3b62b7c-1b72-4dc8-a20e-eab964763c0b" %}
 {% set access_mode_unlinked_technical_asset_id = "939455a4-8bf0-4127-b414-100e6df9faa9" %}
 {% set access_modes_consumer = "98688e99-24e8-425d-8ca8-7134257028fd" %}
+{% set access_modes_consumer_pending = "f39ab873-24f9-4745-bab4-25cedb0b6dfa" %}
 {% set access_modes_example = "da9e4ef1-48d5-4f3d-9094-100d3abc64b5" %}
 {% set dei_access_modes_example_output_port = "64369c22-9e41-4bfa-953a-87ddf484cd52" %}
 
@@ -720,7 +721,20 @@ VALUES (gen_random_uuid(), '{{ access_modes_example }}'::uuid, '{{ john_id }}'::
 ), timezone('utc'::text, current_timestamp
 ), NULL, NULL);
 
-INSERT INTO public.datasets (id, namespace, data_product_id, name, description, about, status, access_type, created_on, updated_on, deleted_at) VALUES ('{{ dei_access_modes_example_output_port }}'::uuid, 'access-mode-representative-dataset', '{{ access_modes_example }}'::uuid, 'Access mode example', 'Quarterly representation metrics by function and level', 'Output port for access mode examples.', 'ACTIVE', 'RESTRICTED', timezone('utc'::text, current_timestamp), NULL, NULL);
+INSERT INTO public.datasets (id, namespace, data_product_id, name, description, about, status, access_type, created_on, updated_on, deleted_at)
+VALUES ('{{ dei_access_modes_example_output_port }}'::uuid, 'access-mode-representative-dataset', '{{ access_modes_example }}'::uuid, 'Access mode example', 'Quarterly representation metrics by function and level', 'Output port for access mode examples.', 'ACTIVE', 'RESTRICTED', timezone('utc'::text, current_timestamp), NULL, NULL);
+
+INSERT INTO public.role_assignments_dataset (
+    id, dataset_id, data_product_id, user_id, role_id, decision, requested_by_id, requested_on, decided_by_id, decided_on, created_on, updated_on, deleted_at) VALUES (
+    gen_random_uuid(),
+    '{{ dei_access_modes_example_output_port }}'::uuid, (
+        SELECT data_product_id FROM public.datasets
+        WHERE id = '{{ dei_access_modes_example_output_port }}'::uuid), '{{ john_id }}'::uuid, (
+        SELECT r.id FROM public.roles AS r
+        WHERE r.scope = 'dataset' AND r.prototype = 2
+    ), 'APPROVED', '{{ john_id }}'::uuid, '2025-10-28 16:32:57.902449', '{{ john_id }}'::uuid, '2025-10-28 16:32:57.910346', '2025-10-28 16:32:57.89898', '2025-10-28 16:32:57.908607', NULL
+);
+
 
 INSERT INTO public.data_output_configurations (id, configuration_type)
 VALUES ('3e5b2eb0-2d78-4ef4-b73b-57df8d85be11', 'RedshiftTechnicalAssetConfiguration');
@@ -830,6 +844,38 @@ SELECT
     timezone('utc'::text, current_timestamp),
     '{{ jane_id }}'::uuid,
     timezone('utc'::text, current_timestamp),
+    NULL,
+    NULL,
+    '{{ access_mode_read }}'::uuid,
+    timezone('utc'::text, current_timestamp),
+    NULL
+FROM link;
+
+-- Access modes consumer (pending request)
+INSERT INTO public.abstract_data_products (id, status, finalizers, name, namespace, abstract_data_product_type, description, domain_id, created_on, updated_on, deleted_at) VALUES ('{{ access_modes_consumer_pending }}'::uuid, 'active', '{}', 'Access modes consumer pending', 'access_modes_consumer_pending', 'data_products', 'Consumer data product for access mode examples with a pending request.', '{{ customer_domain_id }}'::uuid, timezone('utc'::text, current_timestamp), NULL, NULL);
+
+INSERT INTO public.data_products (id, about, type_id, lifecycle_id, usage)
+VALUES ('{{ access_modes_consumer_pending }}'::uuid, NULL, '1b4a64b3-96fb-404c-a73c-294802dc9852', '{{ data_product_lifecycle_id }}'::uuid, NULL);
+
+WITH link AS (
+    INSERT INTO public.input_ports (id, consuming_abstract_data_product_id, dataset_id, status, created_on, updated_on, deleted_at)
+    VALUES (gen_random_uuid(), '{{ access_modes_consumer_pending }}'::uuid, '{{ dei_access_modes_example_output_port }}'::uuid, 'PENDING', timezone('utc'::text, current_timestamp), NULL, NULL)
+    RETURNING id
+)
+
+INSERT INTO public.input_port_requests (id, input_port_id, decision, justification, decision_note, access_duration_type, requested_duration_days, requested_by_id, requested_on, decided_by_id, decided_on, valid_from, valid_until, access_mode_id, created_on, updated_on)
+SELECT
+    gen_random_uuid(),
+    link.id,
+    'PENDING',
+    'Consumer access for access mode examples.',
+    NULL,
+    'PERMANENT',
+    NULL,
+    '{{ jane_id }}'::uuid,
+    timezone('utc'::text, current_timestamp),
+    NULL,
+    NULL,
     NULL,
     NULL,
     '{{ access_mode_read }}'::uuid,

--- a/frontend/src/components/access-modes/access-mode.component.tsx
+++ b/frontend/src/components/access-modes/access-mode.component.tsx
@@ -1,4 +1,5 @@
 import { Tag, Tooltip } from 'antd';
+import type { ComponentProps } from 'react';
 import { useTranslation } from 'react-i18next';
 
 type AccessModeDisplay = {
@@ -8,16 +9,17 @@ type AccessModeDisplay = {
 };
 type Props = {
     accessMode?: AccessModeDisplay | null;
+    tagProps?: ComponentProps<typeof Tag>;
 };
 
-export default function AccessMode({ accessMode }: Props) {
+export default function AccessMode({ accessMode, tagProps }: Props) {
     const { t } = useTranslation();
     if (!accessMode) {
         return t('None');
     }
     return (
         <Tooltip key={accessMode.id} title={accessMode.description || undefined}>
-            <Tag>{accessMode.name}</Tag>
+            <Tag {...tagProps}>{accessMode.name}</Tag>
         </Tooltip>
     );
 }

--- a/frontend/src/components/pending-access-requests-modal/review-request-modal.tsx
+++ b/frontend/src/components/pending-access-requests-modal/review-request-modal.tsx
@@ -10,8 +10,9 @@ import {
 } from '@ant-design/icons';
 import { Avatar, Button, Card, Col, Divider, Flex, Form, Input, Modal, Row, Space, Typography, theme } from 'antd';
 import { addDays } from 'date-fns';
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import AccessMode from '@/components/access-modes/access-mode.component.tsx';
 import {
     AbstractProductIcon,
     DataProductOutlined,
@@ -20,7 +21,7 @@ import {
 } from '@/components/icons';
 import { AccessDurationType } from '@/store/api/services/generated/configurationAccessDurationsApi.ts';
 import { RenewalStatus } from '@/store/api/services/generated/dataProductsOutputPortsInputPortsApi.ts';
-import type { AbstractDataProductType } from '@/store/api/services/generated/usersApi.ts';
+import type { AbstractDataProductType, InputPortRequest } from '@/store/api/services/generated/usersApi.ts';
 import {
     type Request,
     RequestType_DataProductRoleAssignment,
@@ -53,7 +54,7 @@ type RequestDetails = {
         type: string;
         icon: React.ReactNode;
     };
-    accessType: string;
+    accessType: string | ReactNode;
     justification: string;
     hasJustification: boolean;
     requestedOn: string;
@@ -98,11 +99,14 @@ const abstractDataProductTypeName = (type: AbstractDataProductType) => {
     }
 };
 
+const isInputPortRequest = (action: Request): action is InputPortRequest =>
+    action.request_type === RequestType_InputPort;
+
 function getRequestDetails(
     action: Request,
     t: (key: string, params?: Record<string, string>) => string,
 ): RequestDetails | undefined {
-    if (action.request_type === RequestType_InputPort) {
+    if (isInputPortRequest(action)) {
         return {
             requesterName: `${action.requested_by.first_name} ${action.requested_by.last_name}`,
             requesterEmail: action.requested_by.email,
@@ -126,7 +130,14 @@ function getRequestDetails(
                 type: t('Output Port'),
                 icon: <OutputPortOutlined />,
             },
-            accessType: t('READ ONLY'),
+            accessType: action.access_mode ? (
+                <AccessMode
+                    accessMode={action.access_mode}
+                    tagProps={{ style: { fontSize: 16, fontWeight: 700, paddingInline: 10, paddingBlock: 2 } }}
+                />
+            ) : (
+                t('READ ONLY')
+            ),
             justification: action.justification || t('No justification provided'),
             hasJustification: true,
             requestedOn: action.requested_on,
@@ -217,7 +228,7 @@ export function ReviewRequestModal({ action, open, onClose, onAccept, onReject }
 
     const handleReject = () => {
         const { decisionNote } = form.getFieldsValue();
-        if (action.request_type === RequestType_InputPort && !decisionNote?.trim()) {
+        if (isInputPortRequest(action) && !decisionNote?.trim()) {
             form.setFields([{ name: 'decisionNote', errors: [t('A decision note is required when declining')] }]);
             return;
         }
@@ -257,8 +268,8 @@ export function ReviewRequestModal({ action, open, onClose, onAccept, onReject }
             {/* 3-Tile Access Visualization using Antd Row/Col */}
             <Row gutter={[16, 16]}>
                 {/* Requesting Consumer Tile */}
-                <Col span={9}>
-                    <Card size="small" variant="outlined">
+                <Col span={9} style={{ display: 'flex' }}>
+                    <Card size="small" variant="outlined" style={{ flex: 1 }}>
                         <Typography.Text strong style={{ fontSize: 12 }}>
                             {t('Requesting Consumer')}
                         </Typography.Text>
@@ -280,20 +291,30 @@ export function ReviewRequestModal({ action, open, onClose, onAccept, onReject }
                 </Col>
                 {/* Requests Role/Access Tile (smaller) */}
                 <Col span={6} style={{ display: 'flex' }}>
-                    <Card size="small" variant="outlined" style={{ flex: 1 }}>
+                    <Card
+                        size="small"
+                        variant="outlined"
+                        style={{ flex: 1 }}
+                        styles={{ body: { display: 'flex', flexDirection: 'column', height: '100%' } }}
+                    >
                         <Typography.Text strong style={{ fontSize: 12 }}>
                             {details.requestType === t('Role Assignment') ? t('Requests Role') : t('Requests Access')}
                         </Typography.Text>
-                        <Flex align="center" justify="center">
-                            <Typography.Text strong style={{ fontSize: 16 }}>
-                                {details.accessType}
-                            </Typography.Text>
+
+                        <Flex align="center" justify="center" style={{ flex: 1 }}>
+                            {typeof details.accessType === 'string' ? (
+                                <Typography.Text strong style={{ fontSize: 16 }}>
+                                    {details.accessType}
+                                </Typography.Text>
+                            ) : (
+                                details.accessType
+                            )}
                         </Flex>
                     </Card>
                 </Col>
                 {/* Requested Resource Tile */}
-                <Col span={9}>
-                    <Card size="small" variant="outlined">
+                <Col span={9} style={{ display: 'flex' }}>
+                    <Card size="small" variant="outlined" style={{ flex: 1 }}>
                         <Typography.Text strong style={{ fontSize: 12 }}>
                             {t('Requested Resource')}
                         </Typography.Text>
@@ -427,7 +448,7 @@ export function ReviewRequestModal({ action, open, onClose, onAccept, onReject }
                         </Flex>
                     </Card>
                 </Col>
-                {action.request_type === RequestType_InputPort && (
+                {isInputPortRequest(action) && (
                     <Col span={24}>
                         <Form form={form} layout="vertical">
                             <Form.Item


### PR DESCRIPTION
In support of: #3981

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested.

Access modes:
<img width="924" height="760" alt="image" src="https://github.com/user-attachments/assets/e34bdd8e-d041-4ca1-b46e-d4e5b31d38bb" />

Normal variant:
<img width="903" height="762" alt="image" src="https://github.com/user-attachments/assets/9e4fdd01-d210-45d6-9c17-76ba531ba8de" />


Also fixed it so that all boxes are full widht and height