### PR TITLE
First implementation of hidden data products

### DIFF
--- a/backend/app/authorization/role_assignments/output_port/router.py
+++ b/backend/app/authorization/role_assignments/output_port/router.py
@@ -23,8 +23,8 @@ from app.core.auth.auth import get_authenticated_user
 from app.core.authz import Action, Authorization
 from app.core.authz.resolvers import (
     DatasetResolver,
-    DatasetRoleAssignmentResolver,
     EmptyResolver,
+    OutputPortRoleAssignmentResolver,
 )
 from app.database.database import get_db_session
 from app.events.enums import EventReferenceEntity, EventType
@@ -42,7 +42,7 @@ router = APIRouter(prefix="/v2/authz/role_assignments/output_port")
         Depends(
             Authorization.enforce(
                 Action.OUTPUT_PORT__DELETE_USER,
-                resolver=DatasetRoleAssignmentResolver,
+                resolver=OutputPortRoleAssignmentResolver,
             )
         )
     ],
@@ -216,7 +216,7 @@ def create_output_port_role_assignment(
         Depends(
             Authorization.enforce(
                 Action.OUTPUT_PORT__APPROVE_USER_REQUEST,
-                resolver=DatasetRoleAssignmentResolver,
+                resolver=OutputPortRoleAssignmentResolver,
             )
         )
     ],
@@ -280,7 +280,7 @@ def decide_output_port_role_assignment(
         Depends(
             Authorization.enforce(
                 Action.OUTPUT_PORT__UPDATE_USER,
-                resolver=DatasetRoleAssignmentResolver,
+                resolver=OutputPortRoleAssignmentResolver,
             )
         )
     ],

--- a/backend/app/authorization/roles/model.py
+++ b/backend/app/authorization/roles/model.py
@@ -1,10 +1,12 @@
 import uuid
 
 from sqlalchemy import Column, Integer, SmallInteger, String
+from sqlalchemy import Enum as SAEnum
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
-from sqlalchemy.orm import mapped_column
+from sqlalchemy.orm import mapped_column, validates
 
-from app.authorization.roles.schema import Prototype
+from app.authorization.roles.schema import Prototype, Scope
+from app.core.authz.actions import AuthorizationAction
 from app.database.database import Base
 from app.shared.model import BaseORM
 
@@ -14,7 +16,34 @@ class Role(Base, BaseORM):
 
     id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String)
-    scope = Column(String)
+
+    scope = mapped_column(
+        SAEnum(
+            Scope,
+            values_callable=lambda enum: [e.value for e in enum],
+            native_enum=False,
+            validate_strings=True,
+        ),
+        nullable=False,
+    )
     prototype = Column(SmallInteger, default=Prototype.CUSTOM)
     description = Column(String)
     permissions = Column(ARRAY(Integer))
+
+    @validates("permissions")
+    def validate_permissions(self, key: str, permissions: list[int]) -> list[int]:
+        """
+        For a Data Product role we want to ensure that the HIDDEN_DATA_PRODUCT__READ permission is always included,
+        even if not explicitly set.
+        This permission is required to ensure people have access to hidden data products.
+        """
+
+        if (
+            self.scope == Scope.DATA_PRODUCT
+            and int(AuthorizationAction.HIDDEN_DATA_PRODUCT__READ) not in permissions
+        ):
+            permissions = [
+                *permissions,
+                int(AuthorizationAction.HIDDEN_DATA_PRODUCT__READ),
+            ]
+        return sorted(set(permissions))

--- a/backend/app/authorization/roles/service.py
+++ b/backend/app/authorization/roles/service.py
@@ -34,7 +34,6 @@ class RoleService:
     ) -> Role:
         model = RoleModel(**role.parse_pydantic_schema())
         model.prototype = prototype
-        model.permissions = self._canonical_permissions(model.permissions)
         self.db.add(model)
         self.db.commit()
         return model
@@ -53,8 +52,6 @@ class RoleService:
                 detail="You cannot change the permissions of the admin role",
             )
         for k, v in update.items():
-            if k == "permissions":
-                v = self._canonical_permissions(v)
             setattr(role, k, v)
 
         self.db.commit()
@@ -71,12 +68,6 @@ class RoleService:
         self.db.delete(role)
         self.db.commit()
         return role
