### PR TITLE
A data product role has output ports rights

### DIFF
--- a/backend/app/authorization/router.py
+++ b/backend/app/authorization/router.py
@@ -3,10 +3,14 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
 from pydantic.json_schema import SkipJsonSchema
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from app.authorization.schema_response import AccessResponse, IsAdminResponse
 from app.core.auth.auth import get_authenticated_user
 from app.core.authz import Action, Authorization
+from app.data_products.output_ports.model import OutputPort
+from app.database.deps import get_db_session
 from app.users.schema import User
 
 router = APIRouter(tags=["Authorization"], prefix="/v2/authz")
@@ -33,6 +37,7 @@ def check_access(
     resource: Annotated[UUID | SkipJsonSchema[None], Query()] = None,
     domain: Annotated[UUID | SkipJsonSchema[None], Query()] = None,
     user: User = Depends(get_authenticated_user),
+    db: Session = Depends(get_db_session),
 ) -> AccessResponse:
     """Allows the requesting user to check whether an access check will fail or succeed.
     Useful to conditionally disable parts of the UI that are known to be inaccessible.
@@ -40,9 +45,16 @@ def check_access(
     sub = str(user.id)
     dom = "*" if domain is None else str(domain)
     obj = "*" if resource is None else str(resource)
+    parent = "*"
+    if resource is not None and action.name.startswith("OUTPUT_PORT__"):
+        data_product_id = db.scalar(
+            select(OutputPort.data_product_id).where(OutputPort.id == resource)
+        )
+        if data_product_id is not None:
+            parent = str(data_product_id)
 
     authorizer = Authorization()
-    result = authorizer.has_access(sub=sub, dom=dom, obj=obj, act=action)
+    result = authorizer.has_access(sub=sub, dom=dom, obj=obj, parent=parent, act=action)
     return AccessResponse(allowed=result)
 
 

--- a/backend/app/core/authz/authorization.py
+++ b/backend/app/core/authz/authorization.py
@@ -66,10 +66,15 @@ class Authorization(metaclass=Singleton):
             user: User = Depends(get_authenticated_user),
             db: Session = Depends(get_db_session),
         ) -> None:
-            obj = await resolver.resolve(request, object_id, db)
-            dom = await resolver.resolve_domain(db, obj)
+            context = await resolver.resolve_context(request, object_id, db)
 
-            if not cls().has_access(sub=str(user.id), dom=dom, obj=obj, act=action):
+            if not cls().has_access(
+                sub=str(user.id),
+                dom=context.domain_id,
+                obj=context.object_id,
+                parent=context.parent_id,
+                act=action,
+            ):
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="You don't have permission to perform this action",
@@ -79,11 +84,17 @@ class Authorization(metaclass=Singleton):
 
     @cachedmethod(lambda self: self._cache)
     def has_access(
-        self, *, sub: str, dom: str, obj: str, act: AuthorizationAction
+        self,
+        *,
+        sub: str,
+        dom: str,
+        obj: str,
+        act: AuthorizationAction,
+        parent: str = "*",
     ) -> bool:
         with tracer.start_as_current_span("has_access"):
             enforcer: SyncedEnforcer = self._enforcer
-            return enforcer.enforce(sub, dom, obj, str(act))
+            return enforcer.enforce(sub, dom, obj, parent, str(act))
 
     def _after_update(self) -> None:
         """The cache should be purged when the casbin database is altered,

--- a/backend/app/core/authz/rbac_model.conf
+++ b/backend/app/core/authz/rbac_model.conf
@@ -1,5 +1,5 @@
 [request_definition]
-r = sub, dom, obj, act
+r = sub, dom, obj, parent, act
 
 [policy_definition]
 p = sub, act
@@ -17,6 +17,7 @@ m = g3(r.sub, "*") || (( \
     p.sub == "*" \
     || g(r.sub, p.sub, r.obj) \
     || g("*", p.sub, r.obj) \
+    || g(r.sub, p.sub, r.parent) \
     || g2(r.sub, p.sub, r.dom) \
     || g3(r.sub, p.sub) \
 ) && r.act == p.act)

