### PR TITLE
Fix front end test flakes

### DIFF
--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
-import { afterAll, afterEach, beforeAll } from 'vitest';
+import { afterAll, afterEach, beforeAll, vi } from 'vitest';
 import { server } from './mocks/server';
 
 (globalThis as Record<string, unknown>).config = {
@@ -40,6 +40,10 @@ beforeAll(() => {
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
 afterEach(() => {
+    // Clear any pending timers created by UI libraries (for example useDelayState from
+    // @rc-component/util). Those delayed callbacks can fire after jsdom teardown and attempt
+    // to access window, which would otherwise throw ReferenceError: window is not defined.
+    vi.clearAllTimers();
     server.resetHandlers();
     cleanup();
 });

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -39,11 +39,11 @@ beforeAll(() => {
 });
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
-afterEach(() => {
-    // Clear any pending timers created by UI libraries (for example useDelayState from
-    // @rc-component/util). Those delayed callbacks can fire after jsdom teardown and attempt
+afterEach(async () => {
+    // Ensure all pending timers created by UI libraries (for example useDelayState from
+    // @rc-component/util) are ran. Those delayed callbacks can fire after jsdom teardown and attempt
     // to access window, which would otherwise throw ReferenceError: window is not defined.
-    vi.clearAllTimers();
+    await vi.runAllTimersAsync();
     server.resetHandlers();
     cleanup();
 });


### PR DESCRIPTION
By clearing times after each test, UI components
have delayed callbacks that try to do something,
but everything is already torn down. Resulting in
failure to access window for example.

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested.


Should fix issues like this, this PR adds and ADR so no front end change 
<img width="2554" height="1313" alt="image" src="https://github.com/user-attachments/assets/d6a97583-879c-40d2-b600-4639edd741d8" />