-
-    @staticmethod
-    def _canonical_permissions(permissions: list[int]) -> list[int]:
-        result = list(set(permissions))
-        result.sort()
-        return result
 
     def find_prototype(self, scope: Scope, prototype: Prototype) -> Role:
         return self.db.scalars(

--- a/backend/app/authorization/service.py
+++ b/backend/app/authorization/service.py
@@ -1,7 +1,5 @@
-from typing import TYPE_CHECKING
-
-from casbin_sqlalchemy_adapter import Adapter, CasbinRule
-from sqlalchemy import delete, func, select
+from casbin_sqlalchemy_adapter import CasbinRule
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.authorization.role_assignments.data_product.auth import (
@@ -22,10 +20,10 @@ from app.authorization.role_assignments.output_port.service import (
 from app.authorization.roles.auth import AuthRole
 from app.authorization.roles.service import RoleService
 from app.core.authz import Authorization
+from app.core.authz.actions import AuthorizationAction
 from app.core.logging import logger
 
-if TYPE_CHECKING:
-    from casbin import SyncedEnforcer
+DATA_PRODUCT_READER_ROLE = "/role/data-product-reader"
 
 
 class AuthorizationService:
@@ -34,8 +32,7 @@ class AuthorizationService:
         self.authorizer = Authorization()
 
     def reload_enforcer(self) -> None:
-        removed = self._clear_casbin_table()
-        logger.info(f"Removed {removed} rows from the casbin table")
+        self.authorizer.pause_enforcer_for_reload()
 
         changed_roles, total_roles = self._sync_roles()
         logger.info(f"Synced {changed_roles}/{total_roles} roles to the casbin table")
@@ -58,25 +55,15 @@ class AuthorizationService:
             " global assignments to the casbin table"
         )
 
+        self._sync_data_product_reader_role()
+        logger.info("Synced data product reader role permissions")
+
+        self.authorizer.start_enforcer_after_reload()
+
         logger.info(
             "Authorization reload done - the casbin table"
             f" now contains {self._casbin_row_count(self.db)} rows"
         )
-
-    @classmethod
-    def _clear_casbin_table(cls) -> int:
-        """Clears the database table used by casbin. Use with caution!
-        This means the casbin table will be out of sync with the role assignments.
-        """
-        authorizer = Authorization()
-        enforcer: SyncedEnforcer = authorizer._enforcer
-        adapter: Adapter = enforcer._e.adapter
-
-        enforcer.clear_policy()
-        with adapter._session_scope() as session:
-            count = cls._casbin_row_count(session)
-            session.execute(delete(CasbinRule))
-        return count
 
     @staticmethod
     def _casbin_row_count(session: Session) -> int:
@@ -127,3 +114,12 @@ class AuthorizationService:
             if GlobalAuthAssignment(assignment).add():
                 changes += 1
         return changes, len(global_assignments)
+
+    def _sync_data_product_reader_role(self):
+        from app.data_products.service import DataProductService
+
+        self.authorizer.sync_role_permissions(
+            role_id=DATA_PRODUCT_READER_ROLE,
+            actions=[AuthorizationAction.HIDDEN_DATA_PRODUCT__READ],
+        )
+        DataProductService(self.db).sync_discoverable_data_products()

--- a/backend/app/configuration/data_product_types/service.py
+++ b/backend/app/configuration/data_product_types/service.py
@@ -92,7 +92,6 @@ class DataProductTypeService:
             )
 
         self.db.delete(data_product_type)
-        self.db.commit()
 
     def migrate_data_product_type(self, from_id: UUID, to_id: UUID) -> None:
         data_product_type = ensure_data_product_type_exists(
@@ -104,5 +103,3 @@ class DataProductTypeService:
 
         for data_product in data_product_type.data_products:
             data_product.type_id = new_data_product_type.id
-
-        self.db.commit()

--- a/backend/app/core/authz/__init__.py
+++ b/backend/app/core/authz/__init__.py
@@ -2,17 +2,17 @@ from .actions import AuthorizationAction as Action
 from .authorization import Authorization
 from .resolvers import (
     DataOutputDatasetAssociationResolver,
-    DataOutputResolver,
     DataProductDatasetAssociationResolver,
     DataProductResolver,
     DatasetResolver,
+    TechnicalAssetResolver,
 )
 
 __all__ = (
     "Action",
     "Authorization",
     "DataOutputDatasetAssociationResolver",
-    "DataOutputResolver",
+    "TechnicalAssetResolver",
     "DataProductDatasetAssociationResolver",
     "DataProductResolver",
     "DatasetResolver",

--- a/backend/app/core/authz/actions.py
+++ b/backend/app/core/authz/actions.py
@@ -50,3 +50,8 @@ class AuthorizationAction(IntEnum):
     OUTPUT_PORT__READ_INTEGRATIONS = 413
     OUTPUT_PORT__UPDATE_DATA_QUALITY = 414
     OUTPUT_PORT__UPDATE_CONTRACT = 415
+
+    # The hidden section contains actions that can't be modified by Portal admins. They are used to ensure hidden
+    # Data Products are not accessible by default to any user, and can only be accessed by users with the right permissions.
+    # Discoverable Data Products ensure that everyone has this permission on their Data Product without any role.
+    HIDDEN_DATA_PRODUCT__READ = 901

--- a/backend/app/core/authz/authorization.py
+++ b/backend/app/core/authz/authorization.py
@@ -153,6 +153,22 @@ class Authorization(metaclass=Singleton):
         self._after_update()
         return updated
 
+    def pause_enforcer_for_reload(self) -> None:
+        """This stops autoloading and auto policy saving of the enforcer.
+        IT ALSO CLEARS ALL POLICIES FROM CASBIN.
+        To be used when you want to recreate the casbin table.
+        By pausing these it goes faster and avoids race conditions."""
+        self._enforcer.stop_auto_load_policy()
+        self._enforcer.enable_auto_save(False)
+        self._enforcer.clear_policy()
+
+    def start_enforcer_after_reload(self) -> None:
+        """This resumes autoloading and auto policy saving of the enforcer. It also flushes the current policy to the database.
+        To be used when you want to recreate the casbin table, to be used after pause_enforcer_for_reload."""
+        self._enforcer.save_policy()
+        self._enforcer.start_auto_load_policy(settings.AUTHORIZER_AUTOLOAD_INTERVAL)
+        self._enforcer.enable_auto_save(True)
+
     def revoke_domain_role(self, *, user_id: ID, role_id: ID, domain_id: ID) -> bool:
         """Deletes the entry in the casbin table,
         revoking the role for the chosen domain and user."""

--- a/backend/app/core/authz/rbac_model.conf
+++ b/backend/app/core/authz/rbac_model.conf
@@ -16,6 +16,7 @@ e = some(where (p.eft == allow))
 m = g3(r.sub, "*") || (( \
     p.sub == "*" \
     || g(r.sub, p.sub, r.obj) \
+    || g("*", p.sub, r.obj) \
     || g2(r.sub, p.sub, r.dom) \
     || g3(r.sub, p.sub) \
 ) && r.act == p.act)

--- a/backend/app/core/authz/readme.md
+++ b/backend/app/core/authz/readme.md
@@ -25,11 +25,12 @@ The `p` lines define policies (meaning a single rule to evaluate).
 The `g`, `g2` and `g3` lines define different role assignments.
 
 ```
-p, role1, read
+p, role1, delete
 p, role1, write
 p, role1, update
-p, role2, read
+p, role2, update
 p, role2, delete
+p, /role/dataproductreader, read
 p, *, dance -- policy for everyone
 
 g, alice, role1, dataset1 -- resource role assignment
@@ -37,6 +38,7 @@ g, bob, role1, dataset2 -- resource role assignment
 g2, alice, role1, domain1 -- domain role assignment
 g2, bob, role2, domain1 -- domain role assignment
 g3, carol, * -- admin assignment
+g, *, /role/dataproductreader, product1
 ```
 
 ### Requests
@@ -44,10 +46,18 @@ g3, carol, * -- admin assignment
 Some example requests with their outputs.
 
 ```
-alice, domain1, dataset1, read -- true, role1 can read dataset1
-alice, domain1, dataset1, delete -- false, role1 cannot delete dataset1
+alice, domain1, dataset1, write -- true, role1 can write dataset1
+alice, domain1, dataset1, spoof -- false, role1 cannot spoof dataset1
 bob, domain1, dataset1, delete -- true, role2 can delete in domain1
 carol, foo, bar, baz -- true, carol is admin
 john, foo, bar, dance -- true, everyone is allowed to dance
 john, domain1, dataset1, read -- false, john has no role assigned
+anyone, domain1, product1, read -- true, everyone can read product1
 ```
+
+## Hidden data product access
+
+Hidden data products are supported through a read only role, that is added with policy read.
+This read action will be added by default to add data product roles, and is hidden for users.
+But this action will give you rights to any data product you have access to.
+And visible data products will use the g("*", public_reader_role_id, product_id) wildcard to allow access to all users.

--- a/backend/app/core/authz/resolvers.py
+++ b/backend/app/core/authz/resolvers.py
@@ -37,7 +37,7 @@ class SubjectResolver(ABC):
         cls, request: Request, key: str, db: Session = Depends(get_db_session)
     ):
         if (result := request.query_params.get(key)) is not None:
-            return cast("str", result)
+            return result
         if (result := request.path_params.get(key)) is not None:
             return cast("str", result)
         json_body = await request.json()
@@ -74,7 +74,7 @@ class ExplorationResolver(SubjectResolver):
     model: Model = Exploration
 
 
-class DatasetRoleAssignmentResolver(SubjectResolver):
+class OutputPortRoleAssignmentResolver(SubjectResolver):
     model: Model = DataProduct
 
     @classmethod
@@ -154,7 +154,7 @@ class DataProductNameResolver(SubjectResolver):
         return cls.DEFAULT
 
 
-class DataOutputResolver(SubjectResolver):
+class TechnicalAssetResolver(SubjectResolver):
     model: Model = DataProduct
 
     @classmethod
@@ -163,13 +163,13 @@ class DataOutputResolver(SubjectResolver):
     ):
         obj = await DataProductResolver.resolve(request, key, db)
         if obj != cls.DEFAULT:
-            data_output = (
+            technical_asset = (
                 db.scalars(select(TechnicalAsset).where(TechnicalAsset.id == obj))
                 .unique()
                 .one_or_none()
             )
-            if data_output:
-                return data_output.owner_id
+            if technical_asset:
+                return technical_asset.owner_id
         return cls.DEFAULT
 
 

--- a/backend/app/data_products/model.py
+++ b/backend/app/data_products/model.py
@@ -1,6 +1,8 @@
+import enum
 from typing import TYPE_CHECKING
 
 from sqlalchemy import Column, ForeignKey, String, func, select
+from sqlalchemy import Enum as SAEnum
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, Session, column_property, mapped_column, relationship
 
@@ -27,6 +29,11 @@ if TYPE_CHECKING:
     )
 
 
+class DataProductVisibility(enum.Enum):
+    HIDDEN = "hidden"
+    DISCOVERABLE = "discoverable"
+
+
 class DataProduct(
     AbstractDataProduct,
     EventTrackedMixin,
@@ -38,6 +45,16 @@ class DataProduct(
     )
     about = Column(String)
     usage = Column(String, nullable=True)
+    visibility = mapped_column(
+        SAEnum(
+            DataProductVisibility,
+            values_callable=lambda enum: [e.value for e in enum],
+            native_enum=False,
+            validate_strings=True,
+        ),
+        nullable=False,
+        default=DataProductVisibility.DISCOVERABLE,
+    )
 
     type_id: Mapped[UUID] = mapped_column(ForeignKey("data_product_types.id"))
     lifecycle_id: Mapped[UUID] = mapped_column(

--- a/backend/app/data_products/router.py
+++ b/backend/app/data_products/router.py
@@ -383,7 +383,14 @@ def update_data_product_usage(
     )
 
 
-@router.get("/{id}/graph")
+@router.get(
+    "/{id}/graph",
+    dependencies=[
+        Depends(
+            Authorization.enforce(Action.HIDDEN_DATA_PRODUCT__READ, DataProductResolver)
+        )
+    ],
+)
 def get_data_product_graph_data(
     id: UUID, db: Session = Depends(get_db_session), level: int = 3
 ) -> Graph:
@@ -580,7 +587,14 @@ def get_data_products(
     )
 
 
-@router.get("/{id}/history")
+@router.get(
+    "/{id}/history",
+    dependencies=[
+        Depends(
+            Authorization.enforce(Action.HIDDEN_DATA_PRODUCT__READ, DataProductResolver)
+        )
+    ],
+)
 def get_data_product_event_history(
     id: UUID, db: Session = Depends(get_db_session)
 ) -> GetEventHistoryResponse:
@@ -594,14 +608,28 @@ def get_data_product_event_history(
     )
 
 
-@router.get("/{id}")
+@router.get(
+    "/{id}",
+    dependencies=[
+        Depends(
+            Authorization.enforce(Action.HIDDEN_DATA_PRODUCT__READ, DataProductResolver)
+        )
+    ],
+)
 def get_data_product(
     id: UUID, db: Session = Depends(get_db_session)
 ) -> GetDataProductResponse:
     return DataProductService(db).get_data_product(id)
 
 
-@router.get("/{id}/input_ports")
+@router.get(
+    "/{id}/input_ports",
+    dependencies=[
+        Depends(
+            Authorization.enforce(Action.HIDDEN_DATA_PRODUCT__READ, DataProductResolver)
+        )
+    ],
+)
 def get_data_product_input_ports(
     id: UUID,
     db: Session = Depends(get_db_session),
@@ -614,7 +642,14 @@ def get_data_product_input_ports(
     )
 
 
-@router.get("/{id}/rolled_up_tags")
+@router.get(
+    "/{id}/rolled_up_tags",
+    dependencies=[
+        Depends(
+            Authorization.enforce(Action.HIDDEN_DATA_PRODUCT__READ, DataProductResolver)
+        )
+    ],
+)
 def get_data_product_rolled_up_tags(
     id: UUID, db: Session = Depends(get_db_session)
 ) -> GetDataProductRolledUpTagsResponse:
@@ -695,7 +730,14 @@ def remove_input_port_for_data_product(
         )
 
 
-@router.get("/{id}/settings")
+@router.get(
+    "/{id}/settings",
+    dependencies=[
+        Depends(
+            Authorization.enforce(Action.HIDDEN_DATA_PRODUCT__READ, DataProductResolver)
+        )
+    ],
+)
 def get_data_product_settings(
     id: UUID, db: Session = Depends(get_db_session)
 ) -> GetDataProductSettingsResponse:

--- a/backend/app/data_products/service.py
+++ b/backend/app/data_products/service.py
@@ -16,6 +16,7 @@ from app.abstract_data_product.input_ports.model import (
 from app.abstract_data_product.service import AbstractDataProductService
 from app.authorization.role_assignments.enums import DecisionStatus
 from app.authorization.roles.schema import Prototype
+from app.authorization.service import DATA_PRODUCT_READER_ROLE
 from app.configuration.data_product_lifecycles.model import (
     DataProductLifecycle as DataProductLifeCycleModel,
 )
@@ -23,13 +24,14 @@ from app.configuration.data_product_settings.model import DataProductSettingValu
 from app.configuration.tags.model import Tag as TagModel
 from app.configuration.tags.model import ensure_tag_exists
 from app.configuration.tags.schema import Tag
+from app.core.authz import Authorization
 from app.core.aws.get_url import _get_data_product_role_arn
 from app.core.namespace.validation import (
     NamespaceValidator,
     TechnicalAssetNamespaceValidator,
 )
 from app.data_products.model import DataProduct as DataProductModel
-from app.data_products.model import ensure_data_product_exists
+from app.data_products.model import DataProductVisibility, ensure_data_product_exists
 from app.data_products.output_port_technical_assets_link.model import (
     DataOutputDatasetAssociation,
 )
@@ -61,6 +63,23 @@ class DataProductService(AbstractDataProductService):
         super().__init__(db)
         self.namespace_validator = NamespaceValidator(DataProductModel)
         self.technical_asset_namespace_validator = TechnicalAssetNamespaceValidator()
+
+    @staticmethod
+    def _sync_public_reader_grouping(
+        data_product_id: UUID, visibility: DataProductVisibility
+    ) -> None:
+        if visibility == DataProductVisibility.DISCOVERABLE:
+            Authorization().assign_resource_role(
+                user_id="*",
+                role_id=DATA_PRODUCT_READER_ROLE,
+                resource_id=str(data_product_id),
+            )
+        else:
+            Authorization().revoke_resource_role(
+                user_id="*",
+                role_id=DATA_PRODUCT_READER_ROLE,
+                resource_id=str(data_product_id),
+            )
 
     def get_data_product_settings(
         self, data_product_id: UUID
@@ -183,6 +202,8 @@ class DataProductService(AbstractDataProductService):
         model = DataProductModel(**data_product_schema, tags=tags)
         self.db.add(model)
         self.db.commit()
+        self._sync_public_reader_grouping(model.id, model.visibility)
+        self.db.commit()
         return model
 
     def remove_data_product(self, id: UUID) -> DataProductModel:
@@ -223,14 +244,23 @@ class DataProductService(AbstractDataProductService):
                 detail=f"Invalid namespace: {validity.value}",
             )
 
+        visibility_change = None
         for k, v in update_data_product.items():
             if k == "tag_ids":
                 new_tags = self._get_tags(v)
                 current_data_product.tags = new_tags
+            elif k == "visibility":
+                visibility_change = current_data_product.visibility
+                setattr(current_data_product, k, v)
             else:
                 setattr(current_data_product, k, v) if v else None
 
         self.db.commit()
+        if visibility_change is not None:
+            self._sync_public_reader_grouping(
+                current_data_product.id, current_data_product.visibility
+            )
+            self.db.commit()
         return UpdateDataProductResponse(id=current_data_product.id)
 
     def update_data_product_about(
@@ -421,3 +451,12 @@ class DataProductService(AbstractDataProductService):
                 )
 
         return Graph(nodes=set(nodes), edges=set(edges))
+
+    def sync_discoverable_data_products(self):
+        visible_data_product_ids = self.db.scalars(
+            select(DataProductModel.id).where(
+                DataProductModel.visibility == DataProductVisibility.DISCOVERABLE
+            )
+        ).all()
+        for id in visible_data_product_ids:
+            self._sync_public_reader_grouping(id, DataProductVisibility.DISCOVERABLE)

--- a/backend/app/data_products/technical_assets/router.py
+++ b/backend/app/data_products/technical_assets/router.py
@@ -7,8 +7,8 @@ from app.core.auth.auth import get_authenticated_user
 from app.core.authz import (
     Action,
     Authorization,
-    DataOutputResolver,
     DataProductResolver,
+    TechnicalAssetResolver,
 )
 from app.data_products.technical_assets.model import ensure_technical_asset_exists
 from app.data_products.technical_assets.schema_request import (
@@ -41,7 +41,18 @@ router = APIRouter(
 )
 
 
-@router.get("/")
+@router.get(
+    "/",
+    dependencies=[
+        Depends(
+            Authorization.enforce(
+                Action.HIDDEN_DATA_PRODUCT__READ,
+                DataProductResolver,
+                object_id="data_product_id",
+            )
+        )
+    ],
+)
 def get_data_product_technical_assets(
     data_product_id: UUID, db: Session = Depends(get_db_session)
 ) -> GetTechnicalAssetsResponse:
@@ -55,7 +66,18 @@ def get_data_product_technical_assets(
     )
 
 
-@router.get("/{id}")
+@router.get(
+    "/{id}",
+    dependencies=[
+        Depends(
+            Authorization.enforce(
+                Action.HIDDEN_DATA_PRODUCT__READ,
+                DataProductResolver,
+                object_id="data_product_id",
+            )
+        )
+    ],
+)
 def get_technical_asset(
     data_product_id: UUID, id: UUID, db: Session = Depends(get_db_session)
 ) -> GetTechnicalAssetsResponseItem:
@@ -64,7 +86,18 @@ def get_technical_asset(
     )
 
 
-@router.get("/{id}/history")
+@router.get(
+    "/{id}/history",
+    dependencies=[
+        Depends(
+            Authorization.enforce(
+                Action.HIDDEN_DATA_PRODUCT__READ,
+                DataProductResolver,
+                object_id="data_product_id",
+            )
+        )
+    ],
+)
 def get_technical_asset_event_history(
     data_product_id: UUID, id: UUID, db: Session = Depends(get_db_session)
 ) -> GetEventHistoryResponse:
@@ -95,7 +128,7 @@ def get_technical_asset_event_history(
         Depends(
             Authorization.enforce(
                 Action.DATA_PRODUCT__DELETE_TECHNICAL_ASSET,
-                DataOutputResolver,
+                TechnicalAssetResolver,
             )
         ),
     ],
@@ -140,7 +173,7 @@ def remove_technical_asset(
         Depends(
             Authorization.enforce(
                 Action.DATA_PRODUCT__UPDATE_TECHNICAL_ASSET,
-                DataOutputResolver,
+                TechnicalAssetResolver,
             )
         ),
     ],
@@ -180,7 +213,7 @@ def update_technical_asset(
         Depends(
             Authorization.enforce(
                 Action.DATA_PRODUCT__UPDATE_TECHNICAL_ASSET,
-                DataOutputResolver,
+                TechnicalAssetResolver,
             )
         ),
     ],
@@ -205,7 +238,18 @@ def update_technical_asset_status(
     )
 
 
-@router.get("/{id}/graph")
+@router.get(
+    "/{id}/graph",
+    dependencies=[
+        Depends(
+            Authorization.enforce(
+                Action.HIDDEN_DATA_PRODUCT__READ,
+                DataProductResolver,
+                object_id="data_product_id",
+            )
+        )
+    ],
+)
 def get_technical_asset_graph_data(
     data_product_id: UUID,
     id: UUID,

--- a/backend/app/database/alembic/versions/2026_08_25_1136-676a29542f0b_data_product_visibility.py
+++ b/backend/app/database/alembic/versions/2026_08_25_1136-676a29542f0b_data_product_visibility.py
@@ -1,0 +1,63 @@
+"""Data product visibility
+
+Revision ID: 676a29542f0b
+Revises: e4b81c7d2f90
+Create Date: 2026-08-25 11:36:05.162137
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.authorization.roles.schema import Scope
+from app.core.authz.actions import AuthorizationAction
+
+# revision identifiers, used by Alembic.
+revision: str = "676a29542f0b"
+down_revision: Union[str, None] = "e4b81c7d2f90"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "data_products",
+        sa.Column(
+            "visibility",
+            sa.String(),
+            nullable=False,
+            server_default="discoverable",
+        ),
+    )
+
+    op.execute(
+        sa.text(
+            """
+            UPDATE roles
+            SET permissions = COALESCE(permissions, ARRAY[]::int[]) || :read_action
+            WHERE scope = :scope
+              AND NOT (:read_action = ANY(COALESCE(permissions, ARRAY[]::int[])))
+            """
+        ).bindparams(
+            read_action=int(AuthorizationAction.HIDDEN_DATA_PRODUCT__READ),
+            scope=Scope.DATA_PRODUCT,
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            UPDATE roles
+            SET permissions = array_remove(permissions, :read_action)
+            WHERE scope = :scope
+            """
+        ).bindparams(
+            read_action=int(AuthorizationAction.HIDDEN_DATA_PRODUCT__READ),
+            scope=Scope.DATA_PRODUCT,
+        )
+    )
+    op.drop_column("data_products", "visibility")

--- a/backend/tests/app/authorization/role_assignments/data_product/test_router.py
+++ b/backend/tests/app/authorization/role_assignments/data_product/test_router.py
@@ -236,21 +236,24 @@ class TestDataProductRoleAssignmentsRouter:
         assert {approver.id for approver in approvers} == {other_approver.id}
         assert requester.id not in {approver.id for approver in approvers}
 
-    def test_request_assignment_no_right(self, client: TestClient):
+    def test_request_assignment_no_right(
+        self, client: TestClient, everyone_role_permissions
+    ):
         data_product: DataProduct = DataProductFactory()
         UserFactory(external_id=settings.DEFAULT_USERNAME)
 
         user: User = UserFactory()
         role: Role = RoleFactory(scope=Scope.DATA_PRODUCT)
 
-        response = client.post(
-            f"{ENDPOINT}/request",
-            json={
-                "user_id": str(user.id),
-                "role_id": str(role.id),
-                "data_product_id": str(data_product.id),
-            },
-        )
+        with everyone_role_permissions(permissions=[]):
+            response = client.post(
+                f"{ENDPOINT}/request",
+                json={
+                    "user_id": str(user.id),
+                    "role_id": str(role.id),
+                    "data_product_id": str(data_product.id),
+                },
+            )
         assert response.status_code == 403
 
     def test_delete_assignment(self, client: TestClient):

--- a/backend/tests/app/authorization/role_assignments/output_port/test_router.py
+++ b/backend/tests/app/authorization/role_assignments/output_port/test_router.py
@@ -161,21 +161,24 @@ class TestDatasetRoleAssignmentsRouter:
         self.test_request_assignment(client)
         assert_event_in_queue("output_port_role_assignment.event", capture_events)
 
-    def test_request_assignment_no_right(self, client: TestClient):
+    def test_request_assignment_no_right(
+        self, client: TestClient, everyone_role_permissions
+    ):
         dataset: Dataset = OutputPortFactory()
         UserFactory(external_id=settings.DEFAULT_USERNAME)
 
         user: User = UserFactory()
         role: Role = RoleFactory(scope=Scope.DATASET)
 
-        response = client.post(
-            f"{ENDPOINT}/request",
-            json={
-                "output_port_id": str(dataset.id),
-                "user_id": str(user.id),
-                "role_id": str(role.id),
-            },
-        )
+        with everyone_role_permissions(permissions=[]):
+            response = client.post(
+                f"{ENDPOINT}/request",
+                json={
+                    "output_port_id": str(dataset.id),
+                    "user_id": str(user.id),
+                    "role_id": str(role.id),
+                },
+            )
         assert response.status_code == 403
 
     def test_delete_assignment(self, client: TestClient):

--- a/backend/tests/app/authorization/roles/test_router.py
+++ b/backend/tests/app/authorization/roles/test_router.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 
 from app.authorization.roles import ADMIN_UUID
 from app.authorization.roles.schema import Role, Scope
+from app.core.authz.actions import AuthorizationAction
 from tests.factories import RoleFactory
 
 ENDPOINT = "/api/v2/authz/roles"
@@ -43,6 +44,31 @@ class TestRolesRouter:
         assert data["permissions"] == self.test_role["permissions"]
 
     @pytest.mark.usefixtures("admin")
+    def test_create_data_product_role_adds_read_permission(self, client: TestClient):
+        response = client.post(
+            ENDPOINT,
+            json={
+                "name": "data product role",
+                "scope": Scope.DATA_PRODUCT,
+                "description": "data product role description",
+                "permissions": [
+                    int(AuthorizationAction.DATA_PRODUCT__UPDATE_PROPERTIES)
+                ],
+            },
+        )
+        assert response.status_code == 200, response.text
+
+        data = response.json()
+        assert data["scope"] == Scope.DATA_PRODUCT
+        assert AuthorizationAction.HIDDEN_DATA_PRODUCT__READ in data["permissions"]
+        assert data["permissions"] == sorted(
+            [
+                int(AuthorizationAction.HIDDEN_DATA_PRODUCT__READ),
+                int(AuthorizationAction.DATA_PRODUCT__UPDATE_PROPERTIES),
+            ]
+        )
+
+    @pytest.mark.usefixtures("admin")
     def test_update_role_old(self, client: TestClient):
         role: Role = RoleFactory()
         response = client.put(
@@ -53,6 +79,37 @@ class TestRolesRouter:
             },
         )
         assert response.status_code == 200, response.text
+
+    @pytest.mark.usefixtures("admin")
+    def test_update_data_product_role_adds_read_permission(self, client: TestClient):
+        role: Role = RoleFactory(
+            scope=Scope.DATA_PRODUCT,
+            permissions=[int(AuthorizationAction.DATA_PRODUCT__UPDATE_PROPERTIES)],
+        )
+        response = client.put(
+            f"{ENDPOINT}/{role.id}",
+            json={
+                "permissions": [
+                    int(AuthorizationAction.DATA_PRODUCT__UPDATE_PROPERTIES),
+                    int(AuthorizationAction.DATA_PRODUCT__UPDATE_SETTINGS),
+                ],
+                "description": "updated_description",
+            },
+        )
+        assert response.status_code == 200, response.text
+
+        data = response.json()
+        assert data["id"] == str(role.id)
+        assert data["scope"] == role.scope
+        assert data["description"] == "updated_description"
+        assert AuthorizationAction.HIDDEN_DATA_PRODUCT__READ in data["permissions"]
+        assert data["permissions"] == sorted(
+            [
+                int(AuthorizationAction.HIDDEN_DATA_PRODUCT__READ),
+                int(AuthorizationAction.DATA_PRODUCT__UPDATE_PROPERTIES),
+                int(AuthorizationAction.DATA_PRODUCT__UPDATE_SETTINGS),
+            ]
+        )
 
     @pytest.mark.usefixtures("admin")
     def test_update_role(self, client: TestClient):

--- a/backend/tests/app/authorization/test_actions.py
+++ b/backend/tests/app/authorization/test_actions.py
@@ -7,8 +7,8 @@ from app.core.authz import Action
 class TestAction:
     def test_authorization_actions_equivalence(self):
         """
-        Test to ensure that the AuthorizationAction enum in the TypeScript file
-        matches the AuthorizationAction class in the Python file.
+        Test to ensure that the public AuthorizationAction enum in the TypeScript
+        file matches the Python enum, while hidden 9xx actions stay backend-only.
         """
         # Path to the TypeScript file
 
@@ -31,12 +31,20 @@ class TestAction:
                 value = value.strip().rstrip(",")
                 ts_enum[key] = int(value)
 
-        # Extract the Python enum as a dictionary
-        py_enum = {action.name: action.value for action in Action}
+        # Extract the Python enum as a dictionary, excluding backend-only 9xx actions
+        py_enum = {
+            action.name: action.value
+            for action in Action
+            if not 900 <= action.value < 1000
+        }
 
         # Compare the two dictionaries
         assert ts_enum == py_enum, (
             "Mismatch between TypeScript and"
             f"Python enums:\nTS: {json.dumps(ts_enum, indent=2)}\n"
             f"PY: {json.dumps(py_enum, indent=2)}"
+        )
+        assert all(not 900 <= value < 1000 for value in ts_enum.values()), (
+            "Frontend RBAC actions should not include backend-only 9xx actions:\n"
+            f"TS: {json.dumps(ts_enum, indent=2)}"
         )

--- a/backend/tests/app/authorization/test_service.py
+++ b/backend/tests/app/authorization/test_service.py
@@ -2,11 +2,13 @@ from casbin_sqlalchemy_adapter import CasbinRule
 
 from app.authorization.service import AuthorizationService
 from app.core.authz import Authorization
+from app.data_products.model import DataProductVisibility
 from app.database.database import get_db_session
+from tests.factories import DataProductFactory
 
 
 class TestAuthorizationService:
-    def test_clear_casbin_table(self, authorizer: Authorization):
+    def test_reload_enforcer(self, authorizer: Authorization):
         db = next(get_db_session())
 
         existing = len(db.query(CasbinRule).all())
@@ -19,6 +21,26 @@ class TestAuthorizationService:
         assert len(db.query(CasbinRule).all()) == 5 + existing, "roles not recorded"
 
         service = AuthorizationService(db)
-        service._clear_casbin_table()
+        service.reload_enforcer()
 
-        assert len(db.query(CasbinRule).all()) == 0, "database not cleared"
+        assert len(db.query(CasbinRule).all()) == existing, (
+            "Syncing did not remove the roles"
+        )
+
+    def test_reload_enforcer_ensure_discoverable_data_products_sync(
+        self, authorizer: Authorization
+    ):
+        db = next(get_db_session())
+
+        existing = len(db.query(CasbinRule).all())
+
+        for i in range(5):
+            DataProductFactory(visibility=DataProductVisibility.DISCOVERABLE)
+            DataProductFactory(visibility=DataProductVisibility.HIDDEN)
+
+        assert len(db.query(CasbinRule).all()) == 5 + existing, "roles not recorded"
+
+        service = AuthorizationService(db)
+        service.reload_enforcer()
+
+        assert len(db.query(CasbinRule).all()) == 5 + existing, "database not cleared"

--- a/backend/tests/app/configuration/data_product_types/test_router.py
+++ b/backend/tests/app/configuration/data_product_types/test_router.py
@@ -62,7 +62,7 @@ class TestDataProductTypesRouter:
         assert response.status_code == 400
 
     @pytest.mark.usefixtures("admin")
-    def test_migrate_data_product_types(self, client):
+    def test_migrate_data_product_types(self, client, session):
         data_product_type = DataProductTypeFactory()
         new_data_product_type = DataProductTypeFactory()
         data_product = DataProductFactory(type=data_product_type)
@@ -70,6 +70,7 @@ class TestDataProductTypesRouter:
             client, data_product_type.id, new_data_product_type.id
         )
         assert response.status_code == 200
+        session.refresh(data_product)
         assert data_product.type.id == new_data_product_type.id
 
     def test_create_data_product_type_admin_only(

--- a/backend/tests/app/core/authz/test_authorization.py
+++ b/backend/tests/app/core/authz/test_authorization.py
@@ -45,6 +45,36 @@ class TestAuthorization:
         authorizer.revoke_resource_role(user_id=user, role_id=role, resource_id=obj)
         assert authorizer.has_access(sub=user, dom=ANY, obj=obj, act=allowed) is False
 
+    def test_wildcard_resource_role(self, authorizer: Authorization):
+        role = "public_reader"
+        obj = "test_resource"
+        allowed = AuthorizationAction.HIDDEN_DATA_PRODUCT__READ
+        denied = AuthorizationAction.DATA_PRODUCT__UPDATE_SETTINGS
+
+        authorizer.sync_role_permissions(role_id=role, actions=[allowed])
+        authorizer.assign_resource_role(user_id="*", role_id=role, resource_id=obj)
+
+        assert (
+            authorizer.has_access(sub="user_1", dom=ANY, obj=obj, act=allowed) is True
+        )
+        assert (
+            authorizer.has_access(sub="user_2", dom=ANY, obj=obj, act=allowed) is True
+        )
+        assert (
+            authorizer.has_access(sub="user_1", dom=ANY, obj=obj, act=denied) is False
+        )
+        assert (
+            authorizer.has_access(
+                sub="user_1", dom=ANY, obj="other_resource", act=allowed
+            )
+            is False
+        )
+
+        authorizer.revoke_resource_role(user_id="*", role_id=role, resource_id=obj)
+        assert (
+            authorizer.has_access(sub="user_1", dom=ANY, obj=obj, act=allowed) is False
+        )
+
     def test_domain_role(self, authorizer: Authorization):
         role = "test_role"
         user = "test_user"
@@ -66,19 +96,20 @@ class TestAuthorization:
         authorizer.revoke_domain_role(user_id=user, role_id=role, domain_id=dom)
         assert authorizer.has_access(sub=user, dom=dom, obj=ANY, act=allowed) is False
 
-    def test_global_role(self, authorizer: Authorization):
+    def test_global_role(self, authorizer: Authorization, everyone_role_permissions):
         user = "test_user"
         role = "test_role"
         act = AuthorizationAction.GLOBAL__REQUEST_OUTPUT_PORT_ACCESS
 
-        authorizer.sync_role_permissions(role_id=role, actions=[act])
-        assert authorizer.has_access(sub=user, dom=ANY, obj=ANY, act=act) is False
+        with everyone_role_permissions(permissions=[]):
+            authorizer.sync_role_permissions(role_id=role, actions=[act])
+            assert authorizer.has_access(sub=user, dom=ANY, obj=ANY, act=act) is False
 
-        authorizer.assign_global_role(user_id=user, role_id=role)
-        assert authorizer.has_access(sub=user, dom=ANY, obj=ANY, act=act) is True
+            authorizer.assign_global_role(user_id=user, role_id=role)
+            assert authorizer.has_access(sub=user, dom=ANY, obj=ANY, act=act) is True
 
-        authorizer.revoke_global_role(user_id=user, role_id=role)
-        assert authorizer.has_access(sub=user, dom=ANY, obj=ANY, act=act) is False
+            authorizer.revoke_global_role(user_id=user, role_id=role)
+            assert authorizer.has_access(sub=user, dom=ANY, obj=ANY, act=act) is False
 
     def test_admin_role(self, authorizer: Authorization):
         user = "test_user"

--- a/backend/tests/app/data_products/test_router.py
+++ b/backend/tests/app/data_products/test_router.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 from app.authorization.roles.schema import Scope
 from app.core.authz import Action
+from app.data_products.model import DataProductVisibility
 from app.resource_names.service import ResourceNameValidityType
 from app.settings import settings
 from tests.factories import (
@@ -169,6 +170,26 @@ class TestDataProductsRouter:
         assert response.status_code == 200
         assert response.json()["id"] == str(data_product.id)
 
+    def test_get_data_product_hidden_not_assigned(self, client):
+        data_product = DataProductFactory(visibility=DataProductVisibility.HIDDEN)
+
+        response = self.get_data_product(client, data_product.id)
+        assert response.status_code == 403
+
+    def test_get_data_product_hidden(self, client):
+        data_product = DataProductFactory(visibility=DataProductVisibility.HIDDEN)
+        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        role = RoleFactory(
+            scope=Scope.DATA_PRODUCT,
+            permissions=[Action.DATA_PRODUCT__READ_INTEGRATIONS],
+        )
+        DataProductRoleAssignmentFactory(
+            data_product_id=data_product.id, role_id=role.id, user_id=user.id
+        )
+
+        response = self.get_data_product(client, data_product.id)
+        assert response.status_code == 200, response.text
+
     def test_get_conveyor_ide_url(self, client):
         user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         cvr = PlatformFactory(name="Conveyor")
@@ -315,23 +336,14 @@ class TestDataProductsRouter:
         )
         assert response.status_code == 403
 
+    @pytest.mark.usefixtures("admin")
     def test_remove_finalizer_triggers_deletion(self, client):
         """Removing the last finalizer from a DELETING product deletes it."""
         from app.data_products.status import AbstractDataProductStatus
 
-        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         data_product = DataProductFactory(
             finalizers=["last-one"],
             status=AbstractDataProductStatus.DELETING.value,
-        )
-        role = RoleFactory(
-            scope=Scope.DATA_PRODUCT,
-            permissions=[Action.DATA_PRODUCT__DELETE],
-        )
-        DataProductRoleAssignmentFactory(
-            user_id=user.id,
-            role_id=role.id,
-            data_product_id=data_product.id,
         )
         response = client.delete(
             f"{ENDPOINT}/{data_product.id}/finalizers/last-one",
@@ -339,23 +351,14 @@ class TestDataProductsRouter:
         assert response.status_code == 200
         assert self.get_data_product(client, data_product.id).status_code == 404
 
+    @pytest.mark.usefixtures("admin")
     def test_remove_finalizer_not_last_does_not_delete(self, client):
         """Removing a finalizer when others remain leaves the product in DELETING."""
         from app.data_products.status import AbstractDataProductStatus
 
-        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         data_product = DataProductFactory(
             finalizers=["a", "b"],
             status=AbstractDataProductStatus.DELETING.value,
-        )
-        role = RoleFactory(
-            scope=Scope.DATA_PRODUCT,
-            permissions=[Action.DATA_PRODUCT__DELETE],
-        )
-        DataProductRoleAssignmentFactory(
-            user_id=user.id,
-            role_id=role.id,
-            data_product_id=data_product.id,
         )
         response = client.delete(
             f"{ENDPOINT}/{data_product.id}/finalizers/a",
@@ -410,6 +413,7 @@ class TestDataProductsRouter:
             data_product_id=data_product.id,
         )
         response = self.get_data_product(client, data_product.id)
+        assert response.status_code == 200
         assert response.json()["status"] == "pending"
         _ = self.update_data_product_usage(
             client, {"usage": "new usage"}, data_product.id
@@ -417,7 +421,13 @@ class TestDataProductsRouter:
         response = self.get_data_product(client, data_product.id)
         assert response.json()["usage"] == "new usage"
 
-    def test_get_data_product_by_id_with_invalid_id(self, client):
+    @pytest.mark.usefixtures("admin")
+    def test_get_data_product_by_id_with_invalid_id_admin(self, client):
+        data_product = self.get_data_product(client, self.invalid_id)
+        assert data_product.status_code == 404
+
+    @pytest.mark.usefixtures("admin")
+    def test_get_data_product_by_id_with_invalid_id_regular_user(self, client):
         data_product = self.get_data_product(client, self.invalid_id)
         assert data_product.status_code == 404
 
@@ -496,6 +506,7 @@ class TestDataProductsRouter:
     def test_get_data_product_graph_data(self, client):
         data_product = DataProductFactory()
         response = client.get(f"{ENDPOINT}/{data_product.id}/graph")
+        assert response.status_code == 200, response.text
         assert response.json()["edges"] == []
         for node in response.json()["nodes"]:
             assert node == {
@@ -750,48 +761,29 @@ class TestDataProductsRouter:
         history = self.get_data_product_history(client, data_product.id).json()
         assert len(history["events"]) == 1
 
+    @pytest.mark.usefixtures("admin")
     def test_history_event_created_on_data_product_deletion(self, client):
-        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         data_product = DataProductFactory()
-        role = RoleFactory(
-            scope=Scope.DATA_PRODUCT,
-            permissions=[Action.DATA_PRODUCT__DELETE],
-        )
-        DataProductRoleAssignmentFactory(
-            user_id=user.id,
-            role_id=role.id,
-            data_product_id=data_product.id,
-        )
         response = self.delete_data_product(client, data_product.id)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
-        history = self.get_data_product_history(client, data_product.id).json()
-        assert len(history["events"]) == 1
+        history = self.get_data_product_history(client, data_product.id)
+        assert history.status_code == 200, history.text
+        assert len(history.json()["events"]) == 1
 
+    @pytest.mark.usefixtures("admin")
     def test_retain_deleted_data_product_name_in_history(self, client: TestClient):
-        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
         data_product = DataProductFactory()
-        role = RoleFactory(
-            scope=Scope.DATA_PRODUCT,
-            permissions=[Action.DATA_PRODUCT__DELETE],
-        )
-        DataProductRoleAssignmentFactory(
-            user_id=user.id,
-            role_id=role.id,
-            data_product_id=data_product.id,
-        )
-
-        data_product_id = data_product.id
-        data_product_name = data_product.name
 
         response = self.delete_data_product(client, data_product.id)
         assert response.status_code == 200
 
-        response = self.get_data_product_history(client, data_product_id)
+        response = self.get_data_product_history(client, data_product.id)
+        assert response.status_code == 200, response.text
         assert len(response.json()["events"]) == 1
         assert (
             response.json()["events"][0]["deleted_subject_identifier"]
-            == data_product_name
+            == data_product.name
         )
 
     def test_get_output_ports(self, client: TestClient):

--- a/backend/tests/app/explorations/test_event_emission.py
+++ b/backend/tests/app/explorations/test_event_emission.py
@@ -1,20 +1,11 @@
 """Integration tests: exploration REST endpoints emit ORM-tracked events."""
 
 import uuid
-from unittest.mock import AsyncMock, patch
 
 import faker
 
-from app.authorization.roles.schema import Scope
-from app.core.authz import Action
-from app.settings import settings
 from tests.conftest import webhook_v2_config
-from tests.factories import (
-    DomainFactory,
-    GlobalRoleAssignmentFactory,
-    RoleFactory,
-    UserFactory,
-)
+from tests.factories import DomainFactory
 
 ROUTE = "/api/v2/explorations"
 
@@ -28,43 +19,28 @@ def _create_payload(domain_id: str) -> dict:
     }
 
 
-def _authorized_user():
-    user = UserFactory(external_id=settings.DEFAULT_USERNAME)
-    role = RoleFactory(
-        scope=Scope.GLOBAL, permissions=[Action.GLOBAL__CREATE_EXPLORATION]
-    )
-    GlobalRoleAssignmentFactory(user_id=user.id, role_id=role.id)
-    return user
-
-
 class TestExplorationEventEmission:
     def test_create_exploration_emits_created_event(self, capture_events, client):
-        d = DomainFactory()
-        _authorized_user()
-
-        response = client.post(ROUTE, json=_create_payload(str(d.id)))
+        response = client.post(ROUTE, json=_create_payload(str(DomainFactory().id)))
 
         assert response.status_code == 200
         assert len(capture_events.captured_events) == 1
         assert capture_events.captured_events[0].event_type() == "exploration.event"
 
-    @patch("app.core.webhooks.v2.call_v2_webhook", new_callable=AsyncMock)
     def test_no_event_emitted_when_webhook_not_configured(self, capture_events, client):
-        d = DomainFactory()
-        _authorized_user()
-
         with webhook_v2_config(url=None):
-            response = client.post(ROUTE, json=_create_payload(str(d.id)))
+            response = client.post(ROUTE, json=_create_payload(str(DomainFactory().id)))
 
         assert response.status_code == 200
         assert len(capture_events.captured_events) == 0
 
-    def test_no_event_emitted_on_failed_request(self, capture_events, client):
+    def test_no_event_emitted_on_failed_request(
+        self, capture_events, client, everyone_role_permissions
+    ):
         """A 4xx response must not emit any event."""
-        d = DomainFactory()
-        # no authorized user → 403
 
-        response = client.post(ROUTE, json=_create_payload(str(d.id)))
+        with everyone_role_permissions(permissions=[]):
+            response = client.post(ROUTE, json=_create_payload(str(uuid.uuid4())))
 
         assert response.status_code >= 400
         assert len(capture_events.captured_events) == 0

--- a/backend/tests/app/shared/test_router.py
+++ b/backend/tests/app/shared/test_router.py
@@ -193,6 +193,82 @@ def test_openapi_file_upload_uses_binary_schema():
     }
 
 
+def _iter_app_routes():
+    def walk(node):
+        if isinstance(node, APIRoute):
+            yield node
+            return
+
+        if type(node).__name__ == "_IncludedRouter":
+            for candidate in node.effective_candidates():
+                yield from walk(candidate)
+            return
+
+        if hasattr(node, "path") and hasattr(node, "dependencies"):
+            yield node
+
+    for route in app.routes:
+        yield from walk(route)
+
+
+def _route_has_authorization_enforce(route) -> bool:
+    dependencies = list(getattr(route, "dependencies", []) or [])
+    dependencies.extend(getattr(route.dependant, "dependencies", []) or [])
+
+    for dependency in dependencies:
+        call = getattr(dependency, "call", None)
+        if call is None:
+            continue
+
+        qualname = getattr(call, "__qualname__", "")
+        module = getattr(call, "__module__", "")
+        name = getattr(call, "__name__", "")
+
+        if (
+            "Authorization.enforce" in qualname
+            or "Authorization.enforce" in repr(call)
+            or qualname.startswith("Authorization.enforce.<locals>.inner")
+            or (name == "inner" and qualname.startswith("Authorization.enforce."))
+            or (
+                module.startswith("app.")
+                and qualname.startswith("Authorization.enforce.")
+            )
+        ):
+            return True
+
+    return False
+
+
+def test_every_protected_v2_route_has_authorization_enforce_dependency():
+    excluded_paths = {
+        # Everyone is allowed to read the list of data products, so no authorization is needed.
+        # We filter out hidden data products in the service layer
+        "/api/v2/data_products",
+    }
+    missing = []
+
+    for route in _iter_app_routes():
+        if not getattr(route, "path", "").startswith("/api/v2/"):
+            continue
+        # For now we only check data products paths, and exclude output port paths
+        if not route.path.startswith("/api/v2/data_products"):
+            continue
+        if route.path.startswith(
+            "/api/v2/data_products/{data_product_id}/output_ports"
+        ):
+            continue
+        if route.path in excluded_paths:
+            continue
+
+        if not _route_has_authorization_enforce(route):
+            missing.append(f"{route.path} [{route.name}]")
+
+    assert not missing, (
+        "The following API routes do not declare an Authorization.enforce dependency:\n"
+        + "\n".join(missing)
+    )
+
+
 def test_routes_not_v2_are_deprecated():
     """
     Ensures that all routes not starting with /api/v2/ are marked as deprecated.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -6,11 +6,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session, scoped_session
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 from starlette.routing import _DefaultLifespan
 
+from app.authorization.roles.model import Role
+from app.authorization.roles.schema import Prototype, Scope
 from app.authorization.service import AuthorizationService
 from app.core.auth.device_flows.service import verify_auth_header
+from app.core.authz import Action
 from app.core.authz.authorization import Authorization
 from app.core.context import _pending_events
 from app.core.webhooks.events import V2Event
@@ -80,6 +84,42 @@ def client() -> Generator[TestClient, None, None]:
 
 
 @pytest.fixture
+def everyone_role_permissions(session: Session):
+    def everyone_role() -> Role:
+        role = session.scalar(
+            select(Role)
+            .where(Role.prototype == Prototype.EVERYONE)
+            .where(Role.scope == Scope.GLOBAL)
+        )
+        assert role is not None, "Failed to find the global 'everyone' role"
+        return role
+
+    @contextmanager
+    def _change_permissions(*, permissions: list[Action] | None = None):
+        role = everyone_role()
+        if permissions is None:
+            raise Exception("Permissions must be provided")
+
+        original_permissions = list(role.permissions or [])
+        next_permissions = [int(action) for action in permissions]
+
+        role.permissions = next_permissions
+        session.commit()
+        Authorization().sync_everyone_role_permissions(actions=permissions)
+
+        try:
+            yield
+        finally:
+            role = everyone_role()
+            assert role is not None, "Failed to find the global 'everyone' role"
+            role.permissions = original_permissions
+            session.commit()
+            Authorization().sync_everyone_role_permissions(actions=original_permissions)
+
+    return _change_permissions
+
+
+@pytest.fixture
 def default_data_product_payload() -> dict[str, Any]:
     data_product_type = DataProductTypeFactory()
     user = UserFactory()
@@ -111,15 +151,17 @@ def default_dataset_payload() -> dict[str, Any]:
 
 
 @pytest.fixture(autouse=True)
-def clear_db(session: scoped_session[Session]) -> None:
+def clear_db(session: Session) -> None:
     """Clear database after each test."""
     for table in reversed(Base.metadata.sorted_tables):
+        if table.name == "casbin_rule":
+            continue
         if table.name == "roles":
             session.execute(table.delete().where(table.c.prototype == 0))
         else:
             session.execute(table.delete())
+    AuthorizationService(session).reload_enforcer()
     session.commit()
-    AuthorizationService._clear_casbin_table()
     reset_unique_fakers()
 
 

--- a/backend/tests/factories/data_product.py
+++ b/backend/tests/factories/data_product.py
@@ -2,6 +2,7 @@ import factory
 from faker import Faker
 
 from app.data_products.model import DataProduct
+from app.data_products.service import DataProductService
 from app.data_products.status import AbstractDataProductStatus
 from tests.factories.lifecycle import LifecycleFactory
 
@@ -26,3 +27,10 @@ class DataProductFactory(factory.alchemy.SQLAlchemyModelFactory):
     domain = factory.SubFactory(DomainFactory)
     lifecycle = factory.SubFactory(LifecycleFactory)
     usage = factory.Faker("word")
+
+    @factory.post_generation
+    def sync_public_reader_grouping(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        DataProductService._sync_public_reader_grouping(self.id, self.visibility)

--- a/backend/tests/factories/role.py
+++ b/backend/tests/factories/role.py
@@ -20,9 +20,7 @@ class RoleFactory(factory.alchemy.SQLAlchemyModelFactory):
 
     id = factory.Faker("uuid4")
     name = factory.Sequence(lambda _: faker.unique.name())
-    scope = factory.Faker(
-        "random_element", elements=("global", "data_product", "dataset")
-    )
+    scope = factory.Faker("random_element", elements=("global", "dataset"))
     description = factory.Faker("text")
     permissions = factory.Faker(
         "random_elements", elements=list(map(int, AuthorizationAction)), unique=True

--- a/backend/tests/factories/test_data_product_factory.py
+++ b/backend/tests/factories/test_data_product_factory.py
@@ -1,0 +1,22 @@
+from app.authorization.service import DATA_PRODUCT_READER_ROLE
+from app.core.authz.authorization import Authorization
+from app.data_products.model import DataProductVisibility
+from tests.factories import DataProductFactory
+
+
+def test_syncs_public_reader_grouping_for_discoverable_data_products():
+    data_product = DataProductFactory(visibility=DataProductVisibility.DISCOVERABLE)
+    assert Authorization().has_resource_role(
+        user_id="*",
+        role_id=DATA_PRODUCT_READER_ROLE,
+        resource_id=str(data_product.id),
+    )
+
+
+def test_does_not_assign_public_reader_grouping_for_hidden_data_products():
+    data_product = DataProductFactory(visibility=DataProductVisibility.HIDDEN)
+    assert not Authorization().has_resource_role(
+        user_id="*",
+        role_id=DATA_PRODUCT_READER_ROLE,
+        resource_id=str(data_product.id),
+    )

--- a/cli/golang/pkg/api/oas_schemas_gen.go
+++ b/cli/golang/pkg/api/oas_schemas_gen.go
@@ -752,6 +752,7 @@ const (
 	AuthorizationAction413 AuthorizationAction = 413
 	AuthorizationAction414 AuthorizationAction = 414
 	AuthorizationAction415 AuthorizationAction = 415
+	AuthorizationAction901 AuthorizationAction = 901
 )
 
 // AllValues returns all AuthorizationAction values.
@@ -795,6 +796,7 @@ func (AuthorizationAction) AllValues() []AuthorizationAction {
 		AuthorizationAction413,
 		AuthorizationAction414,
 		AuthorizationAction415,
+		AuthorizationAction901,
 	}
 }
 

--- a/cli/golang/pkg/api/oas_validators_gen.go
+++ b/cli/golang/pkg/api/oas_validators_gen.go
@@ -349,6 +349,8 @@ func (s AuthorizationAction) Validate() error {
 		return nil
 	case 415:
 		return nil
+	case 901:
+		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -8848,7 +8848,8 @@
           412,
           413,
           414,
-          415
+          415,
+          901
         ],
         "title": "AuthorizationAction",
         "description": "The integer values for the authorization actions are stored directly in the DB.\nThis means you can change the name of the actions, but not their integer values.\nThe values for the actions are spaced on purpose, to make it easier to extend.\nThis has no technical benefit, but it makes it easier to read for developers."

--- a/frontend/src/store/api/services/generated/authorizationApi.ts
+++ b/frontend/src/store/api/services/generated/authorizationApi.ts
@@ -78,7 +78,8 @@ export type AuthorizationAction =
   | 412
   | 413
   | 414
-  | 415;
+  | 415
+  | 901;
 export type IsAdminResponse = {
   is_admin: boolean;
   time?: string | null;

--- a/frontend/src/store/api/services/generated/authorizationRoleAssignmentsApi.ts
+++ b/frontend/src/store/api/services/generated/authorizationRoleAssignmentsApi.ts
@@ -347,7 +347,8 @@ export type AuthorizationAction =
   | 412
   | 413
   | 414
-  | 415;
+  | 415
+  | 901;
 export type Prototype = 0 | 1 | 2 | 3;
 export type Role = {
   name: string;

--- a/frontend/src/store/api/services/generated/authorizationRolesApi.ts
+++ b/frontend/src/store/api/services/generated/authorizationRolesApi.ts
@@ -81,7 +81,8 @@ export type AuthorizationAction =
   | 412
   | 413
   | 414
-  | 415;
+  | 415
+  | 901;
 export type Prototype = 0 | 1 | 2 | 3;
 export type Role = {
   name: string;

--- a/frontend/src/store/api/services/generated/usersApi.ts
+++ b/frontend/src/store/api/services/generated/usersApi.ts
@@ -143,7 +143,8 @@ export type AuthorizationAction =
   | 412
   | 413
   | 414
-  | 415;
+  | 415
+  | 901;
 export type Prototype = 0 | 1 | 2 | 3;
 export type Role = {
   name: string;

--- a/sdk/sdk/api_client/models/authorization_action.py
+++ b/sdk/sdk/api_client/models/authorization_action.py
@@ -40,6 +40,7 @@ class AuthorizationAction(IntEnum):
     VALUE_413 = 413
     VALUE_414 = 414
     VALUE_415 = 415
+    VALUE_901 = 901
 
     def __str__(self) -> str:
         return str(self.value)


### PR DESCRIPTION
This implements hidden data products in the backend but no API endpoints currently allow to create one. This is on purpose, development is cut into multiple smaller PR's.

In support of: #4162

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested.



Follow up PR's will:
- redact hidden data products in input ports, and consumers lists
- Allow creation of hidden data products
- Ensure hidden data products can only contain restricted output ports