--- a/backend/app/core/authz/readme.md
+++ b/backend/app/core/authz/readme.md
@@ -61,3 +61,9 @@ Hidden data products are supported through a read only role, that is added with 
 This read action will be added by default to add data product roles, and is hidden for users.
 But this action will give you rights to any data product you have access to.
 And visible data products will use the g("*", public_reader_role_id, product_id) wildcard to allow access to all users.
+
+
+## Parent access
+
+We support a parent model, where a data product role for example can give access to all output ports under it.
+In the request the parent must be passed for output ports. This can ensure the data product role can give rights.

--- a/backend/app/core/authz/resolvers.py
+++ b/backend/app/core/authz/resolvers.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from dataclasses import dataclass
 from typing import Type, TypeAlias, Union, cast
 
 from fastapi import Depends, Request
@@ -24,8 +25,15 @@ from app.database.deps import get_db_session
 from app.explorations.model import Exploration
 
 Model: TypeAlias = Union[
-    Type[DataProduct], Type[OutputPort], Type[TechnicalAsset], None
+    Type[DataProduct], Type[OutputPort], Type[TechnicalAsset], Type[Exploration], None
 ]
+
+
+@dataclass(frozen=True)
+class AuthorizationContext:
+    object_id: str
+    parent_id: str
+    domain_id: str
 
 
 class SubjectResolver(ABC):
@@ -33,7 +41,7 @@ class SubjectResolver(ABC):
     model: Model = None
 
     @classmethod
