### PR TITLE
Added unique index to user external id

### DIFF
--- a/backend/app/database/alembic/versions/2026_09_04_0935-ae23301a4a69_user_unique_external_id.py
+++ b/backend/app/database/alembic/versions/2026_09_04_0935-ae23301a4a69_user_unique_external_id.py
@@ -1,0 +1,25 @@
+"""User unique external_id
+
+Revision ID: ae23301a4a69
+Revises: 676a29542f0b
+Create Date: 2026-09-04 09:35:17.028747
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "ae23301a4a69"
+down_revision: Union[str, None] = "676a29542f0b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint("uq_users_external_id", "users", ["external_id"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_users_external_id", "users")


### PR DESCRIPTION
This should never happen, since external
ID should define a user.
The reason for adding it is that it
happened in a test, so adding a check for
it now.

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested.