-    async def resolve(
+    async def _resolve(
         cls, request: Request, key: str, db: Session = Depends(get_db_session)
     ):
         if (result := request.query_params.get(key)) is not None:
@@ -47,7 +55,7 @@ class SubjectResolver(ABC):
         return cls.DEFAULT
 
     @classmethod
-    async def resolve_domain(
+    async def _resolve_domain(
         cls,
         db: Session,
         id_: str,
@@ -57,10 +65,25 @@ class SubjectResolver(ABC):
         domain = db.scalar(select(cls.model.domain_id).where(cls.model.id == id_))
         return cls.DEFAULT if domain is None else str(domain)
 
+    @classmethod
+    async def _resolve_parent(cls, db: Session, id_: str) -> str:
+        return cls.DEFAULT
+
+    @classmethod
+    async def resolve_context(
+        cls, request: Request, key: str, db: Session = Depends(get_db_session)
+    ) -> AuthorizationContext:
+        object_id = str(await cls._resolve(request, key, db))
+        return AuthorizationContext(
+            object_id=object_id,
+            parent_id=await cls._resolve_parent(db, object_id),
+            domain_id=await cls._resolve_domain(db, object_id),
+        )
+
 
 class EmptyResolver(SubjectResolver):
     @classmethod
-    async def resolve(
+    async def _resolve(
         cls, request: Request, key: str, db: Session = Depends(get_db_session)
     ):
         return cls.DEFAULT
@@ -75,13 +98,13 @@ class ExplorationResolver(SubjectResolver):
 
 
 class OutputPortRoleAssignmentResolver(SubjectResolver):
-    model: Model = DataProduct
+    model: Model = OutputPort
 
     @classmethod
-    async def resolve(
+    async def _resolve(
         cls, request: Request, key: str, db: Session = Depends(get_db_session)
     ):
-        obj = await DataProductResolver.resolve(request, key, db)
+        obj = await super()._resolve(request, key, db)
         if obj != cls.DEFAULT:
             assignment = (
                 db.scalars(
@@ -94,15 +117,23 @@ class OutputPortRoleAssignmentResolver(SubjectResolver):
                 return assignment.output_port_id
         return cls.DEFAULT
 
+    @classmethod
+    async def _resolve_domain(cls, db: Session, id_: str) -> str:
+        return await DatasetResolver._resolve_domain(db, id_)
+
+    @classmethod
+    async def _resolve_parent(cls, db: Session, id_: str) -> str:
+        return await DatasetResolver._resolve_parent(db, id_)
+
 
 class DataProductRoleAssignmentResolver(SubjectResolver):
     model: Model = DataProduct
 
     @classmethod
-    async def resolve(
+    async def _resolve(
         cls, request: Request, key: str, db: Session = Depends(get_db_session)
     ):
-        obj = await DataProductResolver.resolve(request, key, db)
+        obj = await super()._resolve(request, key, db)
         if obj != cls.DEFAULT:
             assignment = (
                 db.scalars(
@@ -122,7 +153,7 @@ class DatasetResolver(SubjectResolver):
     model: Model = OutputPort
 
     @classmethod
-    async def resolve_domain(
+    async def _resolve_domain(
         cls,
         db: Session,
         id_: str,
@@ -134,15 +165,24 @@ class DatasetResolver(SubjectResolver):
         )
         return cls.DEFAULT if domain is None else str(domain)
 
+    @classmethod
+    async def _resolve_parent(cls, db: Session, id_: str) -> str:
+        if id_ == cls.DEFAULT:
+            return cls.DEFAULT
+        data_product_id = db.scalar(
+            select(OutputPort.data_product_id).where(OutputPort.id == id_)
+        )
+        return cls.DEFAULT if data_product_id is None else str(data_product_id)
+
 
 class DataProductNameResolver(SubjectResolver):
     model: Model = DataProduct
 
     @classmethod
-    async def resolve(
+    async def _resolve(
         cls, request: Request, key: str, db: Session = Depends(get_db_session)
     ):
-        obj = await DataProductResolver.resolve(request, key, db)
+        obj = await DataProductResolver._resolve(request, key, db)
         if obj != cls.DEFAULT:
             data_product = (
                 db.scalars(select(DataProduct).where(DataProduct.namespace == obj))
@@ -158,10 +198,10 @@ class TechnicalAssetResolver(SubjectResolver):
     model: Model = DataProduct
 
     @classmethod
-    async def resolve(
+    async def _resolve(
         cls, request: Request, key: str, db: Session = Depends(get_db_session)
     ):
-        obj = await DataProductResolver.resolve(request, key, db)
+        obj = await DataProductResolver._resolve(request, key, db)
         if obj != cls.DEFAULT:
             technical_asset = (
                 db.scalars(select(TechnicalAsset).where(TechnicalAsset.id == obj))
@@ -175,10 +215,10 @@ class TechnicalAssetResolver(SubjectResolver):
 
 class DataOutputDatasetAssociationResolver(DatasetResolver):
     @classmethod
-    async def resolve(
+    async def _resolve(
         cls, request: Request, key: str, db: Session = Depends(get_db_session)
     ):
-        obj = await SubjectResolver.resolve(request, key, db)
+        obj = await SubjectResolver._resolve(request, key, db)
         if obj != cls.DEFAULT:
             data_output_dataset = db.scalar(
                 select(DataOutputDatasetAssociation).where(
@@ -192,10 +232,10 @@ class DataOutputDatasetAssociationResolver(DatasetResolver):
 
 class DataProductDatasetAssociationResolver(DatasetResolver):
     @classmethod
-    async def resolve(
+    async def _resolve(
         cls, request: Request, key: str, db: Session = Depends(get_db_session)
     ):
-        obj = await DataProductResolver.resolve(request, key, db)
+        obj = await DataProductResolver._resolve(request, key, db)
         if obj != cls.DEFAULT:
             data_product_dataset = (
                 db.scalars(select(InputPort).where(InputPort.id == obj))

--- a/backend/app/data_products/output_port_technical_assets_link/service.py
+++ b/backend/app/data_products/output_port_technical_assets_link/service.py
@@ -7,11 +7,15 @@ from fastapi import HTTPException, status
 from sqlalchemy import asc, or_, select
 from sqlalchemy.orm import Session
 
+from app.authorization.role_assignments.data_product.model import (
+    DataProductRoleAssignment as DataProductRoleAssignmentModel,
+)
 from app.authorization.role_assignments.enums import DecisionStatus
 from app.authorization.role_assignments.output_port.model import (
     DatasetRoleAssignment as DatasetRoleAssignmentModel,
 )
 from app.core.authz import Action, Authorization
+from app.data_products.model import DataProduct as DataProductModel
 from app.data_products.output_port_technical_assets_link.model import (
     DataOutputDatasetAssociation as DataOutputDatasetAssociationModel,
 )
@@ -156,10 +160,19 @@ class TechnicalAssetOutputPortService:
                     DataOutputDatasetAssociationModel.status == DecisionStatus.PENDING,
                 )
                 .where(
-                    DataOutputDatasetAssociationModel.output_port.has(
-                        OutputPortModel.assignments.any(
-                            DatasetRoleAssignmentModel.user_id == user.id
-                        )
+                    or_(
+                        DataOutputDatasetAssociationModel.output_port.has(
+                            OutputPortModel.assignments.any(
+                                DatasetRoleAssignmentModel.user_id == user.id
+                            )
+                        ),
+                        DataOutputDatasetAssociationModel.output_port.has(
+                            OutputPortModel.data_product.has(
+                                DataProductModel.assignments.any(
+                                    DataProductRoleAssignmentModel.user_id == user.id
+                                )
+                            )
+                        ),
                     )
                 )
                 .order_by(asc(DataOutputDatasetAssociationModel.requested_on))
@@ -176,6 +189,7 @@ class TechnicalAssetOutputPortService:
                 sub=str(user.id),
                 dom=str(a.output_port.data_product.domain.id),
                 obj=str(a.output_port_id),
+                parent=str(a.output_port.data_product_id),
                 act=Action.OUTPUT_PORT__APPROVE_TECHNICAL_ASSET_LINK_REQUEST,
             )
         ]

--- a/backend/app/data_products/output_ports/input_ports/service.py
+++ b/backend/app/data_products/output_ports/input_ports/service.py
@@ -17,6 +17,9 @@ from app.abstract_data_product.input_ports.model import (
     InputPortRequest as InputPortRequestModel,
 )
 from app.abstract_data_product.model import AbstractDataProduct
+from app.authorization.role_assignments.data_product.model import (
+    DataProductRoleAssignment as DataProductRoleAssignmentModel,
+)
 from app.authorization.role_assignments.output_port.model import (
     DatasetRoleAssignment as DatasetRoleAssignmentModel,
 )
@@ -278,10 +281,19 @@ class InputPortService:
                     InputPortRequestModel.decision == InputPortRequestDecision.PENDING
                 )
                 .where(
-                    InputPortModel.output_port.has(
-                        OutputPortModel.assignments.any(
-                            DatasetRoleAssignmentModel.user_id == user.id
-                        )
+                    or_(
+                        InputPortModel.output_port.has(
+                            OutputPortModel.assignments.any(
+                                DatasetRoleAssignmentModel.user_id == user.id
+                            )
+                        ),
+                        InputPortModel.output_port.has(
+                            OutputPortModel.data_product.has(
+                                DataProductModel.assignments.any(
+                                    DataProductRoleAssignmentModel.user_id == user.id
+                                )
+                            )
+                        ),
                     )
                 )
                 .options(
@@ -303,6 +315,7 @@ class InputPortService:
                 sub=str(user.id),
                 dom=str(a.input_port.output_port.data_product.domain.id),
                 obj=str(a.input_port.output_port_id),
+                parent=str(a.input_port.output_port.data_product_id),
                 act=Action.OUTPUT_PORT__APPROVE_DATAPRODUCT_ACCESS_REQUEST,
             )
         ]

--- a/backend/app/database/alembic/versions/2026_09_04_1430-c8fbf0cf31e4_add_output_port_permissions_to_data_product_owner.py
+++ b/backend/app/database/alembic/versions/2026_09_04_1430-c8fbf0cf31e4_add_output_port_permissions_to_data_product_owner.py
@@ -1,0 +1,59 @@
+"""Add output port permissions to data product owner
+
+Revision ID: c8fbf0cf31e4
+Revises: ae23301a4a69
+Create Date: 2026-09-04 14:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "c8fbf0cf31e4"
+down_revision: Union[str, None] = "ae23301a4a69"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE roles
+        SET permissions = (
+            SELECT ARRAY(
+                SELECT DISTINCT unnest(
+                    permissions || ARRAY[
+                        401, 402, 403, 404, 405, 406, 407, 408,
+                        409, 410, 411, 412, 413, 414, 415
+                    ]
+                )
+                ORDER BY 1
+            )
+        )
+        WHERE scope = 'data_product'
+          AND prototype = 2
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE roles
+        SET permissions = (
+            SELECT ARRAY(
+                SELECT unnest(permissions)
+                EXCEPT SELECT unnest(
+                    ARRAY[
+                        401, 402, 403, 404, 405, 406, 407, 408,
+                        409, 410, 411, 412, 413, 414, 415
+                    ]
+                )
+                ORDER BY 1
+            )
+        )
+        WHERE scope = 'data_product'
+          AND prototype = 2
+        """
+    )

--- a/backend/tests/app/authorization/test_router.py
+++ b/backend/tests/app/authorization/test_router.py
@@ -5,7 +5,13 @@ from fastapi.testclient import TestClient
 from app.authorization.schema_response import AccessResponse
 from app.core.authz import Action, Authorization
 from app.settings import settings
-from tests.factories import UserFactory
+from tests.factories import (
+    DataProductFactory,
+    DataProductRoleAssignmentFactory,
+    OutputPortFactory,
+    RoleFactory,
+    UserFactory,
+)
 
 ENDPOINT = "/api/v2/authz"
 
@@ -40,6 +46,23 @@ class TestAuthorizationRouter:
 
         access = AccessResponse(**response.json())
         assert access.allowed is True
+
+    def test_check_access_authorized_by_data_product_role(
+        self, client: TestClient, authorizer: Authorization
+    ):
+        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        data_product = DataProductFactory()
+        output_port = OutputPortFactory(data_product=data_product)
+        action = Action.OUTPUT_PORT__UPDATE_PROPERTIES
+        role = RoleFactory(permissions=[action])
+        DataProductRoleAssignmentFactory(
+            role_id=role.id, user_id=user.id, data_product_id=data_product.id
+        )
+
+        response = client.get(f"{ENDPOINT}/access/{action}?resource={output_port.id}")
+
+        assert response.status_code == 200
+        assert AccessResponse(**response.json()).allowed is True
 
     def test_is_admin(self, client: TestClient):
         response = client.get(f"{ENDPOINT}/admin")

--- a/backend/tests/app/core/authz/test_authorization.py
+++ b/backend/tests/app/core/authz/test_authorization.py
@@ -96,6 +96,33 @@ class TestAuthorization:
         authorizer.revoke_domain_role(user_id=user, role_id=role, domain_id=dom)
         assert authorizer.has_access(sub=user, dom=dom, obj=ANY, act=allowed) is False
 
+    def test_data_product_role_applies_to_output_port(self, authorizer: Authorization):
+        role = "data_product_role"
+        user = "test_user"
+        data_product = "data_product"
+        output_port = "output_port"
+        action = AuthorizationAction.OUTPUT_PORT__UPDATE_PROPERTIES
+
+        authorizer.sync_role_permissions(role_id=role, actions=[action])
+        authorizer.assign_resource_role(
+            user_id=user, role_id=role, resource_id=data_product
+        )
+
+        assert authorizer.has_access(
+            sub=user,
+            dom=ANY,
+            obj=output_port,
+            parent=data_product,
+            act=action,
+        )
+        assert not authorizer.has_access(
+            sub=user,
+            dom=ANY,
+            obj=output_port,
+            parent="other_data_product",
+            act=action,
+        )
+
     def test_global_role(self, authorizer: Authorization, everyone_role_permissions):
         user = "test_user"
         role = "test_role"

--- a/backend/tests/app/data_products/output_ports/test_router.py
+++ b/backend/tests/app/data_products/output_ports/test_router.py
@@ -414,6 +414,23 @@ class TestOutputPortRouter:
         response = self.get_output_port(client, ds.id, ds.data_product.id)
         assert response.status_code == 404
 
+    def test_remove_output_port_with_data_product_role(self, client):
+        user = UserFactory(external_id=settings.DEFAULT_USERNAME)
+        role = RoleFactory(
+            scope=Scope.DATA_PRODUCT,
+            permissions=[AuthorizationAction.OUTPUT_PORT__DELETE],
+        )
+        ds = OutputPortFactory()
+        DataProductRoleAssignmentFactory(
+            user_id=user.id,
+            role_id=role.id,
+            data_product_id=ds.data_product.id,
+        )
+
+        response = self.delete_output_port(client, ds.data_product.id, ds.id)
+
+        assert response.status_code == 200
+
     def test_get_output_port_with_invalid_id(self, client):
         dp = DataProductFactory()
         dataset = self.get_output_port(client, dp.id, self.invalid_id)

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -25,6 +25,7 @@ sidebar_position: 200
 - **[General]**: Performance improvements for all output port endpoints, since we now cache the Embedding models used in output port search
 - **[General]**: We now allow changing DB pool settings, this allows you to tweak this for your specific environment. We set the default to a pool of 20 and a max overflow of 20, which should be sufficient for most installations.
 - **[Data model]**: Allow uploading the data model of an output port through the UI
+- **[Data Product Roles]**: Data product roles can now also give rights to all output ports under a data product, instead of only the data product itself. By default a Data Product owner, can do all actions on all Output Ports under that Data Product.
 
 ## 0.7.0
 

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -86,6 +86,7 @@
     "Allows modifying properties such as labels and the description of a Data Product": "Allows modifying properties such as labels and the description of a Data Product",
     "Allows modifying properties such as labels and the description of an Output Port": "Allows modifying properties such as labels and the description of an Output Port",
     "Allows modifying the configuration options of this installation": "Allows modifying the configuration options of this installation",
+    "Allows modifying the data contract of an Output Port": "Allows modifying the data contract of an Output Port",
     "Allows modifying the details of a Technical Asset of this Data Product": "Allows modifying the details of a Technical Asset of this Data Product",
     "Allows removing a Technical Asset from this Data Product and unlinking it from a Dataset": "Allows removing a Technical Asset from this Data Product and unlinking it from a Dataset",
     "Allows removing a user as member from this Data Product": "Allows removing a user as member from this Data Product",

--- a/frontend/src/pages/roles/components/roles-table.component.tsx
+++ b/frontend/src/pages/roles/components/roles-table.component.tsx
@@ -530,8 +530,27 @@ function determinePermissionsForScope(scope: Scope, roles: Role[], t: TFunction)
                     name: 'Insert data quality results',
                     description: t('Allows inserting data quality results for an Output Port'),
                 },
+                {
+                    type: 'Instance',
+                    id: AuthorizationAction.OUTPUT_PORT__UPDATE_CONTRACT,
+                    name: 'Manage data contract',
+                    description: t('Allows modifying the data contract of an Output Port'),
+                },
             ];
             break;
+    }
+
+    if (scope === Scope.DATA_PRODUCT) {
+        permissions.push(
+            {
+                type: 'Group',
+                id: 'Manage Output Ports',
+                name: 'Manage Output Ports',
+            },
+            ...determinePermissionsForScope(Scope.DATASET, roles, t).filter(
+                (permission): permission is PermissionInstance => permission.type === 'Instance',
+            ),
+        );
     }
 
     const determineAccess = (permission: AuthorizationAction) => {


### PR DESCRIPTION
Ensure that a data product role can give
rights to it's output ports.

In support of: #4162

- [x] Update the release notes document if needed in the [release notes](../docs/docs/release-notes.md).
- [x] When updating the UI please provide screenshots or videos to the reviewers.
- [x] Updated sample data so the new feature can be easily tested.


Adds a manage output ports to the data product role.
<img width="2556" height="1338" alt="image" src="https://github.com/user-attachments/assets/f347efa6-387d-41af-9800-de16cff9101d" />
